### PR TITLE
feat: add reading metadata & add chapter title toggle

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-weread-plugin",
 	"name": "Weread Plugin",
-	"version": "0.6.1",
+	"version": "0.7.0",
 	"minAppVersion": "0.12.0",
 	"description": "This is obsidian plugin for Tencent weread.",
 	"author": "hankzhao",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-weread-plugin",
 	"name": "Weread Plugin",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"minAppVersion": "0.12.0",
 	"description": "This is obsidian plugin for Tencent weread.",
 	"author": "hankzhao",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-weread-plugin",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-weread-plugin",
-			"version": "0.6.0",
+			"version": "0.6.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/crypto-js": "^4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-weread-plugin",
-	"version": "0.6.1",
+	"version": "0.7.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-weread-plugin",
-			"version": "0.6.1",
+			"version": "0.7.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/crypto-js": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-weread-plugin",
-	"version": "0.6.1",
+	"version": "0.7.0",
 	"description": "This is a community plugin for tencent weread (https://r.qq.com)",
 	"main": "main.ts",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-weread-plugin",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"description": "This is a community plugin for tencent weread (https://r.qq.com)",
 	"main": "main.ts",
 	"scripts": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,7 +3,12 @@ import { settingsStore } from './settings';
 import { get } from 'svelte/store';
 import { getCookieString } from './utils/cookiesUtil';
 import { Cookie, parse, splitCookiesString } from 'set-cookie-parser';
-import { HighlightResponse, BookReviewResponse, ChapterResponse } from './models';
+import {
+	HighlightResponse,
+	BookReviewResponse,
+	ChapterResponse,
+	BookReadInfoResponse
+} from './models';
 export default class ApiManager {
 	readonly baseUrl: string = 'https://i.weread.qq.com';
 
@@ -207,6 +212,19 @@ export default class ApiManager {
 				'Failed to fetch weread notebook chapters . Please check your Cookies and try again.'
 			);
 			console.error('get book chapters error' + bookId, e);
+		}
+	}
+	async getBookReadInfo(bookId: string): Promise<BookReadInfoResponse> {
+		try {
+			const url = `${this.baseUrl}/book/readinfo?bookId=${bookId}&readingDetail=1&readingBookIndex=1&finishedDate=1`;
+			const req: RequestUrlParam = { url: url, method: 'GET', headers: this.getHeaders() };
+			const resp = await requestUrl(req);
+			return resp.json;
+		} catch (e) {
+			new Notice(
+				'Failed to fetch weread notebook read info . Please check your Cookies and try again.'
+			);
+			console.error('get book read info error' + bookId, e);
 		}
 	}
 

--- a/src/assets/notebookTemplate.njk
+++ b/src/assets/notebookTemplate.njk
@@ -20,8 +20,9 @@ lastReadDate: {{metaData.lastReadDate}}
 {% for highlight in chapter.highlights %}{% if highlight.reviewContent %}
 > 📌  {{ highlight.markText |trim }} ^{{highlight.bookmarkId}}
 - 💭 {{highlight.reviewContent}} - ⏱ {{highlight.createTime}} {% else %}
-> 📌 {{ highlight.markText |trim }} ^{{highlight.bookmarkId}}
-- ⏱ {{highlight.createTime}}{% endif %} {% endfor %}{% endfor %}
+> 📌 {{ highlight.markText |trim }} 
+> ⏱ {{highlight.createTime}} ^{{highlight.bookmarkId}}{% endif %}
+{% endfor %}{% endfor %}
 # 读书笔记
 {% for chapter in bookReview.chapterReviews %}{% if chapter.reviews or chapter.chapterReview %}
 ## {{chapter.chapterTitle}}

