### PR TITLE
feat: add realtime njk template renderer;

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,47 @@
+# Copilot Instructions for obsidian-weread-plugin
+
+## Project Overview
+- This is an Obsidian community plugin for syncing WeRead (微信读书) book metadata, highlights, notes, and reviews into Markdown files in an Obsidian vault.
+- The plugin supports login via WeChat QR code, cookie management, custom templates (Nunjucks), and flexible file naming/frontmatter.
+- Main logic is in `src/`, with subfolders for API, models, rendering, settings, and utilities. Templates are in `src/assets/`.
+
+## Key Components
+- `src/api.ts`: Handles WeRead API requests and data fetching.
+- `src/syncNotebooks.ts`: Core sync logic for books, highlights, and notes.
+- `src/renderer.ts`: Converts fetched data into Markdown using Nunjucks templates.
+- `src/settings.ts` & `src/settingTab.ts`: Plugin settings UI and logic.
+- `src/utils/`: Utility functions for cookies, dates, file management, frontmatter, etc.
+- `src/components/`: UI models for login/logout and reading state.
+
+## Developer Workflows
+- **Build:** Use `npm run build` (uses webpack, see `webpack.config.js`).
+- **Release:** See GitHub Actions workflows in `.github/workflows/` for CI and release automation.
+- **Versioning:** Use `version-bump.mjs` and `versions.json` for version management.
+- **Sync:** Main entry is `Sync Weread command` (see README for usage).
+
+## Project Conventions
+- All book/note sync is overwrite-based: do not edit synced files directly.
+- Templates use Nunjucks (`.njk` in `src/assets/`).
+- Settings and state are managed via Obsidian's plugin API and custom UI components.
+- Cookie management is abstracted in `src/cookieCloud.ts` and `src/utils/cookiesUtil.ts`.
+- File and frontmatter logic is in `src/utils/fileUtils.ts` and `src/utils/frontmatter.ts`.
+
+## Integration Points
+- Relies on WeRead web APIs (see `docs/weread-api.md`).
+- Uses Nunjucks for template rendering.
+- Integrates with Obsidian's plugin API for UI, commands, and file management.
+
+## Examples & References
+- See `README.md` for user-facing features and workflows.
+- See `docs/weread-api.md` for API details.
+- Templates: `src/assets/notebookTemplate.njk`, `src/assets/wereadOfficialTemplate.njk`.
+
+## Tips for AI Agents
+- When adding features, follow the modular structure (API, sync, render, settings, utils).
+- Respect the overwrite sync model—never write code that edits user notes in place.
+- Use existing utility functions for cookies, file, and frontmatter handling.
+- Reference and extend Nunjucks templates for new output formats.
+- For new settings, update both `settings.ts` and `settingTab.ts`.
+
+---
+_Last updated: 2025-11-13_

