### PR TITLE
feat: toolbar redesign, sync log filter, inline image filter, and theme save fix

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-weread-plugin",
 	"name": "Weread",
-		"version": "1.4.1",
+	"version": "1.4.2",
 	"minAppVersion": "0.12.0",
 	"description": "This is obsidian plugin for Tencent weread.",
 	"author": "hankzhao",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-weread-plugin",
-		"version": "1.4.1",
+	"version": "1.4.2",
 	"description": "This is a community plugin for tencent weread (https://r.qq.com)",
 	"main": "main.ts",
 	"scripts": {

--- a/src/components/syncLogModal.ts
+++ b/src/components/syncLogModal.ts
@@ -1,4 +1,4 @@
-import { App, Modal, Notice, Platform, setIcon, TFile } from 'obsidian';
+import { App, Modal, Notice, Platform, setIcon, TFile, ToggleComponent } from 'obsidian';
 import type { SyncLogEntry } from '../models';
 import { settingsStore } from '../settings';
 
@@ -7,6 +7,9 @@ const MODAL_MAX_WIDTH = '90vw';
 const MODAL_MAX_HEIGHT = '80vh';
 
 export class SyncLogModal extends Modal {
+	private showAll = false;
+	private logsContainer: HTMLElement;
+
 	constructor(app: App) {
 		super(app);
 	}
@@ -20,22 +23,51 @@ export class SyncLogModal extends Modal {
 
 		const header = contentEl.createDiv({ cls: 'sync-log-header' });
 		header.createEl('h2', { text: '同步日志' });
-		header.createDiv({ cls: 'sync-log-subtitle', text: '最近 10 次同步记录' });
 
-		const logsContainer = contentEl.createDiv({ cls: 'sync-log-container' });
+		const headerRight = header.createDiv({ cls: 'sync-log-header-right' });
+		headerRight.createSpan({ cls: 'sync-log-toggle-label', text: '显示空白记录' });
+		const toggle = new ToggleComponent(headerRight);
+		toggle.setValue(this.showAll);
+		toggle.onChange((value) => {
+			this.showAll = value;
+			this.renderLogs();
+		});
 
-		const logs = settingsStore.actions.getSyncLogs();
+		this.logsContainer = contentEl.createDiv({ cls: 'sync-log-container' });
+		this.renderLogs();
+	}
+
+	private renderLogs() {
+		this.logsContainer.empty();
+		const allLogs = settingsStore.actions.getSyncLogs();
+		const logs = this.showAll ? allLogs : allLogs.filter((log) => log.syncedBooks > 0);
+
+		const visibleCount = logs.length;
+		const totalCount = allLogs.length;
+		const subtitle = this.showAll
+			? `最近 ${totalCount} 次同步记录`
+			: `${visibleCount} 条有效记录（共 ${totalCount} 次）`;
+
+		// 更新或创建 subtitle
+		let subtitleEl = this.contentEl.querySelector('.sync-log-subtitle') as HTMLElement;
+		if (!subtitleEl) {
+			const header = this.contentEl.querySelector('.sync-log-header') as HTMLElement;
+			subtitleEl = header.createDiv({ cls: 'sync-log-subtitle' });
+			// 移到 header 末尾之前（toggle 之前）
+			header.insertBefore(subtitleEl, header.querySelector('.sync-log-header-right'));
+		}
+		subtitleEl.setText(subtitle);
 
 		if (logs.length === 0) {
-			logsContainer.createDiv({
+			this.logsContainer.createDiv({
 				cls: 'sync-log-empty',
-				text: '暂无同步记录'
+				text: this.showAll ? '暂无同步记录' : '暂无有效同步记录'
 			});
 			return;
 		}
 
 		for (const log of logs) {
-			const logItem = logsContainer.createDiv({ cls: 'sync-log-item' });
+			const logItem = this.logsContainer.createDiv({ cls: 'sync-log-item' });
 			this.renderLogEntry(logItem, log);
 		}
 	}

--- a/src/components/themeManagerModal.ts
+++ b/src/components/themeManagerModal.ts
@@ -135,8 +135,11 @@ export class ThemeManagerModal extends Modal {
 						this.app,
 						theme.template,
 						(newTemplate: string) => {
+							// 从 store 取最新的 theme，避免 trimBlocks 被快照覆盖
+							const latestTheme =
+								get(settingsStore).themes.find((t) => t.id === theme.id) ?? theme;
 							settingsStore.actions.saveTheme({
-								...theme,
+								...latestTheme,
 								template: newTemplate
 							});
 							new Notice('主题已保存');
@@ -501,8 +504,10 @@ class CreateThemeModal extends Modal {
 				this.app,
 				newTheme.template,
 				(updatedTemplate: string) => {
+					const latestTheme =
+						get(settingsStore).themes.find((t) => t.id === newTheme.id) ?? newTheme;
 					settingsStore.actions.saveTheme({
-						...newTheme,
+						...latestTheme,
 						template: updatedTemplate
 					});
 					new Notice('主题已创建');

--- a/src/components/wereadBookshelf.ts
+++ b/src/components/wereadBookshelf.ts
@@ -156,18 +156,6 @@ export class WereadBookshelfView extends ItemView {
 		});
 		setIcon(syncButton, 'sync');
 
-		const syncOptionsButton = toolbarActions.createEl('button', {
-			cls: 'clickable-icon weread-bookshelf-icon-button weread-toolbar-icon-button',
-			attr: { 'aria-label': '选项' }
-		});
-		setIcon(syncOptionsButton, 'settings');
-
-		const syncLogButton = toolbarActions.createEl('button', {
-			cls: 'clickable-icon weread-bookshelf-icon-button weread-toolbar-icon-button',
-			attr: { 'aria-label': '同步日志' }
-		});
-		setIcon(syncLogButton, 'scroll-text');
-
 		const openWebButton = Platform.isDesktopApp
 			? (() => {
 					const btn = toolbarActions.createEl('button', {
@@ -178,6 +166,19 @@ export class WereadBookshelfView extends ItemView {
 					return btn;
 			  })()
 			: null;
+
+		const syncLogButton = toolbarActions.createEl('button', {
+			cls: 'clickable-icon weread-bookshelf-icon-button weread-toolbar-icon-button',
+			attr: { 'aria-label': '同步日志' }
+		});
+		setIcon(syncLogButton, 'history');
+
+		const syncOptionsButton = toolbarActions.createEl('button', {
+			cls: 'clickable-icon weread-bookshelf-icon-button weread-toolbar-icon-button',
+			attr: { 'aria-label': '选项' }
+		});
+		setIcon(syncOptionsButton, 'settings');
+
 		syncButton.onclick = async () => {
 			syncButton.disabled = true;
 			syncOptionsButton.disabled = true;

--- a/src/components/wereadBookshelf.ts
+++ b/src/components/wereadBookshelf.ts
@@ -357,7 +357,7 @@ export class WereadBookshelfView extends ItemView {
 		if (book.remoteExists && !book.hasLocalFile) {
 			const syncButton = container.createEl('button', {
 				cls: 'clickable-icon weread-bookshelf-icon-button',
-				attr: { 'aria-label': '同步此书', title: '同步此书' }
+				attr: { 'aria-label': '同步此书' }
 			});
 			setIcon(syncButton, 'refresh-ccw');
 			syncButton.onclick = async (event) => {
@@ -375,7 +375,7 @@ export class WereadBookshelfView extends ItemView {
 		if (this.isDisplayLocalOnly(book) && book.localFile?.file?.path) {
 			const deleteButton = container.createEl('button', {
 				cls: 'clickable-icon weread-bookshelf-icon-button',
-				attr: { 'aria-label': '删除本地文件', title: '删除本地文件' }
+				attr: { 'aria-label': '删除本地文件' }
 			});
 			setIcon(deleteButton, 'trash');
 			deleteButton.onclick = async (event) => {
@@ -395,7 +395,7 @@ export class WereadBookshelfView extends ItemView {
 		if (book.remoteExists) {
 			const readButton = container.createEl('button', {
 				cls: 'clickable-icon weread-bookshelf-icon-button',
-				attr: { 'aria-label': '阅读此书', title: '阅读此书' }
+				attr: { 'aria-label': '阅读此书' }
 			});
 			setIcon(readButton, 'book-open');
 			readButton.onclick = async (event) => {

--- a/src/components/wereadBookshelf.ts
+++ b/src/components/wereadBookshelf.ts
@@ -3,6 +3,7 @@ import WereadPlugin from '../../main';
 import WereadBookshelfService from '../bookshelf';
 import type { BookshelfBook } from '../models';
 import { WereadBookDetailModal } from './wereadBookDetailModal';
+import { SyncLogModal } from './syncLogModal';
 import { settingsStore } from '../settings';
 import { get } from 'svelte/store';
 import { getPcUrl } from '../parser/parseResponse';
@@ -161,6 +162,12 @@ export class WereadBookshelfView extends ItemView {
 		});
 		setIcon(syncOptionsButton, 'settings');
 
+		const syncLogButton = toolbarActions.createEl('button', {
+			cls: 'clickable-icon weread-bookshelf-icon-button weread-toolbar-icon-button',
+			attr: { 'aria-label': '同步日志' }
+		});
+		setIcon(syncLogButton, 'scroll-text');
+
 		const openWebButton = Platform.isDesktopApp
 			? (() => {
 					const btn = toolbarActions.createEl('button', {
@@ -193,6 +200,9 @@ export class WereadBookshelfView extends ItemView {
 		};
 		syncOptionsButton.onclick = () => {
 			this.plugin.openWereadSettingsTab();
+		};
+		syncLogButton.onclick = () => {
+			new SyncLogModal(this.app).open();
 		};
 		if (openWebButton) {
 			openWebButton.onclick = async () => {

--- a/src/components/wereadBookshelf.ts
+++ b/src/components/wereadBookshelf.ts
@@ -150,24 +150,24 @@ export class WereadBookshelfView extends ItemView {
 
 		const toolbarActions = toolbar.createDiv({ cls: 'weread-bookshelf-toolbar-actions' });
 		const syncButton = toolbarActions.createEl('button', {
-			cls: 'mod-cta weread-toolbar-button'
+			cls: 'clickable-icon weread-bookshelf-icon-button weread-toolbar-icon-button mod-cta',
+			attr: { 'aria-label': '同步' }
 		});
 		setIcon(syncButton, 'sync');
-		syncButton.createSpan({ text: '同步' });
 
 		const syncOptionsButton = toolbarActions.createEl('button', {
-			cls: 'weread-toolbar-button'
+			cls: 'clickable-icon weread-bookshelf-icon-button weread-toolbar-icon-button',
+			attr: { 'aria-label': '选项' }
 		});
 		setIcon(syncOptionsButton, 'settings');
-		syncOptionsButton.createSpan({ text: '选项' });
 
 		const openWebButton = Platform.isDesktopApp
 			? (() => {
 					const btn = toolbarActions.createEl('button', {
-						cls: 'weread-toolbar-button weread-bookshelf-web-button'
+						cls: 'clickable-icon weread-bookshelf-icon-button weread-toolbar-icon-button',
+						attr: { 'aria-label': '网页版' }
 					});
 					setIcon(btn, 'globe');
-					btn.createSpan({ text: '网页版' });
 					return btn;
 			  })()
 			: null;

--- a/src/parser/parseResponse.ts
+++ b/src/parser/parseResponse.ts
@@ -68,6 +68,10 @@ export const parseHighlights = (
 			.filter((chapter) => chapter.chapterUid === highlight.chapterUid)
 			.first();
 		const intentMarkText = addIndentToParagraphs(highlight.markText);
+		const filterInlineImages = get(settingsStore).filterInlineImages;
+		const markText = filterInlineImages
+			? removeInlineImagePlaceholders(intentMarkText)
+			: intentMarkText;
 		return {
 			bookmarkId: highlight.bookmarkId?.replace(/[_~]/g, '-'),
 			created: highlight.createTime,
@@ -79,7 +83,7 @@ export const parseHighlights = (
 			style: highlight.style,
 			colorStyle: highlight.colorStyle,
 			chapterTitle: chapterInfo?.title || '未知章节',
-			markText: intentMarkText,
+			markText: markText,
 			reviewContent: addIndentToParagraphs(reviewContent)
 		};
 	});
@@ -99,6 +103,13 @@ const addIndentToParagraphs = (content: string): string => {
 
 	// 将段落数组重新组合成一个字符串
 	return paragraphs.join('\n');
+};
+
+// 移除弹注图片占位符，如 [图片]、[插图] 等
+const INLINE_IMAGE_PLACEHOLDER_RE = /\[图片\]|\[插图\]/g;
+const removeInlineImagePlaceholders = (content: string): string => {
+	if (!content) return content;
+	return content.replace(INLINE_IMAGE_PLACEHOLDER_RE, '').replace(/\n{3,}/g, '\n\n').trim();
 };
 
 export const parseArticleHighlightReview = (

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -18,7 +18,6 @@ import WereadLoginModel from './components/wereadLoginModel';
 import WereadLogoutModel from './components/wereadLogoutModel';
 import CookieCloudConfigModal from './components/cookieCloudConfigModel';
 import { ThemeManagerModal } from './components/themeManagerModal';
-import { SyncLogModal } from './components/syncLogModal';
 
 import ApiManager from './api';
 import { parseBookIdList } from './utils/bookIdUtils';
@@ -945,7 +944,6 @@ export class WereadSettingsTab extends PluginSettingTab {
 		if (get(settingsStore).scheduledSyncToggle) {
 			this.scheduledSyncInterval();
 		}
-		this.showLastSyncInfo();
 	}
 
 	private scheduledSyncInterval(): void {
@@ -966,31 +964,6 @@ export class WereadSettingsTab extends PluginSettingTab {
 			});
 	}
 
-	private showLastSyncInfo(): void {
-		const settings = get(settingsStore);
-		const { lastSyncTime, lastSyncBookCount, lastSyncBookTitles } = settings;
-
-		let statusText = '尚未执行过同步';
-		if (lastSyncTime > 0) {
-			const lastSyncStr = new Date(lastSyncTime).toLocaleString();
-			statusText = `上次同步：${lastSyncStr}，共 ${lastSyncBookCount} 本书`;
-			if (lastSyncBookTitles.length > 0) {
-				statusText += `\n最近同步：${lastSyncBookTitles.join('、')}`;
-			}
-		}
-
-		new Setting(this.containerEl).setName('同步状态').setDesc(statusText);
-
-		// Sync log button at the end of scheduled sync section
-		new Setting(this.containerEl)
-			.setName('查看同步日志')
-			.setDesc('查看最近 10 次同步的详细记录，包括同步的笔记')
-			.addButton((button) => {
-				button.setButtonText('查看日志').onClick(() => {
-					new SyncLogModal(this.app).open();
-				});
-			});
-	}
 
 	private createFolderSuggestModal(onSelect: (value: string) => void) {
 		const folders = this.getFolderPaths();

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -103,6 +103,7 @@ export class WereadSettingsTab extends PluginSettingTab {
 		new Setting(this.containerEl).setName('文件设置').setHeading();
 		this.fileNameType();
 		this.removeParens();
+		this.filterInlineImages();
 		this.subFolderType();
 
 		new Setting(this.containerEl).setName('日记设置').setHeading();
@@ -628,6 +629,19 @@ export class WereadSettingsTab extends PluginSettingTab {
 					);
 				});
 		}
+	}
+
+	private filterInlineImages(): void {
+		new Setting(this.containerEl)
+			.setName('过滤弹注图片占位符')
+			.setDesc('启用后，书摘中的 [图片]、[插图] 等弹注占位符将被自动移除，适合古诗文等配有大量弹注的书籍')
+			.addToggle((toggle) => {
+				return toggle
+					.setValue(get(settingsStore).filterInlineImages)
+					.onChange((value) => {
+						settingsStore.actions.setFilterInlineImages(value);
+					});
+			});
 	}
 
 	private showLogout(): void {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -68,6 +68,7 @@ export interface WereadPluginSettings {
 	fileNameType: string;
 	removeParens: boolean;
 	removeParensWhitelist: string;
+	filterInlineImages: boolean;
 	dailyNotesToggle: boolean;
 	notesBlacklist: string;
 	notesWhitelist: string;
@@ -117,6 +118,7 @@ const DEFAULT_SETTINGS: WereadPluginSettings = {
 	fileNameType: 'BOOK_NAME',
 	removeParens: false,
 	removeParensWhitelist: '',
+	filterInlineImages: false,
 	dailyNotesToggle: false,
 	notesBlacklist: '',
 	notesWhitelist: '',
@@ -453,6 +455,13 @@ const createSettingsStore = () => {
 		});
 	};
 
+	const setFilterInlineImages = (filterInlineImages: boolean) => {
+		store.update((state) => {
+			state.filterInlineImages = filterInlineImages;
+			return state;
+		});
+	};
+
 	const setRemoveParensWhitelist = (whitelist: string) => {
 		store.update((state) => {
 			state.removeParensWhitelist = whitelist;
@@ -707,6 +716,7 @@ const createSettingsStore = () => {
 			setFileNameType,
 			setRemoveParens,
 			setRemoveParensWhitelist,
+			setFilterInlineImages,
 			setDailyNotesToggle,
 			setDailyNotesFolder,
 			setDailyNotesFormat,

--- a/style.css
+++ b/style.css
@@ -1413,14 +1413,33 @@
 .sync-log-header {
 	padding: 20px;
 	border-bottom: 1px solid var(--background-modifier-border);
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 4px;
 }
 
 .sync-log-header h2 {
-	margin: 0 0 4px 0;
+	margin: 0;
 	font-size: 1.3em;
+	flex: 1 1 auto;
+}
+
+.sync-log-header-right {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-shrink: 0;
+}
+
+.sync-log-toggle-label {
+	font-size: 0.85em;
+	color: var(--text-muted);
 }
 
 .sync-log-subtitle {
+	width: 100%;
+
 	color: var(--text-muted);
 	font-size: 0.9em;
 }

--- a/style.css
+++ b/style.css
@@ -1323,31 +1323,21 @@
 	margin: -4px 0 12px;
 }
 
-.weread-toolbar-button {
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	padding: 6px 12px;
-	font-size: 13px;
-	border-radius: 4px;
-	cursor: pointer;
-	transition: all 0.2s ease;
+.weread-toolbar-icon-button {
+	width: 32px;
+	height: 32px;
 }
 
-.weread-toolbar-button .svg-icon {
-	width: 18px;
-	height: 18px;
-}
-
-.weread-bookshelf-web-button {
-	background-color: rgba(var(--interactive-accent), 0.1);
-	border: 1px solid rgba(var(--interactive-accent), 0.3);
-	color: var(--interactive-accent);
-}
-
-.weread-bookshelf-web-button:hover {
-	background-color: rgba(var(--interactive-accent), 0.15);
+.weread-toolbar-icon-button.mod-cta {
+	background: var(--interactive-accent);
 	border-color: var(--interactive-accent);
+	color: var(--text-on-accent);
+}
+
+.weread-toolbar-icon-button.mod-cta:hover {
+	background: var(--interactive-accent-hover);
+	border-color: var(--interactive-accent-hover);
+	color: var(--text-on-accent);
 }
 
 .weread-book-detail-badge {


### PR DESCRIPTION
## Summary

### UI / Toolbar
- Replace toolbar text buttons (同步/选项/网页版) with round icon-only buttons, matching the bookshelf icon style
- Add sync log button (history icon) to toolbar; reorder: 同步 | 网页版 | 同步日志 | 选项
- Fix duplicate tooltip on bookshelf icon buttons (`title` + `aria-label` both set — removed `title`)

### Sync Log
- Add toggle in `SyncLogModal` to filter empty syncs (default: show only syncs with `syncedBooks > 0`)
- Remove sync status display and sync log entry from settings tab (accessible via toolbar instead)

### Highlights
- Fix [#385](https://github.com/zhaohongxuan/obsidian-weread-plugin/issues/385): add setting **过滤内联图片占位符** to strip `[图片]`/`[插图]` from highlight text (opt-in, default off)

### Theme Editor
- Fix theme save bug: `trimBlocks` toggle was live-saving with a stale theme snapshot, overwriting in-progress template edits
- Fix `onSave` to pass both `template` and `trimBlocks` together on save click instead of two separate writes
- Fix theme manager modal not refreshing after save (stale closure causing next edit to use old data)
- Show `trimBlocks` toggle in read-only preview mode (disabled state) so users can see the setting
- Format all three built-in templates with proper Nunjucks style (tags on own lines, `trimBlocks: true`)

## Test plan
- [ ] Toolbar shows icon-only round buttons; hovering shows single black tooltip (no duplicate)
- [ ] Sync log button opens modal; empty-sync toggle filters correctly
- [ ] Settings tab no longer shows sync status or sync log entry
- [ ] Enabling 过滤内联图片占位符 removes `[图片]`/`[插图]` from synced highlights
- [ ] Editing a custom theme template + toggling trimBlocks, then saving — both persist correctly after modal close/reopen
- [ ] Built-in theme preview shows trimBlocks toggle in disabled state (enabled/blue)