### PR TITLE
use filename template option to add daily notes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-weread-plugin",
 	"name": "Weread Plugin",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"minAppVersion": "0.12.0",
 	"description": "This is obsidian plugin for Tencent weread.",
 	"author": "hankzhao",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-weread-plugin",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"description": "This is a community plugin for tencent weread (https://r.qq.com)",
 	"main": "main.ts",
 	"scripts": {

--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -38,7 +38,7 @@ export default class FileManager {
 		const appendContent = dailyNoteRefs
 			.map((dailyNoteRef) => {
 				const headContent: string = '\n### '
-					.concat(this.getFileName(dailyNoteRef.metaData))
+					.concat(dailyNoteRef.metaData.title)
 					.concat('\n');
 				const blockList = dailyNoteRef.refBlocks.map((refBlock) => {
 					return `![[${this.getFileName(dailyNoteRef.metaData)}#^${

--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -37,9 +37,13 @@ export default class FileManager {
 	private buildAppendContent(dailyNoteRefs: DailyNoteReferenece[]): string {
 		const appendContent = dailyNoteRefs
 			.map((dailyNoteRef) => {
-				const headContent: string = '\n### '.concat(dailyNoteRef.bookName).concat('\n');
+				const headContent: string = '\n### '
+					.concat(this.getFileName(dailyNoteRef.metaData))
+					.concat('\n');
 				const blockList = dailyNoteRef.refBlocks.map((refBlock) => {
-					return `![[${dailyNoteRef.bookName}#^${refBlock.refBlockId}]]`;
+					return `![[${this.getFileName(dailyNoteRef.metaData)}#^${
+						refBlock.refBlockId
+					}]]`;
 				});
 				const bodyContent = blockList.join('\n');
 				const finalContent = headContent + bodyContent;

--- a/src/models.ts
+++ b/src/models.ts
@@ -76,7 +76,7 @@ export type RenderTemplate = {
 };
 
 export type DailyNoteReferenece = {
-	bookName: string;
+	metaData: Metadata;
 	refBlocks: RefBlockDetail[];
 };
 

--- a/src/parser/parseResponse.ts
+++ b/src/parser/parseResponse.ts
@@ -135,7 +135,7 @@ export const parseDailyNoteReferences = (notebooks: Notebook[]): DailyNoteRefere
 		// only record book have notes
 		if (refBlocks.length > 0) {
 			todayHighlightBlocks.push({
-				bookName: notebook.metaData.title,
+				metaData: notebook.metaData,
 				refBlocks: refBlocks
 			});
 		}


### PR DESCRIPTION
- Issue:
保留笔记到 DailyNotes 时，未使用“文件名模板”对应选项生成链接，而是都使用“书名”选项作为链接。导致最后链接错误。报错：XXXX未创建，点击创建。比如：选项是“书名-作者名”，那么链接就不对了。


- Fix:
 使用 fileManager.getFile(metaData) 去生成链接中的文件名。