--- a/docs/template-editor-window.md
+++ b/docs/template-editor-window.md
@@ -1,0 +1,165 @@
+# 原生窗口模板编辑器
+
+## 概述
+
+新的模板编辑器使用 Electron 的 `BrowserWindow` 创建了一个真正的原生窗口，提供类似 macOS 原生应用的体验。
+
+## 功能特性
+
+### 三栏布局
+
+1. **左侧：模板说明文档** (300px，可调整 250-500px)
+   - 显示完整的 Nunjucks 模板语法说明
+   - 包含可用变量、过滤器和示例代码
+   - 支持拖动调整宽度
+
+2. **中间：模板编辑器** (自适应宽度)
+   - 语法高亮的代码编辑器
+   - 支持 Nunjucks 模板语法
+   - 实时语法验证
+
+3. **右侧：实时预览** (自适应宽度)
+   - 300ms 防抖的实时渲染
+   - 使用示例数据预览效果
+   - 错误提示显示
+
+### 窗口功能
+
+- **原生窗口体验**：使用 Electron BrowserWindow，提供完整的原生窗口功能
+- **可拖动标题栏**：通过标题栏拖动整个窗口
+- **最小尺寸**：1200×600px (初始尺寸：1600×900px)
+- **响应式布局**：自动适应窗口大小
+- **深色主题**：专为深色模式优化的 UI
+
+## 技术实现
+
+### 组件结构
+
+```
+templateEditorWindow.ts
+├── Constructor
+│   ├── 创建 BrowserWindow
+│   ├── 设置窗口参数
+│   └── 初始化 Renderer
+├── loadContent()
+│   └── 加载 HTML 内容
+├── generateHTML()
+│   ├── 生成完整的 HTML/CSS/JS
+│   ├── 嵌入模板说明文档
+│   └── 设置事件监听器
+├── open()
+│   ├── 设置 IPC 通信
+│   ├── update-preview: 更新预览
+│   ├── save-template: 保存模板
+│   └── close-window: 关闭窗口
+└── buildSampleNotebook()
+    └── 生成示例数据
+```
+
+### IPC 通信
+
+**渲染进程 → 主进程**
+- `update-preview`: 发送模板字符串以更新预览
+- `save-template`: 保存模板
+- `close-window`: 关闭窗口
+
+**主进程 → 渲染进程**
+- `preview-updated`: 返回渲染结果或错误信息
+
+### 样式设计
+
+- **字体**：SF Mono, Monaco, Cascadia Code (代码编辑器)
+- **配色**：基于 VS Code 深色主题
+- **布局**：Flexbox 响应式布局
+- **交互**：平滑过渡动画和悬停效果
+
+## 使用方式
+
+### 在设置页面
+
+```typescript
+// settingTab.ts
+private template(): void {
+    const descFragment = document.createRange()
+        .createContextualFragment(templateInstructions);
+
+    new Setting(this.containerEl)
+        .setName('笔记模板')
+        .setDesc(descFragment)
+        .addButton((button) => {
+            return button
+                .setButtonText('编辑模板')
+                .setCta()
+                .onClick(() => {
+                    const editorWindow = new TemplateEditorWindow(
+                        get(settingsStore).template,
+                        (newTemplate: string) => {
+                            settingsStore.actions.setTemplate(newTemplate);
+                        }
+                    );
+                    editorWindow.open();
+                });
+        });
+}
+```
+
+### 编程调用
+
+```typescript
+import { TemplateEditorWindow } from './components/templateEditorWindow';
+
+// 创建编辑器窗口
+const editor = new TemplateEditorWindow(
+    currentTemplate,          // 当前模板字符串
+    (newTemplate: string) => { // 保存回调
+        // 处理保存的模板
+        console.log('新模板:', newTemplate);
+    }
+);
+
+// 打开窗口
+editor.open();
+```
+
+## 与之前实现的对比
+
+| 特性 | 之前 (Modal) | 现在 (BrowserWindow) |
+|------|-------------|---------------------|
+| 窗口类型 | Obsidian Modal | Electron 原生窗口 |
+| 布局 | 两栏（编辑器+预览） | 三栏（说明+编辑器+预览） |
+| 大小调整 | 8方向拖拽调整 | 原生窗口缩放 |
+| 窗口拖动 | 自定义拖拽实现 | 原生标题栏拖拽 |
+| 最大化 | 自定义按钮 | 原生最大化按钮 |
+| 最小尺寸 | 600×400px | 1200×600px |
+| 初始尺寸 | 95vw×90vh | 1600×900px |
+| 说明文档 | 在设置页面 | 集成在窗口左侧 |
+| 主题适配 | CSS 变量 | 独立样式 |
+
+## 优势
+
+1. **真正的原生体验**：使用系统原生窗口，符合用户习惯
+2. **三栏布局**：说明、编辑、预览一目了然
+3. **更大的工作空间**：1600×900px 的初始尺寸
+4. **原生窗口管理**：支持系统级的窗口操作（最小化、最大化、关闭）
+5. **可调整的说明面板**：根据需要调整说明文档的宽度
+6. **专业的编辑体验**：类似 IDE 的界面设计
+
+## 注意事项
+
+1. **仅支持桌面端**：BrowserWindow 仅在 Electron 环境中可用
+2. **内存管理**：确保窗口关闭时清理 IPC 监听器
+3. **调试**：可以使用 Electron DevTools 调试窗口内容
+4. **性能**：使用 300ms 防抖优化实时预览性能
+
+## 未来改进
+
+- [ ] 添加快捷键支持 (Cmd+S 保存等)
+- [ ] 支持多标签页编辑多个模板
+- [ ] 添加模板历史记录
+- [ ] 支持模板导入导出
+- [ ] 添加语法高亮和自动补全
+- [ ] 支持实时预览滚动同步
+
+---
+
+**最后更新**: 2025-11-22

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-weread-plugin",
 	"name": "Weread",
-		"version": "0.14.0",
+		"version": "0.15.0",
 	"minAppVersion": "0.12.0",
 	"description": "This is obsidian plugin for Tencent weread.",
 	"author": "hankzhao",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-weread-plugin",
