### PR TITLE
fix: sync cookies to partition on startup for TAB mode cookie sharing

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -38,6 +38,9 @@ export default class WereadPlugin extends Plugin {
 			});
 		}
 
+		// 启动时同步 Cookie 到 partition，供 webview 使用（非阻塞）
+		this.syncCookiesToPartition();
+
 		const ribbonEl = this.addRibbonIcon('book-open', '打开微信读书书架', (event) => {
 			if (event.button === 0) {
 				this.activateBookshelfView();
@@ -281,6 +284,55 @@ export default class WereadPlugin extends Plugin {
 
 		workspace.revealLeaf(leaf);
 	}
+
+	private async syncCookiesToPartition(): Promise<void> {
+		if (!Platform.isDesktopApp) {
+			return;
+		}
+		const cookies = get(settingsStore).cookies ?? [];
+		if (cookies.length === 0) {
+			return;
+		}
+
+		try {
+			const { remote } = window.require('electron');
+			const { BrowserWindow: RemoteBrowserWindow } = remote;
+			const WEREAD_PARTITION = 'persist:weread-plugin-browser';
+
+			// Create a hidden window with the same partition as webview
+			const hiddenWindow = new RemoteBrowserWindow({
+				width: 1,
+				height: 1,
+				show: false,
+				webPreferences: {
+					partition: WEREAD_PARTITION
+				}
+			});
+
+			const session = hiddenWindow.webContents.session;
+			for (const cookie of cookies) {
+				try {
+					await session.cookies.set({
+						url: 'https://weread.qq.com',
+						name: cookie.name,
+						value: cookie.value,
+						domain: '.weread.qq.com',
+						path: '/',
+						secure: true,
+						httpOnly: false
+					});
+				} catch (e) {
+					console.debug('[weread plugin] cookie set failed:', cookie.name, e);
+				}
+			}
+
+			hiddenWindow.close();
+			console.log('[weread plugin] startup cookie sync complete');
+		} catch (e) {
+			console.error('[weread plugin] startup cookie sync failed', e);
+		}
+	}
+
 	onunload() {
 		console.log('unloading weread plugin', new Date().toLocaleString());
 		this.clearCookieRefreshTimer();

--- a/src/components/wereadBrowserWindow.ts
+++ b/src/components/wereadBrowserWindow.ts
@@ -50,5 +50,8 @@ export default class WereadBrowserWindow {
 				console.debug('[weread plugin] sync window cookie failed', cookie.name, error);
 			}
 		}
+
+		// Force persist cookies to disk before loading URL
+		await session.cookies.flush();
 	}
 }

--- a/src/components/wereadReading.ts
+++ b/src/components/wereadReading.ts
@@ -3,6 +3,7 @@ import WereadPlugin from '../../main';
 
 export const WEREAD_BROWSER_VIEW_ID = 'weread-reading-view';
 const WEREAD_HOME_URL = 'https://weread.qq.com/web/shelf';
+const WEREAD_PARTITION = 'persist:weread-plugin-browser';
 
 type WereadViewState = {
 	url?: string;
@@ -36,6 +37,7 @@ export class WereadReadingView extends ItemView {
 
 	async onOpen() {
 		this.webviewEl = this.contentEl.doc.createElement('webview');
+		this.webviewEl.setAttribute('partition', WEREAD_PARTITION);
 		this.webviewEl.setAttribute('allowpopups', '');
 		this.webviewEl.addClass('weread-frame');
 		this.webviewEl.addEventListener('did-finish-load', () => {

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -223,7 +223,7 @@ export class WereadSettingsTab extends PluginSettingTab {
 		new Setting(this.containerEl)
 			.setName('网页版打开方式')
 			.setDesc(
-				'控制书架中的“进入网页版”和详情页中的“打开网页版详情”默认在新标签页还是新窗口打开'
+				'控制书架中的”进入网页版”和详情页中的”打开网页版详情”默认在新标签页还是新窗口打开'
 			)
 			.addDropdown((dropdown) => {
 				return dropdown


### PR DESCRIPTION
Problem: TAB mode (WereadReadingView) could not share cookies with WINDOW mode (WereadBrowserWindow) on first load because webview's getWebContents() is not available in Obsidian's renderer.

Solution:
- Add syncCookiesToPartition() method in main.ts that runs on plugin load (non-blocking) to sync cookies from settingsStore to the 'persist:weread-plugin-browser' partition using a hidden BrowserWindow
- WereadReadingView now uses the same partition, allowing it to access the cookies synced on startup
- wereadBrowserWindow also flushes cookies after sync for reliability