--- a/src/assets/wereadOfficialTemplate.njk
+++ b/src/assets/wereadOfficialTemplate.njk
@@ -1,0 +1,21 @@
+---
+isbn: {{metaData.isbn}}
+lastReadDate: {{metaData.lastReadDate}}
+---
+《{{metaData.title}}》
+{{metaData.author}}
+{{metaData.noteCount}}个笔记
+{% if bookReview.bookReviews %}{% for bookReview in bookReview.bookReviews %}
+◆ 点评
+{{bookReview.createTime}}
+{{bookReview.mdContent}}{% endfor%}{% endif %}
+{% for chapter in chapterHighlights %}
+{% if chapter.level == 1 %}## ◆ {{chapter.chapterTitle}}{% elif chapter.level == 2 %}### ◆ {{chapter.chapterTitle}}{% elif chapter.level == 3 %}#### ◆ {{chapter.chapterTitle}}{% endif %}
+{% for highlight in chapter.highlights %}{% if highlight.reviewContent %}
+{{highlight.createTime}} 发表想法
+{{highlight.reviewContent}}
+
+> {{ highlight.markText |trim }} ^{{highlight.bookmarkId}}
+ {% else %}
+
+> {{ highlight.markText |trim }} ^{{highlight.bookmarkId}}{% endif %}{% endfor %}{% endfor %}

