### PR TITLE
fix: replaceAll for number type

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -4,11 +4,11 @@ import { settingsStore } from './settings';
 import { get } from 'svelte/store';
 export class Renderer {
 	constructor() {
-		nunjucks.configure({ autoescape: false })
+		nunjucks
+			.configure({ autoescape: false })
 			// 自定义函数 https://mozilla.github.io/nunjucks/api.html#addfilter
 			.addFilter('replace', function (str, pattern, replacement) {
-				if (!str)
-					return ''
+				if (!str) return '';
 
 				if (typeof pattern === 'string') {
 					try {
@@ -22,14 +22,13 @@ export class Renderer {
 						}
 					} catch (e) {
 						// 如果正则表达式无效，回退到字符串替换
-						return str.replaceAll(pattern, replacement);
+						return String(str).replaceAll(pattern, replacement);
 					}
 				} else if (pattern instanceof RegExp) {
-					return str.replace(pattern, replacement);
+					return String(str).replace(pattern, replacement);
 				}
-				return str.replaceAll(pattern, replacement);
-			})
-			;
+				return String(str).replaceAll(pattern, replacement);
+			});
 	}
 
 	validate(template: string): boolean {


### PR DESCRIPTION
更新发现当前划颜色返回的似乎是数字类型，导致 `replaceAll` 运行失败，所有划线都无法同步。
<img width="651" height="183" alt="Snipaste_2025-07-23_14-56-43" src="https://github.com/user-attachments/assets/28cb0b76-78d5-4a09-a353-4c9164e531e2" />

因此在替换之前，先进行一层类型转换。