### PR TITLE
fix: parseProgressValue 对数字类型 progress 调用 trim() 导致崩溃

### DIFF
--- a/src/bookshelf.ts
+++ b/src/bookshelf.ts
@@ -176,9 +176,12 @@ export default class WereadBookshelfService {
 		};
 	}
 
-	private parseProgressValue(progress?: string): number | undefined {
-		if (!progress) {
+	private parseProgressValue(progress?: string | number): number | undefined {
+		if (progress === undefined || progress === null) {
 			return undefined;
+		}
+		if (typeof progress === 'number') {
+			return Number.isNaN(progress) ? undefined : progress;
 		}
 		const progressMatch = progress.trim().match(PROGRESS_TEXT_PATTERN);
 		if (!progressMatch) {


### PR DESCRIPTION
## 问题

书架页面打开时报错 `progress.trim is not a function`：

<img width="508" height="219" alt="Snipaste_2026-04-27_11-38-07" src="https://github.com/user-attachments/assets/310cfaf3-0250-4793-b538-cbc288b80027" />

（默认是显示 e.trim ，编译了未混淆版本后发现是 `progress` 导致的）

## 原因

`src/bookshelf.ts` 中 `parseProgressValue` 方法对 `progress` 参数调用了 `.trim()`，但该值来自 frontmatter YAML 解析。当 frontmatter 中 progress 为纯数字时，YAML 解析器返回的是 `number` 类型而非 `string`，对数字调用 `.trim()` 抛出 **TypeError**。

## 修复

- `parseProgressValue` 参数类型从 `string` 改为 `string | number`
- 当值为 `number` 时直接返回（跳过 NaN 检查）
- 仅对 `string` 类型执行 `.trim()` + `.match()` 逻辑