-		"version": "0.14.0",
+		"version": "0.15.0",
 	"description": "This is a community plugin for tencent weread (https://r.qq.com)",
 	"main": "main.ts",
 	"scripts": {

--- a/src/assets/templateInstructions.html
+++ b/src/assets/templateInstructions.html
@@ -1,7 +1,10 @@
 <a href="https://github.com/zhaohongxuan/obsidian-weread-plugin/wiki/Weread-obsidian-plugin-markdown-template-usage">模板使用说明</a>
-<p>
-  <h2>可用变量</h2>
-</p>
+
+<h3>功能开关</h3>
+<p><strong>✂️ 自动去空白：</strong>开启后会自动移除模板标签（{% %}）前后的换行和空格，让你可以用缩进写出更易读的模板代码。</p>
+<p><strong>📝 Markdown渲染：</strong>开启后右侧预览会渲染为格式化的 Markdown，关闭则显示原始文本。</p>
+
+<h2>可用变量</h2>
 元数据变量(metaData)
 <ul>
   <li><span class="u-pop">{{title}}</span> - 书名</li>

--- a/src/components/templateEditorWindow.ts
+++ b/src/components/templateEditorWindow.ts
@@ -1,0 +1,302 @@
+import { Modal, App, Notice, MarkdownRenderer } from 'obsidian';
+import { Renderer } from '../renderer';
+import type { Notebook } from '../models';
+import templateInstructions from '../assets/templateInstructions.html';
+import { settingsStore } from '../settings';
+import { get } from 'svelte/store';
+
+export class TemplateEditorWindow extends Modal {
+	private initialTemplate: string;
+	private onSave: (template: string) => void;
+	private renderer: Renderer;
+	private editorEl: HTMLTextAreaElement;
+	private previewEl: HTMLElement;
+	private errorEl: HTMLElement;
+	private debounceTimer: NodeJS.Timeout | null = null;
+	private isMarkdownRendered = false;
+	private trimBlocks: boolean;
+
+	constructor(app: App, initialTemplate: string, onSave: (template: string) => void) {
+		super(app);
+		this.initialTemplate = initialTemplate;
+		this.onSave = onSave;
+		this.renderer = new Renderer();
+		// 从 settings 读取 trimBlocks 配置
+		this.trimBlocks = get(settingsStore).trimBlocks;
+	}
+
+	// 禁用点击外部或按 ESC 关闭
+	shouldCloseOnEsc(): boolean {
+		return false;
+	}
+
+	onOpen() {
+		const { contentEl, modalEl } = this;
+
+		// 禁用点击外部关闭模态框
+		modalEl.addEventListener('click', (e: MouseEvent) => {
+			if (e.target === modalEl) {
+				e.stopPropagation();
+			}
+		});
+
+		// 设置模态框样式
+		modalEl.addClass('weread-template-editor-modal');
+		modalEl.style.width = '95vw';
+		modalEl.style.height = '90vh';
+		modalEl.style.maxWidth = '95vw';
+		modalEl.style.maxHeight = '90vh';
+
+		// 创建标题栏
+		const titleBar = contentEl.createDiv('weread-editor-titlebar');
+		titleBar.createEl('h2', { text: '📝 模板编辑器' });
+
+		const buttonGroup = titleBar.createDiv('weread-editor-buttons');
+		const cancelBtn = buttonGroup.createEl('button', { text: '取消', cls: 'mod-cancel' });
+		const saveBtn = buttonGroup.createEl('button', { text: '保存', cls: 'mod-cta' });
+
+		cancelBtn.onclick = () => this.handleCancel();
+		saveBtn.onclick = () => this.handleSave();
+
+		// 创建三栏布局容器
+		const container = contentEl.createDiv('weread-editor-container');
+
+		// 左侧：说明文档
+		const instructionsPanel = container.createDiv('weread-editor-instructions');
+		instructionsPanel.innerHTML = templateInstructions;
+
+		// 中间：编辑器
+		const editorPanel = container.createDiv('weread-editor-panel');
+		editorPanel.createEl('div', { text: '📄 模板编辑 (Nunjucks)', cls: 'panel-header' });
+
+		this.editorEl = editorPanel.createEl('textarea', { cls: 'weread-editor-textarea' });
+		this.editorEl.value = this.initialTemplate;
+
+		// 右侧：预览
+		const previewPanel = container.createDiv('weread-editor-preview');
+		const previewHeader = previewPanel.createDiv('panel-header');
+		previewHeader.createSpan({ text: '👁️ 实时预览' });
+
+		// 创建开关容器
+		const toggleContainer = previewHeader.createDiv('weread-toggle-container');
+
+		// 添加 trimBlocks 切换开关
+		const trimToggleWrapper = toggleContainer.createDiv('weread-toggle-wrapper');
+		trimToggleWrapper.createSpan({ text: '✂️ 自动去空白', cls: 'weread-toggle-label' });
+		const trimToggleSwitch = trimToggleWrapper.createDiv('weread-toggle-switch');
+		if (this.trimBlocks) {
+			trimToggleSwitch.addClass('is-enabled');
+		}
+		trimToggleSwitch.addEventListener('click', () => {
+			this.trimBlocks = !this.trimBlocks;
+			if (this.trimBlocks) {
+				trimToggleSwitch.addClass('is-enabled');
+			} else {
+				trimToggleSwitch.removeClass('is-enabled');
+			}
+			// 保存到 settings
+			settingsStore.actions.setTrimBlocks(this.trimBlocks);
+			this.updatePreview();
+		});
+
+		// 添加渲染模式切换开关
+		const renderToggleWrapper = toggleContainer.createDiv('weread-toggle-wrapper');
+		renderToggleWrapper.createSpan({ text: '📝 Markdown渲染', cls: 'weread-toggle-label' });
+		const renderToggleSwitch = renderToggleWrapper.createDiv('weread-toggle-switch');
+		if (this.isMarkdownRendered) {
+			renderToggleSwitch.addClass('is-enabled');
+		}
+		renderToggleSwitch.addEventListener('click', () => {
+			this.isMarkdownRendered = !this.isMarkdownRendered;
+			if (this.isMarkdownRendered) {
+				renderToggleSwitch.addClass('is-enabled');
+			} else {
+				renderToggleSwitch.removeClass('is-enabled');
+			}
+			this.updatePreview();
+		});
+
+		const previewContent = previewPanel.createDiv('preview-content');
+		this.previewEl = previewContent.createEl('div', { cls: 'preview-text' });
+		this.errorEl = previewContent.createDiv('error-message');
+
+		// 初始预览
+		this.updatePreview();
+
+		// 监听编辑器输入
+		this.editorEl.addEventListener('input', () => {
+			if (this.debounceTimer) {
+				clearTimeout(this.debounceTimer);
+			}
+			this.debounceTimer = setTimeout(() => {
+				this.updatePreview();
+			}, 300);
+		});
+	}
+
+	private updatePreview(): void {
+		try {
+			const templateStr = this.editorEl.value;
+			const sampleNotebook = this.buildSampleNotebook();
+			const preview = this.renderer.renderWithTemplate(
+				templateStr,
+				sampleNotebook,
+				this.trimBlocks
+			);
+
+			// 清空预览容器
+			this.previewEl.empty();
+			this.errorEl.style.display = 'none';
+			this.errorEl.textContent = '';
+
+			if (this.isMarkdownRendered) {
+				// 渲染模式：使用 Obsidian 的 Markdown 渲染器
+				this.previewEl.addClass('markdown-preview-view');
+				this.previewEl.removeClass('preview-source-mode');
+				MarkdownRenderer.renderMarkdown(preview, this.previewEl, '', null);
+			} else {
+				// 源码模式：显示原始文本
+				this.previewEl.removeClass('markdown-preview-view');
+				this.previewEl.addClass('preview-source-mode');
+				const preEl = this.previewEl.createEl('pre');
+				preEl.textContent = preview;
+			}
+		} catch (error: any) {
+			this.previewEl.empty();
+			this.errorEl.style.display = 'block';
+			this.errorEl.textContent = '❌ ' + (error.message || String(error));
+		}
+	}
+
+	private handleCancel(): void {
+		// 检查是否有未保存的更改
+		if (this.editorEl.value !== this.initialTemplate) {
+			const confirmed = confirm('模板已修改但未保存，确定要关闭吗？');
+			if (!confirmed) {
+				return;
+			}
+		}
+		this.close();
+	}
+
+	private handleSave(): void {
+		const template = this.editorEl.value;
+		const isValid = this.renderer.validate(template);
+		if (!isValid) {
+			new Notice('模板语法错误，请检查后再保存！');
+			return;
+		}
+		this.onSave(template);
+		new Notice('模板已保存！');
+		this.close();
+	}
+
+	onClose() {
+		const { contentEl } = this;
+		contentEl.empty();
+		if (this.debounceTimer) {
+			clearTimeout(this.debounceTimer);
+		}
+	}
+
+	private buildSampleNotebook(): Notebook {
+		return {
+			metaData: {
+				bookId: '651358',
+				title: '中国哲学简史',
+				author: '冯友兰',
+				cover: 'https://cdn.weread.qq.com/weread/cover/24/YueWen_651358/t7_YueWen_651358.jpg',
+				url: 'https://weread.qq.com/web/reader/9f832d8059f05e9f8657f05',
+				pcUrl: 'https://weread.qq.com/web/reader/9f832d8059f05e9f8657f05',
+				bookType: 1,
+				publishTime: '2013-01-01',
+				noteCount: 128,
+				reviewCount: 11,
+				isbn: '9787301215692',
+				category: '哲学宗教-东方哲学',
+				publisher: '北京大学出版社',
+				intro: '《中国哲学简史》打通古今中外的相关知识，以宏观开阔的视野对中国哲学进行了深入浅出的、融会贯通的讲解。',
+				lastReadDate: '2022-05-20',
+				totalWords: 450000,
+				rating: '9.2',
+				readInfo: {
+					readingTime: 21720,
+					totalReadDay: 7,
+					continueReadDays: 5,
+					readingBookCount: 3,
+					readingBookDate: 1579929600,
+					finishedDate: 1580227200,
+					readingProgress: 100,
+					markedStatus: 1,
+					finishedBookCount: 12,
+					finishedBookIndex: 1
+				}
+			},
+			chapterHighlights: [
+				{
+					chapterUid: 1001,
+					chapterIdx: 1,
+					chapterTitle: '第一章 中国哲学的精神',
+					level: 1,
+					isMPChapter: 0,
+					highlights: [
+						{
+							bookmarkId: 'bookmark001',
+							created: 1580041310,
+							createTime: '2020-01-28 16:41:50',
+							chapterUid: 1001,
+							chapterIdx: 1,
+							chapterTitle: '第一章 中国哲学的精神',
+							markText:
+								'宗教也和人生有关系。每种大宗教的核心都有一种哲学。事实上，每种大宗教就是一种哲学加上一定的上层建筑。',
+							style: 0,
+							colorStyle: 1,
+							range: '0-50',
+							reviewContent: '宗教与哲学的关系很深刻'
+						},
+						{
+							bookmarkId: 'bookmark002',
+							created: 1580052228,
+							createTime: '2020-01-28 22:06:21',
+							chapterUid: 1001,
+							chapterIdx: 1,
+							chapterTitle: '第一章 中国哲学的精神',
+							markText: '知者不惑，仁者不忧，勇者不惧',
+							style: 0,
+							colorStyle: 2,
+							range: '100-150'
+						},
+						{
+							bookmarkId: 'bookmark003',
+							created: 1580048348,
+							createTime: '2020-01-28 16:52:28',
+							chapterUid: 1001,
+							chapterIdx: 1,
+							chapterTitle: '第一章 中国哲学的精神',
+							markText:
+								'入世与出世是对立的，正如现实主义与理想主义也是对立的一样。中国哲学的任务，就是把这些反命题统一成一个合命题。',
+							style: 0,
+							colorStyle: 1,
+							range: '150-200'
+						}
+					]
+				}
+			],
+			bookReview: {
+				chapterReviews: [],
+				bookReviews: [
+					{
+						reviewId: 'bookReview001',
+						created: 1580227200,
+						createTime: '2020-01-29 00:00:00',
+						content:
+							'这是一部名副其实的可以影响大众一生的文化经典。冯友兰先生以宏观开阔的视野对中国哲学进行了深入浅出的讲解，融会了史与思的智慧结晶。',
+						mdContent:
+							'## 总体评价\n\n这是一部影响深远的哲学经典著作，适合所有想要了解中国传统思想的读者。',
+						type: 3
+					}
+				]
+			}
+		};
+	}
+}

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -49,8 +49,97 @@ export class Renderer {
 			chapterHighlights,
 			bookReview
 		};
-		const template = get(settingsStore).template;
-		const content = nunjucks.renderString(template, context);
+		const settings = get(settingsStore);
+		const template = settings.template;
+		const trimBlocks = settings.trimBlocks;
+
+		// 如果启用了 trimBlocks，使用配置的环境
+		if (trimBlocks) {
+			const env = new nunjucks.Environment(null, {
+				autoescape: false,
+				trimBlocks: true,
+				lstripBlocks: true
+			});
+
+			// 添加自定义过滤器
+			env.addFilter('replace', function (str, pattern, replacement) {
+				if (!str) return '';
+
+				if (typeof pattern === 'string') {
+					try {
+						if (pattern.startsWith('/') && pattern.lastIndexOf('/') > 0) {
+							const regexBody = pattern.slice(1, pattern.lastIndexOf('/'));
+							const flags = pattern.slice(pattern.lastIndexOf('/') + 1);
+							pattern = new RegExp(regexBody, flags);
+						} else {
+							return str.replaceAll(pattern, replacement);
+						}
+					} catch (e) {
+						return String(str).replaceAll(pattern, replacement);
+					}
+				} else if (pattern instanceof RegExp) {
+					return String(str).replace(pattern, replacement);
+				}
+				return String(str).replaceAll(pattern, replacement);
+			});
+
+			const content = env.renderString(template, context);
+			return content;
+		} else {
+			// 使用默认配置（不去空白）
+			const content = nunjucks.renderString(template, context);
+			return content;
+		}
+	}
+
+	/**
+	 * Render a notebook with a custom template string (without using global settings)
+	 * @param templateStr - The template string to use for rendering
+	 * @param entry - The notebook data to render
+	 * @param trimBlocks - Whether to automatically remove newlines after template tags
+	 * @returns The rendered content
+	 */
+	renderWithTemplate(templateStr: string, entry: Notebook, trimBlocks = false): string {
+		const { metaData, chapterHighlights, bookReview } = entry;
+
+		const context: RenderTemplate = {
+			metaData,
+			chapterHighlights,
+			bookReview
+		};
+
+		// 创建临时环境以支持 trimBlocks 配置
+		const env = new nunjucks.Environment(null, {
+			autoescape: false,
+			trimBlocks: trimBlocks,
+			lstripBlocks: trimBlocks
+		});
+
+		// 添加自定义过滤器
+		env.addFilter('replace', function (str, pattern, replacement) {
+			if (!str) return '';
+
+			if (typeof pattern === 'string') {
+				try {
+					// 如果 pattern 以 /.../ 开头和结尾，解析为正则表达式
+					if (pattern.startsWith('/') && pattern.lastIndexOf('/') > 0) {
+						const regexBody = pattern.slice(1, pattern.lastIndexOf('/'));
+						const flags = pattern.slice(pattern.lastIndexOf('/') + 1);
+						pattern = new RegExp(regexBody, flags);
+					} else {
+						return str.replaceAll(pattern, replacement);
+					}
+				} catch (e) {
+					// 如果正则表达式无效，回退到字符串替换
+					return String(str).replaceAll(pattern, replacement);
+				}
+			} else if (pattern instanceof RegExp) {
+				return String(str).replace(pattern, replacement);
+			}
+			return String(str).replaceAll(pattern, replacement);
+		});
+
+		const content = env.renderString(templateStr, context);
 		return content;
 	}
 }

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -1,11 +1,11 @@
 import WereadPlugin from 'main';
