### PR TITLE
feat: add more template variables

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -332,6 +332,7 @@ export type Metadata = {
 		finishedBookIndex: number;
 		finishedDate: number;
 		readingProgress: number;
+		[key: string]: string | number;
 	};
 };
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -2,6 +2,7 @@ import * as nunjucks from 'nunjucks';
 import type { Notebook, RenderTemplate } from './models';
 import { settingsStore } from './settings';
 import { get } from 'svelte/store';
+import {formatTimeDuration, formatTimestampToDate} from "./utils/dateUtil";
 export class Renderer {
 	constructor() {
 		nunjucks.configure({ autoescape: false });
@@ -19,7 +20,12 @@ export class Renderer {
 
 	render(entry: Notebook): string {
 		const { metaData, chapterHighlights, bookReview } = entry;
-
+		// 增加格式化阅读数据
+		metaData.readInfo.readingTimeStr = formatTimeDuration(metaData.readInfo.readingTime);
+		metaData.readInfo.readingTimeStr = formatTimestampToDate(metaData.readInfo.readingBookDate);
+		if (metaData.readInfo.finishedDate) {
+			metaData.readInfo.finishedDateStr = formatTimestampToDate(metaData.readInfo.finishedDate);
+		}
 		const context: RenderTemplate = {
 			metaData,
 			chapterHighlights,


### PR DESCRIPTION
在同步微信读书之后，想结合 timelines 做一个什么时候阅读完某一本书的记录，timelines 要求必须包含一些timeline元素，但是现在能够拿到的 metaData.readInfo 里面的时间戳，无法很好的实现。
timelines结合obsidian-douban实现的效果图：
[效果图](https://github.com/Wanxp/obsidian-douban/blob/master/doc/img/obsidian-douban-time-preview-example.gif)