### PR TITLE
feat: 同步日志功能 + 书架设置优化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ All commands are from `package.json`.
 - Clean build artifacts: `npm run clean`
 - Lint (auto-fix): `npm run lint`
 - Build (type check + lint + webpack): `npm run build`
-- Dev build + sync helper: `npm run dev`
+- Dev build + sync helper: `npm run deploy`
 
 Tests:
 - No test runner is configured in this repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Obsidian community plugin for syncing WeRead (微信读书) data — book metadata, highlights, notes, and reviews — into Markdown files. Sync is overwrite-based; do not edit synced notes in place.
+
+## Build Commands
+
+```bash
+npm install          # Install dependencies
+npm run clean        # Remove dist/ and main.js
+npm run lint         # ESLint with auto-fix
+npm run build        # svelte-check + lint + webpack
+npm run deploy       # Dev build + sync helper script
+```
+
+## Architecture
+
+**Entry point**: `main.ts` — plugin registration and command setup
+
+**Core flow**: `src/api.ts` → `src/parser/parseResponse.ts` → `src/renderer.ts` → `src/syncNotebooks.ts` → file output
+
+- `src/api.ts` — WeRead API requests, cookie refresh, error handling
+- `src/parser/parseResponse.ts` — API response parsing and data transforms
+- `src/renderer.ts` — Nunjucks template rendering to Markdown
+- `src/syncNotebooks.ts` — sync orchestration and notebook saving
+- `src/settings.ts` — settings store and persistence (Svelte)
+- `src/settingTab.ts` — settings UI
+
+**Templates**: Nunjucks templates in `src/assets/*.njk` — `notebookTemplate.njk` for highlights/notes, `wereadOfficialTemplate.njk` for book metadata.
+
+**Utilities**:
+- `src/utils/cookiesUtil.ts` — cookie management
+- `src/utils/frontmatter.ts` — YAML frontmatter generation
+- `src/utils/fileUtils.ts` — file operations
+
+**Settings pattern**: When adding settings, update both `src/settings.ts` (store/defaults) and `src/settingTab.ts` (UI).
+
+## Key Patterns
+
+- **Cookie handling**: `src/cookieCloud.ts` + `src/utils/cookiesUtil.ts` — automatic refresh on expiry
+- **Overwrite sync**: Notes are regenerated on sync; use block references for annotations
+- **Type definitions**: Shared interfaces in `src/models.ts`
+- **Svelte stores**: Settings use Svelte reactive stores; UI updates in `settingTab.ts`
+
+## WeRead API
+
+External API integration documented in `docs/weread-api.md`. Cookie-based auth with automatic refresh.
+
+## Tooling
+
+- TypeScript with `noImplicitAny: true`
+- ESLint + Prettier (single quotes, semicolons, print width 100)
+- Webpack bundling with `ts-loader`

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-weread-plugin",
 	"name": "Weread",
-		"version": "1.2.0",
+		"version": "1.3.0",
 	"minAppVersion": "0.12.0",
 	"description": "This is obsidian plugin for Tencent weread.",
 	"author": "hankzhao",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-weread-plugin",
-		"version": "1.2.0",
+		"version": "1.3.0",
 	"description": "This is a community plugin for tencent weread (https://r.qq.com)",
 	"main": "main.ts",
 	"scripts": {
 		"clean": "rimraf dist main.js",
 		"build": "svelte-check && npm run lint && webpack",
-		"dev": "NODE_ENV=development webpack && ./sync.sh",
+		"deploy": "NODE_ENV=development webpack && ./sync.sh",
 		"lint": "eslint . --ext .ts --fix"
 	},
 	"keywords": [],