-import templateInstructions from './assets/templateInstructions.html';
 import { PluginSettingTab, Setting, App, Platform } from 'obsidian';
 import { settingsStore } from './settings';
 import { get } from 'svelte/store';
 import WereadLoginModel from './components/wereadLoginModel';
 import WereadLogoutModel from './components/wereadLogoutModel';
 import CookieCloudConfigModal from './components/cookieCloudConfigModel';
+import { TemplateEditorWindow } from './components/templateEditorWindow';
 
 import pickBy from 'lodash.pickby';
 import { Renderer } from './renderer';
@@ -337,23 +337,23 @@ export class WereadSettingsTab extends PluginSettingTab {
 	}
 
 	private template(): void {
-		const descFragment = document.createRange().createContextualFragment(templateInstructions);
-
 		new Setting(this.containerEl)
-			.setName('笔记模板')
-			.setDesc(descFragment)
-			.addTextArea((text) => {
-				text.inputEl.style.width = '100%';
-				text.inputEl.style.height = '540px';
-				text.inputEl.style.fontSize = '0.8em';
-				text.setValue(get(settingsStore).template).onChange(async (value) => {
-					const isValid = this.renderer.validate(value);
-					if (isValid) {
-						settingsStore.actions.setTemplate(value);
-					}
-					text.inputEl.style.border = isValid ? '' : '2px solid red';
-				});
-				return text;
+			.setName('笔记模板设置')
+			.setHeading()
+			.addButton((button) => {
+				return button
+					.setButtonText('编辑模板')
+					.setCta()
+					.onClick(() => {
+						const editorWindow = new TemplateEditorWindow(
+							this.app,
+							get(settingsStore).template,
+							(newTemplate: string) => {
+								settingsStore.actions.setTemplate(newTemplate);
+							}
+						);
+						editorWindow.open();
+					});
 			});
 	}
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -27,6 +27,7 @@ interface WereadPluginSettings {
 	convertTags: boolean;
 	saveArticleToggle: boolean;
 	saveReadingInfoToggle: boolean;
+	trimBlocks: boolean;
 	cookieCloudInfo: {
 		serverUrl: string;
 		uuid: string;
@@ -58,6 +59,7 @@ const DEFAULT_SETTINGS: WereadPluginSettings = {
 	convertTags: false,
 	saveArticleToggle: true,
 	saveReadingInfoToggle: true,
+	trimBlocks: false,
 	cookieCloudInfo: {
 		serverUrl: '',
 		uuid: '',
@@ -272,6 +274,13 @@ const createSettingsStore = () => {
 		});
 	};
 
+	const setTrimBlocks = (trimBlocks: boolean) => {
+		store.update((state) => {
+			state.trimBlocks = trimBlocks;
+			return state;
+		});
+	};
+
 	return {
 		subscribe: store.subscribe,
 		initialise,
@@ -296,7 +305,8 @@ const createSettingsStore = () => {
 			setConvertTags,
 			setSaveArticleToggle,
 			setSaveReadingInfoToggle,
-			setCookieCloudInfo
+			setCookieCloudInfo,
+			setTrimBlocks
 		}
 	};
 };

--- a/style.css
+++ b/style.css
@@ -9,3 +9,593 @@
 	border: none;
 	background-clip: content-box;
 }
+
+/* Template Editor Modal Styles */
+.weread-template-editor-modal {
+	width: 95vw;
+	height: 90vh;
+	max-width: none;
+	max-height: none;
+}
+
+.weread-template-editor-modal .modal-content {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	padding: 0;
+}
+
+.weread-editor-titlebar {
+	padding: 12px 20px;
+	border-bottom: 1px solid var(--background-modifier-border);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	background-color: var(--background-secondary);
+}
+
+.weread-editor-titlebar h2 {
+	margin: 0;
+	font-size: 1.3em;
+	font-weight: 600;
+	flex: 1;
+}
+
+.weread-editor-buttons {
+	display: flex;
+	gap: 8px;
+}
+
+.weread-editor-container {
+	display: flex;
+	flex: 1;
+	overflow: hidden;
+	height: 100%;
+}
+
+/* 左侧：说明文档面板 */
+.weread-editor-instructions {
+	width: 300px;
+	min-width: 250px;
+	flex-shrink: 0;
+	background-color: var(--background-secondary);
+	border-right: 1px solid var(--background-modifier-border);
+	overflow-y: auto;
+	padding: 20px;
+}
+
+.weread-editor-instructions h2 {
+	font-size: 1.2em;
+	margin-bottom: 16px;
+	color: var(--text-normal);
+}
+
+.weread-editor-instructions h3 {
+	font-size: 1em;
+	margin-top: 16px;
+	margin-bottom: 8px;
+	color: var(--text-normal);
+}
+
+.weread-editor-instructions p,
+.weread-editor-instructions ul,
+.weread-editor-instructions ol {
+	font-size: 0.9em;
+	line-height: 1.6;
+	margin-bottom: 12px;
+	color: var(--text-muted);
+}
+
+.weread-editor-instructions code {
+	background-color: var(--background-primary-alt);
+	padding: 2px 6px;
+	border-radius: 3px;
+	font-family: var(--font-monospace);
+	font-size: 0.9em;
+	color: var(--text-accent);
+}
+
+.weread-editor-instructions ul,
+.weread-editor-instructions ol {
+	padding-left: 20px;
+}
+
+/* 中间：编辑器面板 */
+.weread-editor-panel {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	background-color: var(--background-primary);
+	border-right: 1px solid var(--background-modifier-border);
+	min-width: 0;
+}
+
+.weread-editor-panel .panel-header {
+	padding: 10px 16px;
+	background-color: var(--background-secondary);
+	border-bottom: 1px solid var(--background-modifier-border);
+	font-size: 0.9em;
+	font-weight: 500;
+	color: var(--text-normal);
+}
+
+.weread-editor-textarea {
+	flex: 1;
+	width: 100%;
+	padding: 16px;
+	border: none;
+	resize: none;
+	font-family: var(--font-monospace);
+	font-size: 13px;
+	line-height: 1.6;
+	background-color: var(--background-primary);
+	color: var(--text-normal);
+	outline: none;
+}
+
+.weread-editor-textarea:focus {
+	outline: none;
+}
+
+/* 右侧：预览面板 */
+.weread-editor-preview {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	background-color: var(--background-primary);
+	min-width: 0;
+}
+
+.weread-editor-preview .panel-header {
+	padding: 10px 16px;
+	background-color: var(--background-secondary);
+	border-bottom: 1px solid var(--background-modifier-border);
+	font-size: 0.9em;
+	font-weight: 500;
+	color: var(--text-normal);
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
+
+/* Toggle 开关容器 */
+.weread-toggle-container {
+	display: flex;
+	gap: 16px;
+	align-items: center;
+}
+
+.weread-toggle-wrapper {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.weread-toggle-label {
+	font-size: 0.85em;
+	color: var(--text-normal);
+	white-space: nowrap;
+}
+
+/* Toggle 开关样式 */
+.weread-toggle-switch {
+	position: relative;
+	width: 40px;
+	height: 20px;
+	background-color: var(--background-modifier-border);
+	border-radius: 10px;
+	cursor: pointer;
+	transition: background-color 0.3s;
+}
+
+.weread-toggle-switch::after {
+	content: '';
+	position: absolute;
+	top: 2px;
+	left: 2px;
+	width: 16px;
+	height: 16px;
+	background-color: white;
+	border-radius: 50%;
+	transition: transform 0.3s;
+}
+
+.weread-toggle-switch.is-enabled {
+	background-color: var(--interactive-accent);
+}
+
+.weread-toggle-switch.is-enabled::after {
+	transform: translateX(20px);
+}
+
+.weread-toggle-switch:hover {
+	opacity: 0.8;
+}
+
+.weread-editor-preview .preview-content {
+	flex: 1;
+	overflow-y: auto;
+	padding: 16px;
+}
+
+.weread-editor-preview .preview-text {
+	color: var(--text-normal);
+	margin: 0;
+}
+
+.weread-editor-preview .preview-text.preview-source-mode pre {
+	font-family: var(--font-monospace);
+	font-size: 13px;
+	line-height: 1.6;
+	white-space: pre-wrap;
+	word-wrap: break-word;
+	margin: 0;
+	padding: 0;
+}
+
+.weread-editor-preview .preview-text.markdown-preview-view {
+	font-family: var(--font-text);
+	font-size: var(--font-text-size);
+	line-height: var(--line-height-normal);
+	padding: 0;
+}
+
+.weread-editor-preview .markdown-preview-view h1,
+.weread-editor-preview .markdown-preview-view h2,
+.weread-editor-preview .markdown-preview-view h3,
+.weread-editor-preview .markdown-preview-view h4,
+.weread-editor-preview .markdown-preview-view h5,
+.weread-editor-preview .markdown-preview-view h6 {
+	font-weight: var(--font-bold);
+	line-height: var(--line-height-tight);
+	margin-top: 1em;
+	margin-bottom: 0.5em;
+}
+
+.weread-editor-preview .markdown-preview-view p {
+	margin-bottom: 1em;
+}
+
+.weread-editor-preview .markdown-preview-view ul,
+.weread-editor-preview .markdown-preview-view ol {
+	padding-left: 2em;
+	margin-bottom: 1em;
+}
+
+.weread-editor-preview .markdown-preview-view code {
+	font-family: var(--font-monospace);
+	background-color: var(--code-background);
+	padding: 0.2em 0.4em;
+	border-radius: 3px;
+}
+
+.weread-editor-preview .markdown-preview-view pre {
+	background-color: var(--code-background);
+	padding: 1em;
+	border-radius: 5px;
+	overflow-x: auto;
+}
+
+.weread-editor-preview .markdown-preview-view blockquote {
+	border-left: 3px solid var(--background-modifier-border);
+	padding-left: 1em;
+	margin-left: 0;
+	color: var(--text-muted);
+}
+
+.weread-editor-preview .error-message {
+	color: #ffffff;
+	background-color: #c73e1d;
+	border: 1px solid #a02f18;
+	padding: 16px;
+	text-align: center;
+	border-radius: 6px;
+	margin: 8px 0;
+	display: none;
+	font-weight: 500;
+	font-size: 0.95em;
+	line-height: 1.5;
+}
+
+/* Template Preview Modal Styles */
+.weread-template-preview-modal {
+	width: 95vw;
+	height: 90vh;
+	max-width: none;
+	max-height: none;
+}
+
+/* 模态窗口需要绝对定位以支持拖动 */
+.modal.weread-template-preview-modal {
+	position: fixed !important;
+}
+
+.weread-template-preview-modal .modal-content {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+}
+
+.weread-modal-title {
+	padding: 12px 20px;
+	border-bottom: 1px solid var(--background-modifier-border);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	user-select: none;
+	background-color: var(--background-secondary);
+}
+
+.weread-modal-title:active {
+	cursor: move;
+}
+
+.weread-modal-title-text {
+	margin: 0;
+	font-size: 1.3em;
+	font-weight: 600;
+	flex: 1;
+}
+
+.weread-modal-controls {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+}
+
+.weread-modal-control-btn {
+	width: 28px;
+	height: 28px;
+	padding: 0;
+	border: none;
+	border-radius: 4px;
+	background-color: transparent;
+	color: var(--text-muted);
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 14px;
+	transition: all 0.2s ease;
+}
+
+.weread-modal-control-btn:hover {
+	background-color: var(--background-modifier-hover);
+	color: var(--text-normal);
+}
+
+.weread-template-container {
+	display: flex;
+	flex: 1;
+	gap: 10px;
+	padding: 10px;
+	overflow: hidden;
+}
+
+.weread-editor-panel,
+.weread-preview-panel {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 8px;
+	overflow: hidden;
+	background-color: var(--background-primary);
+}
+
+.weread-panel-header {
+	padding: 12px 16px;
+	background-color: var(--background-secondary);
+	border-bottom: 1px solid var(--background-modifier-border);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.weread-panel-header h3 {
+	margin: 0;
+	font-size: 1.1em;
+	font-weight: 500;
+	color: var(--text-normal);
+}
+
+.weread-panel-subtitle {
+	font-size: 0.85em;
+	color: var(--text-muted);
+	margin-left: 10px;
+}
+
+.weread-template-editor {
+	flex: 1;
+	width: 100%;
+	padding: 16px;
+	border: none;
+	resize: none;
+	font-family: var(--font-monospace);
+	font-size: 0.9em;
+	line-height: 1.6;
+	background-color: var(--background-primary);
+	color: var(--text-normal);
+	outline: none;
+}
+
+.weread-template-editor:focus {
+	outline: none;
+}
+
+.weread-preview-content {
+	flex: 1;
+	overflow-y: auto;
+	padding: 16px;
+	background-color: var(--background-primary);
+}
+
+.weread-preview-text {
+	margin: 0;
+	padding: 0;
+	font-family: var(--font-monospace);
+	font-size: 0.85em;
+	line-height: 1.6;
+	white-space: pre-wrap;
+	word-wrap: break-word;
+	color: var(--text-normal);
+}
+
+.weread-preview-error {
+	padding: 20px;
+	text-align: center;
+	color: var(--text-error);
+}
+
+.weread-preview-error span {
+	font-size: 1.2em;
+	font-weight: 600;
+	display: block;
+	margin-bottom: 10px;
+}
+
+.weread-preview-error p {
+	margin: 5px 0;
+	font-size: 0.9em;
+	color: var(--text-muted);
+}
+
+.weread-modal-footer {
+	display: flex;
+	justify-content: flex-end;
+	gap: 10px;
+	padding: 16px 20px;
+	border-top: 1px solid var(--background-modifier-border);
+}
+
+.weread-modal-footer button {
+	padding: 8px 20px;
+	border-radius: 5px;
+	font-size: 0.95em;
+	cursor: pointer;
+	border: 1px solid var(--background-modifier-border);
+	background-color: var(--background-primary);
+	color: var(--text-normal);
+	transition: all 0.2s ease;
+}
+
+.weread-modal-footer button:hover {
+	background-color: var(--background-modifier-hover);
+}
+
+.weread-modal-footer button.mod-cta {
+	background-color: var(--interactive-accent);
+	color: var(--text-on-accent);
+	border-color: var(--interactive-accent);
+}
+
+.weread-modal-footer button.mod-cta:hover {
+	background-color: var(--interactive-accent-hover);
+	border-color: var(--interactive-accent-hover);
+}
+
+/* Scrollbar styles */
+.weread-preview-content::-webkit-scrollbar,
+.weread-template-editor::-webkit-scrollbar {
+	width: 8px;
+}
+
+.weread-preview-content::-webkit-scrollbar-track,
+.weread-template-editor::-webkit-scrollbar-track {
+	background: var(--background-secondary);
+}
+
+.weread-preview-content::-webkit-scrollbar-thumb,
+.weread-template-editor::-webkit-scrollbar-thumb {
+	background: var(--background-modifier-border);
+	border-radius: 4px;
+}
+
+.weread-preview-content::-webkit-scrollbar-thumb:hover,
+.weread-template-editor::-webkit-scrollbar-thumb:hover {
+	background: var(--text-muted);
+}
+
+/* Resize handles */
+.weread-resize-handle {
+	position: absolute;
+	z-index: 10;
+}
+
+.weread-resize-n,
+.weread-resize-s {
+	left: 0;
+	right: 0;
+	height: 8px;
+}
+
+.weread-resize-n {
+	top: 0;
+	cursor: ns-resize;
+}
+
+.weread-resize-s {
+	bottom: 0;
+	cursor: ns-resize;
+}
+
+.weread-resize-e,
+.weread-resize-w {
+	top: 0;
+	bottom: 0;
+	width: 8px;
+}
+
+.weread-resize-e {
+	right: 0;
+	cursor: ew-resize;
+}
+
+.weread-resize-w {
+	left: 0;
+	cursor: ew-resize;
+}
+
+.weread-resize-ne,
+.weread-resize-nw,
+.weread-resize-se,
+.weread-resize-sw {
+	width: 16px;
+	height: 16px;
+}
+
+.weread-resize-ne {
+	top: 0;
+	right: 0;
+	cursor: nesw-resize;
+}
+
+.weread-resize-nw {
+	top: 0;
+	left: 0;
+	cursor: nwse-resize;
+}
+
+.weread-resize-se {
+	bottom: 0;
+	right: 0;
+	cursor: nwse-resize;
+}
+
+.weread-resize-sw {
+	bottom: 0;
+	left: 0;
+	cursor: nesw-resize;
+}
+
+/* 悬停时显示调整大小手柄 */
+.weread-resize-handle:hover {
+	background-color: var(--interactive-accent);
+	opacity: 0.3;
+}
+
+/* 防止窗口调整大小时选中文本 */
+.weread-template-preview-modal.is-resizing,
+.weread-template-preview-modal.is-dragging {
+	user-select: none;
+}


### PR DESCRIPTION
## ✨ 新功能

### 1. 模板编辑器实时预览
- **实时渲染**：在模板编辑器中实时渲染预览（300ms 防抖）
- **双模式预览**：
  - **Markdown 渲染模式**：使用 Obsidian 的 Markdown 渲染器展示格式化内容
  - **源码模式**：显示原始渲染文本，便于调试
- **即时反馈**：模板语法错误时实时显示红色错误提示

### 2. trimBlocks 自动去空白开关
- 新增 **✂️ 自动去空白** 功能开关
- 启用后自动移除 Nunjucks 模板标签（`{% %}`）前后的换行和空格
- 生成更干净、缩进更清晰的 Markdown 代码
- 设置项自动保存到插件配置

### 3. 增强的模板编辑界面
- **三栏布局**：
  - 左侧：Nunjucks 模板语法说明（可滚动）
  - 中间：代码编辑器（支持代码高亮、多行编辑）
  - 右侧：实时预览面板
- **改进的 UX**：
  - 清晰的面板标题和功能说明
  - 平滑的样式过渡和交互反馈
  - 深色主题完全适配

---

## 🐛 Bug 修复

- 修复设置页面中模板编辑 textarea 编辑体验不佳的问题
- 修复 "打开微信读书" 命令的重复 ID 导致只有一个命令生效的问题

---

## 💡 使用说明

### 编辑模板
1. 打开 Obsidian 设置 → **Weread** 插件
2. 找到 **"笔记模板设置"** 部分
3. 点击 **"编辑模板"** 按钮打开新的模板编辑器
4. 在中间面板编辑 Nunjucks 模板代码
5. 在右侧实时预览渲染效果
6. 点击 **"保存"** 按钮保存模板

### 使用新功能
- **✂️ 自动去空白**：勾选此选项后，模板标签前后的空格和换行会自动移除，生成更清晰的输出
- **📝 Markdown 渲染**：勾选此选项后预览会显示格式化的 Markdown；取消勾选显示原始文本便于调试

### 示例模板
- 左侧面板提供完整的 Nunjucks 语法说明
- 右侧预览使用《中国哲学简史》数据，包含实际的书籍元数据、高亮、书评等

---

## 📚 相关资源

- **模板文档**：[Weread Template Usage](https://github.com/zhaohongxuan/obsidian-weread-plugin/wiki/Weread-obsidian-plugin-markdown-template-usage)
- **模板编辑器详解**：`docs/template-editor-window.md`
- **Nunjucks 官方文档**：[Mozilla Nunjucks](https://mozilla.github.io/nunjucks/)