--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -175,13 +175,13 @@ export default class FileManager {
 	private getFileName(metaData: Metadata): string {
 		const fileNameType = get(settingsStore).fileNameType;
 		const baseFileName = sanitizeTitle(metaData.title);
-		if (fileNameType == 'BOOK_NAME-AUTHOR') {
+		if (fileNameType == 'BOOK_NAME_AUTHOR') {
 			if (metaData.duplicate) {
 				return `${baseFileName}-${metaData.author}-${metaData.bookId}`;
 			}
 			return `${baseFileName}-${metaData.author}`;
 		} else {
-			if (metaData.duplicate || fileNameType == 'BOOK_NAME-BOOKID') {
+			if (metaData.duplicate || fileNameType == 'BOOK_NAME_BOOKID') {
 				return `${baseFileName}-${metaData.bookId}`;
 			}
 			return baseFileName;

--- a/src/models.ts
+++ b/src/models.ts
@@ -119,6 +119,80 @@ export type ChapterResponse = {
 	}[];
 };
 
+export type BookReadInfoResponse = {
+	finishedBookCount: number;
+	finishedBookIndex: number;
+	finishedDate: number;
+	readingBookCount: number;
+	readingBookDate: number;
+	readingProgress: number;
+	readingReviewId: string;
+	canCancelReadstatus: number;
+	markedStatus: number;
+	readingTime: number;
+	totalReadDay: number;
+	recordReadingTime: number;
+	continueReadDays: number;
+	continueBeginDate: number;
+	continueEndDate: number;
+	showSummary: number;
+	showDetail: number;
+	readDetail: {
+		totalReadingTime: number;
+		totalReadDay: number;
+		continueReadDays: number;
+		continueBeginDate: number;
+		continueEndDate: number;
+		beginReadingDate: number;
+		lastReadingDate: number;
+		longestReadingDate: number;
+		avgReadingTime: number;
+		longestReadingTime: number;
+		data: {
+			readDate: number;
+			readTime: number;
+		}[];
+	};
+	bookInfo: {
+		bookId: string;
+		title: string;
+		author: string;
+		translator: string;
+		intro: string;
+		cover: string;
+		version: number;
+		format: string;
+		type: number;
+		soldout: number;
+		bookStatus: number;
+		payType: number;
+		finished: number;
+		maxFreeChapter: number;
+		free: number;
+		mcardDiscount: number;
+		ispub: number;
+		extra_type: number;
+		cpid: number;
+		publishTime: string;
+		lastChapterIdx: number;
+		paperBook: {
+			skuId: string;
+		};
+		centPrice: number;
+		readingCount: number;
+		maxfreeInfo: {
+			maxfreeChapterIdx: number;
+			maxfreeChapterUid: number;
+			maxfreeChapterRatio: number;
+		};
+		blockSaveImg: number;
+		language: string;
+		hideUpdateTime: boolean;
+		isEPUBComics: number;
+		webBookControl: number;
+	};
+};
+
 export type Chapter = {
 	chapterUid: number;
 	chapterIdx: number;
@@ -154,6 +228,19 @@ export type Metadata = {
 	file?: AnnotationFile;
 	totalWords?: number;
 	rating?: string;
+	readInfo?: {
+		markedStatus: number;
+		readingTime: number;
+		totalReadDay: number;
+		continueReadDays: number;
+		readingBookCount: number;
+		readingBookIndex: number;
+		readingBookDate: number;
+		finishedBookCount: number;
+		finishedBookIndex: number;
+		finishedDate: number;
+		readingProgress: number;
+	};
 };
 
 export type Highlight = {

--- a/src/parser/parseResponse.ts
+++ b/src/parser/parseResponse.ts
@@ -14,6 +14,8 @@ import type {
 } from 'src/models';
 import { NodeHtmlMarkdown } from 'node-html-markdown';
 import * as CryptoJS from 'crypto-js';
+import { settingsStore } from '../settings';
+import { get } from 'svelte/store';
 
 export const parseMetadata = (noteBook: any): Metadata => {
 	const book = noteBook['book'];
@@ -67,7 +69,7 @@ export const parseHighlights = (
 			style: highlight.style,
 			colorStyle: highlight.colorStyle,
 			chapterTitle: chapterInfo?.title || '未知章节',
-			markText: highlight.markText?.replace(/\n/gi, ''),
+			markText: highlight.markText,
 			reviewContent: reviewContent
 		};
 	});
@@ -98,7 +100,7 @@ export const parseChapterHighlightReview = (
 				return o1Start - o2Start;
 			});
 		let chapterReviews;
-		if (chapterHighlights && reviews) {
+		if (chapterHighlights && chapterHighlights.length > 0 && reviews) {
 			chapterReviews = reviews
 				.filter((review) => chapterUid == review.chapterUid && review.type == 1)
 				.sort((o1, o2) => {
@@ -115,15 +117,20 @@ export const parseChapterHighlightReview = (
 					}
 				});
 		}
-		chapterResult.push({
-			chapterUid: chapterUid,
-			chapterIdx: chapterIdx,
-			chapterTitle: chapterTitle,
-			level: chapter.level,
-			isMPChapter: chapter.isMPChapter,
-			chapterReviews: chapterReviews,
-			highlights: chapterHighlights
-		});
+
+		const showEmptyChapterTitleToggle = get(settingsStore).showEmptyChapterTitleToggle;
+		// if showEmptyChapterTitle is true, will set chapter even there is no highlight in this chapter
+		if ((chapterHighlights && chapterHighlights.length > 0) || showEmptyChapterTitleToggle) {
+			chapterResult.push({
+				chapterUid: chapterUid,
+				chapterIdx: chapterIdx,
+				chapterTitle: chapterTitle,
+				level: chapter.level,
+				isMPChapter: chapter.isMPChapter,
+				chapterReviews: chapterReviews,
+				highlights: chapterHighlights
+			});
+		}
 	}
 
 	return chapterResult.sort((o1, o2) => o1.chapterIdx - o2.chapterIdx);

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -9,6 +9,7 @@ import pickBy from 'lodash.pickby';
 import { Renderer } from './renderer';
 import { getEncodeCookieString } from './utils/cookiesUtil';
 import { Notice } from 'obsidian';
+
 export class WereadSettingsTab extends PluginSettingTab {
 	private plugin: WereadPlugin;
 	private renderer: Renderer;
@@ -42,6 +43,7 @@ export class WereadSettingsTab extends PluginSettingTab {
 		this.noteCountLimit();
 		this.fileNameType();
 		this.subFolderType();
+		this.showEmptyChapterTitleToggle();
 		this.dailyNotes();
 		const dailyNotesToggle = get(settingsStore).dailyNotesToggle;
 		if (dailyNotesToggle) {
@@ -205,8 +207,8 @@ export class WereadSettingsTab extends PluginSettingTab {
 			.addDropdown((dropdown) => {
 				dropdown.addOptions({
 					BOOK_NAME: '书名',
-					'BOOK_NAME-AUTHOR': '书名-作者名',
-					'BOOK_NAME-ID': '书名-bookId'
+					BOOK_NAME_AUTHOR: '书名-作者名',
+					BOOK_NAME_BOOKID: '书名-bookId'
 				});
 				return dropdown
 					.setValue(get(settingsStore).fileNameType)
@@ -315,5 +317,21 @@ export class WereadSettingsTab extends PluginSettingTab {
 		} else {
 			keys.createEl('kbd', { text: 'CTRL + SHIFT + I' });
 		}
+	}
+
+	private showEmptyChapterTitleToggle(): void {
+		new Setting(this.containerEl)
+			.setName('是否展示空白章节标题？')
+			.setDesc('如果启用，则章节内没有划线也将展示章节标题')
+			.setHeading()
+			.addToggle((toggle) => {
+				return toggle
+					.setValue(get(settingsStore).showEmptyChapterTitleToggle)
+					.onChange((value) => {
+						console.debug('set empty chapter title toggle to', value);
+						settingsStore.actions.setEmptyChapterTitleToggle(value);
+						this.display();
+					});
+			});
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -20,6 +20,7 @@ interface WereadPluginSettings {
 	fileNameType: string;
 	dailyNotesToggle: boolean;
 	notesBlacklist: string;
+	showEmptyChapterTitleToggle: boolean;
 }
 
 const DEFAULT_SETTINGS: WereadPluginSettings = {
@@ -38,7 +39,8 @@ const DEFAULT_SETTINGS: WereadPluginSettings = {
 	subFolderType: '-1',
 	fileNameType: 'BOOK_NAME',
 	dailyNotesToggle: false,
-	notesBlacklist: ''
+	notesBlacklist: '',
+	showEmptyChapterTitleToggle: false
 };
 
 const createSettingsStore = () => {
@@ -190,6 +192,14 @@ const createSettingsStore = () => {
 			return state;
 		});
 	};
+
+	const setEmptyChapterTitleToggle = (emtpyChapterTitleToggle: boolean) => {
+		store.update((state) => {
+			state.showEmptyChapterTitleToggle = emtpyChapterTitleToggle;
+			return state;
+		});
+	};
+
 	return {
 		subscribe: store.subscribe,
 		initialise,
@@ -206,7 +216,8 @@ const createSettingsStore = () => {
 			setDailyNotesFormat,
 			setInsertAfter,
 			setInsertBefore,
-			setNoteBlacklist
+			setNoteBlacklist,
+			setEmptyChapterTitleToggle
 		}
 	};
 };

--- a/src/syncNotebooks.ts
+++ b/src/syncNotebooks.ts
@@ -22,11 +22,12 @@ export default class SyncNotebooks {
 	}
 
 	async syncNotebooks(force = false, journalDate: string) {
-		const progressNotice = new Notice('微信读书笔记同步开始!', 60000);
+		new Notice('微信读书笔记同步开始!');
 		const syncStartTime = new Date().getTime();
 		const metaDataArr = await this.getALlMetadata();
 		const filterMetaArr = await this.filterNoteMetas(force, metaDataArr);
 		let syncedNotebooks = 0;
+		const progressNotice = new Notice('微信读书笔记同步中, 请稍后！', 60000);
 		for (const meta of filterMetaArr) {
 			const notebook = await this.convertToNotebook(meta);
 			await this.saveNotebook(notebook);

--- a/src/syncNotebooks.ts
+++ b/src/syncNotebooks.ts
@@ -60,14 +60,20 @@ export default class SyncNotebooks {
 	private async convertToNotebook(metaData: Metadata): Promise<Notebook> {
 		const bookDetail = await this.apiManager.getBook(metaData.bookId);
 		if (bookDetail) {
-			metaData['category'] = bookDetail['category'];
-			metaData['publisher'] = bookDetail['publisher'];
-			metaData['isbn'] = bookDetail['isbn'];
-			metaData['intro'] = bookDetail['intro'];
-			metaData['totalWords'] = bookDetail['totalWords'];
+			metaData.category = bookDetail['category'];
+			metaData.publisher = bookDetail['publisher'];
+			metaData.isbn = bookDetail['isbn'];
+			metaData.intro = bookDetail['intro'];
+			metaData.totalWords = bookDetail['totalWords'];
 			const newRating = parseInt(bookDetail['newRating']);
-			metaData['rating'] = `${newRating / 10}%`;
+			metaData.rating = `${newRating / 10}%`;
 		}
+
+		const readInfo = await this.apiManager.getBookReadInfo(metaData.bookId);
+		if (readInfo) {
+			metaData.readInfo = Object.assign({}, readInfo);
+		}
+		console.log('meta read info', readInfo);
 
 		const highlightResp = await this.apiManager.getNotebookHighlights(metaData.bookId);
 		const reviewResp = await this.apiManager.getNotebookReviews(metaData.bookId);

--- a/src/utils/dateUtil.ts
+++ b/src/utils/dateUtil.ts
@@ -1,0 +1,12 @@
+export const formatTimeDuration = (duration: number): string => {
+	const hours = Math.floor(duration / 60);
+	const minutes = duration % 60;
+
+	const formattedDuration = `${hours}小时${minutes}分钟`;
+
+	return formattedDuration;
+};
+
+export const formatTimestampToDate = (readingBookDate: number): string => {
+	return window.moment(readingBookDate * 1000).format('YYYY-MM-DD');
+};

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -46,7 +46,7 @@ export const buildFrontMatter = (
 		const freshMarkdownContent = markdownContent.substring(endInd + 4);
 		const freshFrontMatter = { ...existFrontMatter, ...frontMatter, ...templateFrontMatter };
 		const frontMatterStr = stringifyYaml(freshFrontMatter);
-		return '---\n' + frontMatterStr + '---\n' + freshMarkdownContent;
+		return '---\n' + frontMatterStr + freshMarkdownContent;
 	}
 
 	const frontMatterStr = stringifyYaml(frontMatter);

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -1,5 +1,6 @@
 import { Notice, parseYaml, stringifyYaml, TFile } from 'obsidian';
 import type { Notebook } from '../models';
+import { formatTimeDuration, formatTimestampToDate } from './dateUtil';
 
 type FrontMatterContent = {
 	doc_type: string;
@@ -8,9 +9,22 @@ type FrontMatterContent = {
 	cover: string;
 	noteCount: number;
 	reviewCount: number;
+	readingStatus?: string;
+	progress?: string;
+	readingTime?: string;
+	totalReadDay?: number;
+	readingDate?: string;
+	finishedDate?: string;
 };
 
 export const frontMatterDocType = 'weread-highlights-reviews';
+
+enum ReadingStatus {
+	'未标记' = 1,
+	'在读' = 2,
+	'读过' = 3,
+	'读完' = 4
+}
 
 export const buildFrontMatter = (
 	markdownContent: string,
@@ -25,6 +39,18 @@ export const buildFrontMatter = (
 		reviewCount: noteBook.metaData.reviewCount,
 		noteCount: noteBook.metaData.noteCount
 	};
+
+	const readInfo = noteBook.metaData.readInfo;
+	if (readInfo) {
+		frontMatter.readingStatus = ReadingStatus[readInfo.markedStatus];
+		frontMatter.progress = readInfo.readingProgress + '%';
+		frontMatter.totalReadDay = readInfo.totalReadDay;
+		frontMatter.readingTime = formatTimeDuration(readInfo.readingTime);
+		frontMatter.readingDate = formatTimestampToDate(readInfo.readingBookDate);
+		if (readInfo.finishedDate) {
+			frontMatter.finishedDate = formatTimestampToDate(readInfo.finishedDate);
+		}
+	}
 	let existFrontMatter = Object();
 	if (existFile) {
 		const cache = app.metadataCache.getFileCache(existFile);


### PR DESCRIPTION
本次主要更新了两个功能：

1. 在顶部的frontmatter中，默认增加了**读书元数据**，可以更方便使用**dataview**来统计自己的阅读数据。

    **readingStatus**: 阅读状态，有四种，未标记，在读，读过，读完。
    **progress**：当前图书的阅读状态，注意，这里的进度和上面的状态可能冲突，比如状态是阅读完，但是进度可能不是100%
    **readingTime**：当前图书的阅读时间，格式为XX小时XX分钟
    **totalReadDay**: 当前图书的总阅读天数。
    **readingDate**：当前图书开始阅读的时间。
    **finishedDate**：当前图书完成阅读的时间，如果有的话。

<img width="806" alt="image" src="https://github.com/zhaohongxuan/obsidian-weread-plugin/assets/8613196/d2728256-8fd5-4d63-a5b6-2b179382bf2e">

2. 增加chapter title的开关，如果一个章节下面没有划线，那么默认情况下将**不输出标题**，如果希望展示所有的标题，需要手动打开开关。
<img width="845" alt="image" src="https://github.com/zhaohongxuan/obsidian-weread-plugin/assets/8613196/41aa728f-3835-4372-816d-12930353536c">

3. 修复 #243 和 #238 两个bug
4. 优化了同步流程提示框，不影响功能