### PR TITLE
修复保存到DailyNotes中无法获取用户上传的书籍

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-weread-plugin",
 	"name": "Weread Plugin",
-	"version": "0.5.3",
+	"version": "0.5.4",
 	"minAppVersion": "0.12.0",
 	"description": "This is obsidian plugin for Tencent weread.",
 	"author": "hankzhao",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-weread-plugin",
-	"version": "0.5.3",
+	"version": "0.5.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-weread-plugin",
-			"version": "0.5.3",
+			"version": "0.5.4",
 			"license": "MIT",
 			"dependencies": {
 				"@types/lodash.pickby": "^4.6.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-weread-plugin",
-	"version": "0.5.3",
+	"version": "0.5.4",
 	"description": "This is a community plugin for tencent weread (https://r.qq.com)",
 	"main": "main.ts",
 	"scripts": {

--- a/src/syncNotebooks.ts
+++ b/src/syncNotebooks.ts
@@ -110,8 +110,7 @@ export default class SyncNotebooks {
 	}
 
 	private async saveToJounal(journalDate: string, metaDataArr: Metadata[]) {
-		const books = await this.getBookReadInDate(journalDate);
-		const metaDataArrInDate = metaDataArr.filter((meta) => books.contains(meta.bookId));
+		const metaDataArrInDate = metaDataArr.filter((meta) => meta.lastReadDate === journalDate);
 
 		const notebooksInDate = [];
 		for (const meta of metaDataArrInDate) {
@@ -130,17 +129,6 @@ export default class SyncNotebooks {
 			);
 			this.fileManager.saveDailyNotes(dailyNotePath, dailyNoteRefereneces);
 		}
-	}
-
-	private async getBookReadInDate(journalDate: string): Promise<string[]> {
-		const recentBookData: [] = await this.apiManager.getRecentBooks();
-		const recentBooks = parseRecentBooks(recentBookData);
-		const journalBookIds = recentBooks
-			.filter(
-				(book) => window.moment(book.recentTime * 1000).format('YYYY-MM-DD') === journalDate
-			)
-			.map((book) => book.bookId);
-		return journalBookIds;
 	}
 
 	private getDuplicateBooks(metaDatas: Metadata[]): Set<string> {


### PR DESCRIPTION
`/shelf/friendCommon` 无法获取用户上传的书籍

修复后： 从meta data中拿到用户今日阅读的数据，进行日期比对