--- a/src/components/syncLogModal.ts
+++ b/src/components/syncLogModal.ts
@@ -66,7 +66,7 @@ export class SyncLogModal extends Modal {
 		const status = header.createDiv({
 			cls: log.success ? 'sync-log-status sync-log-success' : 'sync-log-status sync-log-error'
 		});
-		status.setIcon(log.success ? 'check-circle' : 'x-circle');
+		setIcon(status, log.success ? 'check-circle' : 'x-circle');
 		status.createSpan({ text: log.success ? '成功' : '失败' });
 
 		// Stats row

--- a/src/components/wereadBookshelf.ts
+++ b/src/components/wereadBookshelf.ts
@@ -45,7 +45,7 @@ export class WereadBookshelfView extends ItemView {
 	private syncStatusFilter: SyncStatusFilter = DEFAULT_SYNC_STATUS_FILTER;
 	private readingStatusFilter: ReadingStatusFilter = 'all';
 	private sortMode: BookshelfSort = 'recent';
-	private groupByYear = false;
+	private groupByYear = true;
 	private loading = false;
 	private emptyStateEl: HTMLElement;
 	private summaryEl: HTMLElement;
@@ -147,40 +147,6 @@ export class WereadBookshelfView extends ItemView {
 			this.renderBooks();
 		};
 
-		const sortSelect = toolbarFilters.createEl('select', {
-			cls: 'dropdown',
-			attr: { 'aria-label': '选择书架排序方式' }
-		});
-		[
-			['recent', '时间排序'],
-			['title', '按标题排序']
-		].forEach(([value, label]) => {
-			sortSelect.createEl('option', { value, text: label });
-		});
-		const groupToggleWrapper = toolbarFilters.createEl('label', {
-			cls: 'weread-bookshelf-toggle'
-		});
-		const groupToggle = groupToggleWrapper.createEl('input', {
-			type: 'checkbox',
-			attr: { 'aria-label': '按阅读年份分组' }
-		});
-		groupToggle.checked = true;
-		this.groupByYear = true;
-		groupToggleWrapper.createSpan({ cls: 'toggle-slider' });
-		groupToggleWrapper.createSpan({ text: '按年份分组', cls: 'toggle-text' });
-		groupToggle.onchange = () => {
-			this.groupByYear = groupToggle.checked;
-			this.renderBooks();
-		};
-		sortSelect.onchange = () => {
-			this.sortMode = sortSelect.value as BookshelfSort;
-			groupToggle.disabled = this.sortMode !== 'recent';
-			groupToggleWrapper.toggleClass('is-disabled', groupToggle.disabled);
-			this.renderBooks();
-		};
-		groupToggle.disabled = this.sortMode !== 'recent';
-		groupToggleWrapper.toggleClass('is-disabled', groupToggle.disabled);
-
 		const toolbarActions = toolbar.createDiv({ cls: 'weread-bookshelf-toolbar-actions' });
 		const syncButton = toolbarActions.createEl('button', {
 			cls: 'mod-cta weread-toolbar-button'
@@ -251,6 +217,9 @@ export class WereadBookshelfView extends ItemView {
 		this.gridEl.empty();
 		try {
 			this.shelfBooks = await this.bookshelfService.getBookshelfBooks();
+			const settings = get(settingsStore);
+			this.sortMode = settings.bookshelfSortMode;
+			this.groupByYear = settings.bookshelfGroupByYear;
 			this.renderBooks();
 		} catch (error: unknown) {
 			this.summaryEl.setText('加载书架失败');

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -24,7 +24,7 @@ import { Renderer } from './renderer';
 import ApiManager from './api';
 import { parseBookIdList } from './utils/bookIdUtils';
 import { formatTimestampToDate } from './utils/dateUtil';
-import type { ReadingOpenMode, SyncMode } from './settings';
+import type { ReadingOpenMode, SyncMode, BookshelfSortMode } from './settings';
 
 const UNLIMITED_NOTE_COUNT = -1;
 
@@ -100,6 +100,7 @@ export class WereadSettingsTab extends PluginSettingTab {
 
 		this.notebookFolder();
 		this.readingOpenModeSetting();
+		this.bookshelfSettings();
 		this.syncModeSettings();
 		this.scheduledSync();
 
@@ -235,6 +236,34 @@ export class WereadSettingsTab extends PluginSettingTab {
 					.setValue(get(settingsStore).readingOpenMode)
 					.onChange((value: string) => {
 						settingsStore.actions.setReadingOpenMode(value as ReadingOpenMode);
+					});
+			});
+	}
+
+	private bookshelfSettings(): void {
+		new Setting(this.containerEl).setName('书架设置').setHeading();
+
+		new Setting(this.containerEl)
+			.setName('书架排序方式')
+			.setDesc('控制书架中书籍的默认排序方式')
+			.addDropdown((dropdown) => {
+				return dropdown
+					.addOption('recent', '时间排序')
+					.addOption('title', '按标题排序')
+					.setValue(get(settingsStore).bookshelfSortMode)
+					.onChange((value: string) => {
+						settingsStore.actions.setBookshelfSortMode(value as BookshelfSortMode);
+					});
+			});
+
+		new Setting(this.containerEl)
+			.setName('按年份分组')
+			.setDesc('在时间排序时，按照阅读年份对书架进行分组展示')
+			.addToggle((toggle) => {
+				return toggle
+					.setValue(get(settingsStore).bookshelfGroupByYear)
+					.onChange((value) => {
+						settingsStore.actions.setBookshelfGroupByYear(value);
 					});
 			});
 	}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,5 @@
 import { Cookie } from 'set-cookie-parser';
-import { writable } from 'svelte/store';
+import { writable, get } from 'svelte/store';
 import { Platform } from 'obsidian';
 import notebookTemolate from './assets/notebookTemplate.njk';
 import WereadPlugin from '../main';
@@ -7,6 +7,7 @@ import type { SyncLogEntry } from './models';
 
 export type SyncMode = 'blacklist' | 'whitelist';
 export type ReadingOpenMode = 'TAB' | 'WINDOW';
+export type BookshelfSortMode = 'recent' | 'title';
 
 type LegacyWereadPluginSettings = Partial<WereadPluginSettings> & {
 	manualSyncMode?: boolean;
@@ -54,6 +55,8 @@ export interface WereadPluginSettings {
 	lastSyncBookCount: number;
 	lastSyncBookTitles: string[];
 	syncLogs: SyncLogEntry[];
+	bookshelfSortMode: BookshelfSortMode;
+	bookshelfGroupByYear: boolean;
 }
 
 const DEFAULT_SETTINGS: WereadPluginSettings = {
@@ -97,7 +100,9 @@ const DEFAULT_SETTINGS: WereadPluginSettings = {
 	lastSyncTime: 0,
 	lastSyncBookCount: 0,
 	lastSyncBookTitles: [],
-	syncLogs: []
+	syncLogs: [],
+	bookshelfSortMode: 'recent',
+	bookshelfGroupByYear: true
 };
 
 const createSettingsStore = () => {
@@ -457,6 +462,20 @@ const createSettingsStore = () => {
 		return get(store).syncLogs;
 	};
 
+	const setBookshelfSortMode = (sortMode: BookshelfSortMode) => {
+		store.update((state) => {
+			state.bookshelfSortMode = sortMode;
+			return state;
+		});
+	};
+
+	const setBookshelfGroupByYear = (groupByYear: boolean) => {
+		store.update((state) => {
+			state.bookshelfGroupByYear = groupByYear;
+			return state;
+		});
+	};
+
 	return {
 		subscribe: store.subscribe,
 		initialise,
@@ -495,7 +514,9 @@ const createSettingsStore = () => {
 			setScheduledSyncInterval,
 			updateLastSyncInfo,
 			addSyncLog,
-			getSyncLogs
+			getSyncLogs,
+			setBookshelfSortMode,
+			setBookshelfGroupByYear
 		}
 	};
 };

--- a/src/syncNotebooks.ts
+++ b/src/syncNotebooks.ts
@@ -273,11 +273,12 @@ export default class SyncNotebooks {
 		return null;
 	}
 
-	private async saveNotebook(notebook: Notebook): Promise<void> {
+	private async saveNotebook(notebook: Notebook): Promise<string | null> {
 		try {
-			await this.fileManager.saveNotebook(notebook);
+			return await this.fileManager.saveNotebook(notebook);
 		} catch (e) {
 			console.log('[weread plugin] sync note book error', notebook.metaData.title, e);
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- 新增**同步日志**功能：每次同步后在设置页显示最近 10 次同步记录，包含同步的书籍、耗时、成功/失败状态
- 新增**书架设置**设置组：将书架排序方式和按年份分组从书架页工具栏移至设置页
- 新增 Nunjucks **时间格式化过滤器**，方便用户在模板中将时间戳转换为可读日期格式
- 修复同步日志不显示笔记信息的问题

## 同步日志功能

- 每次同步后自动记录：同步时间、同步书籍数、跳过书籍数、耗时、同步的笔记列表
- 在设置页的"定时同步"区域底部提供"查看同步日志"按钮
- 同步日志 modal 支持点击跳转到对应笔记文件

## 书架设置

- 新增"书架设置"设置组（位于"网页版打开方式"下方）
- **书架排序方式**：时间排序 / 按标题排序
- **按年份分组**：在时间排序时按阅读年份分组展示

## 模板时间过滤器

支持 3 个 Nunjucks filter，将时间戳（秒级）转换为可读字符串：

| Filter | 说明 | 示例输出 |
|--------|------|----------|
| formatDate | 日期，默认 YYYY-MM-DD | 2020-01-29 |
| formatDateTime | 日期时间，默认 YYYY-MM-DD HH:mm:ss | 2020-01-29 08:00:00 |
| formatTime | 时间，默认 HH:mm:ss | 08:00:00 |

使用示例：
\`\`\`nunjucks
{{ metaData.readInfo.finishedDate | formatDate }}
{{ metaData.readInfo.finishedDate | formatDateTime }}
{{ metaData.readInfo.finishedDate | formatDate("YYYY年MM月DD日") }}
\`\`\`

过滤器说明已同步更新至模板编辑器左侧帮助面板。

## Test plan

- [ ] 执行一次同步后，在设置页打开同步日志，确认显示笔记信息
- [ ] 修改书架排序方式和年份分组，确认书架页面按新设置展示
- [ ] 在模板中使用 filter，确认时间戳正确转换为日期字符串