### PR TITLE
feat: improve sync UX with cancellation and better progress notice

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -192,7 +192,7 @@ export default class WereadPlugin extends Plugin {
 		await this.activateReadingView(this.getPreferredReadingOpenMode(), url);
 	}
 
-	async startSync(force = false): Promise<number | undefined> {
+	async startSync(force = false, signal?: { cancelled: boolean }): Promise<number | undefined> {
 		if (this.syncing) {
 			new Notice('正在同步微信读书笔记，请勿重复点击');
 			return;
@@ -201,7 +201,8 @@ export default class WereadPlugin extends Plugin {
 		try {
 			const syncedCount = await this.syncNotebooks.syncNotebooks(
 				force,
-				window.moment().format('YYYY-MM-DD')
+				window.moment().format('YYYY-MM-DD'),
+				signal
 			);
 			// 更新最近同步信息
 			const settings = get(settingsStore);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-weread-plugin",
 	"name": "Weread",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"minAppVersion": "0.12.0",
 	"description": "This is obsidian plugin for Tencent weread.",
 	"author": "hankzhao",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-weread-plugin",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"description": "This is a community plugin for tencent weread (https://r.qq.com)",
 	"main": "main.ts",
 	"scripts": {

--- a/src/components/wereadBookshelf.ts
+++ b/src/components/wereadBookshelf.ts
@@ -1,4 +1,4 @@
-import { App, ItemView, Modal, Notice, Platform, WorkspaceLeaf, moment, setIcon } from 'obsidian';
+import { App, ItemView, Modal, Notice, Platform, WorkspaceLeaf, moment, setIcon, setTooltip } from 'obsidian';
 import WereadPlugin from '../../main';
 import WereadBookshelfService from '../bookshelf';
 import type { BookshelfBook } from '../models';
@@ -151,10 +151,51 @@ export class WereadBookshelfView extends ItemView {
 
 		const toolbarActions = toolbar.createDiv({ cls: 'weread-bookshelf-toolbar-actions' });
 		const syncButton = toolbarActions.createEl('button', {
-			cls: 'clickable-icon weread-bookshelf-icon-button weread-toolbar-icon-button mod-cta',
-			attr: { 'aria-label': '同步' }
+			cls: 'clickable-icon weread-bookshelf-icon-button weread-toolbar-icon-button mod-cta'
 		});
-		setIcon(syncButton, 'sync');
+		setIcon(syncButton, 'refresh-ccw');
+
+		// 根据 Alt/Opt 状态切换按钮外观
+		let isHovering = false;
+		let isAltPressed = false;
+		let isSyncing = false;
+		const modKey = Platform.isMacOS ? 'Opt' : 'Alt';
+		const updateSyncButton = (force: boolean) => {
+			if (isSyncing) return;
+			if (force) {
+				setIcon(syncButton, 'refresh-ccw-dot');
+				syncButton.addClass('mod-warning');
+				syncButton.removeClass('mod-cta');
+				setTooltip(syncButton, '强制同步（重新同步所有书籍）');
+			} else {
+				setIcon(syncButton, 'refresh-ccw');
+				syncButton.addClass('mod-cta');
+				syncButton.removeClass('mod-warning');
+				setTooltip(syncButton, `同步 (按住 ${modKey} 强制同步)`);
+			}
+		};
+		setTooltip(syncButton, `同步 (按住 ${modKey} 强制同步)`);
+		syncButton.addEventListener('mouseenter', () => {
+			isHovering = true;
+			updateSyncButton(isAltPressed);
+		});
+		syncButton.addEventListener('mouseleave', () => {
+			isHovering = false;
+			updateSyncButton(false);
+		});
+		// 用 e.code 追踪 Alt 键，比 e.key 在 macOS Electron 下更可靠
+		document.addEventListener('keydown', (e: KeyboardEvent) => {
+			if (e.code === 'AltLeft' || e.code === 'AltRight') {
+				isAltPressed = true;
+				if (isHovering) updateSyncButton(true);
+			}
+		});
+		document.addEventListener('keyup', (e: KeyboardEvent) => {
+			if (e.code === 'AltLeft' || e.code === 'AltRight') {
+				isAltPressed = false;
+				if (isHovering) updateSyncButton(false);
+			}
+		});
 
 		const openWebButton = Platform.isDesktopApp
 			? (() => {
@@ -180,23 +221,36 @@ export class WereadBookshelfView extends ItemView {
 		setIcon(syncOptionsButton, 'settings');
 
 		syncButton.onclick = async () => {
-			syncButton.disabled = true;
+			if (isSyncing) return;
+			const force = isAltPressed;
+
+			// 同步中：切换为取消按钮
+			isSyncing = true;
+			const signal = { cancelled: false };
+			setIcon(syncButton, 'square');
+			setTooltip(syncButton, '取消同步');
+			syncButton.removeClass('mod-cta');
+			syncButton.addClass('mod-warning');
 			syncOptionsButton.disabled = true;
-			if (openWebButton) {
-				openWebButton.disabled = true;
-			}
+			if (openWebButton) openWebButton.disabled = true;
+
+			// 点击取消
+			const cancelHandler = () => { signal.cancelled = true; };
+			syncButton.addEventListener('click', cancelHandler, { once: true });
+
 			try {
-				const updatedCount = await this.plugin.startSync();
+				const updatedCount = await this.plugin.startSync(force, signal);
 				if ((updatedCount ?? 0) > 0) {
 					this.bookshelfService.clearProgressCache();
 					await this.loadBookshelf();
 				}
 			} finally {
-				syncButton.disabled = false;
+				// 恢复同步按钮
+				isSyncing = false;
+				syncButton.removeEventListener('click', cancelHandler);
+				updateSyncButton(isAltPressed);
 				syncOptionsButton.disabled = false;
-				if (openWebButton) {
-					openWebButton.disabled = false;
-				}
+				if (openWebButton) openWebButton.disabled = false;
 			}
 		};
 		syncOptionsButton.onclick = () => {

--- a/src/syncNotebooks.ts
+++ b/src/syncNotebooks.ts
@@ -65,17 +65,46 @@ export default class SyncNotebooks {
 		await this.saveNotebook(notebook);
 		new Notice(`《${currentBookMeta.title}》已同步到本地`);
 	}
-	async syncNotebooks(force = false, journalDate: string): Promise<number> {
+	async syncNotebooks(
+		force = false,
+		journalDate: string,
+		signal?: { cancelled: boolean }
+	): Promise<number> {
 		const syncStartTime = new Date().getTime();
 		const metaDataArr = await this.getALlMetadata();
 		const filterMetaArr = await this.filterNoteMetas(force, metaDataArr);
 		let syncedNotebooks = 0;
-		const progressNotice = new Notice('微信读书笔记同步中, 请稍后！', 0);
+		let failedNotebooks = 0;
+		const total = filterMetaArr.length;
+		const progressNotice = new Notice('', 0);
 		const syncedNotes: SyncedNote[] = [];
 		let lastError: string | undefined;
 
+		// 一次性建好固定尺寸骨架，后续只更新内容，不触发 reflow
+		const frag = document.createDocumentFragment();
+		const container = frag.createDiv({ cls: 'weread-notice-progress' });
+		const headerEl = container.createDiv({ cls: 'weread-notice-progress-header' });
+		const barTrack = container.createDiv({ cls: 'weread-notice-progress-track' });
+		const barFill = barTrack.createDiv({ cls: 'weread-notice-progress-fill' });
+		const titleEl = container.createDiv({ cls: 'weread-notice-progress-title' });
+		progressNotice.setMessage(frag);
+
+		const updateProgress = (current: number, currentTitle?: string) => {
+			const pct = total > 0 ? Math.round((current / total) * 100) : 0;
+			headerEl.setText(`📚 微信读书同步中 · ${current}/${total} 本 (${pct}%)`);
+			barFill.style.width = `${pct}%`;
+			titleEl.setText(currentTitle ? `正在同步：${currentTitle}` : '');
+		};
+
+		updateProgress(0, filterMetaArr[0]?.title);
+
 		try {
-			for (const meta of filterMetaArr) {
+			for (let i = 0; i < filterMetaArr.length; i++) {
+				if (signal?.cancelled) break;
+				const meta = filterMetaArr[i];
+				const next = filterMetaArr[i + 1];
+				// 提前显示下一本书名，让用户感知当前在处理哪本
+				updateProgress(syncedNotebooks, meta.title);
 				try {
 					const notebook = await this.convertToNotebook(meta);
 					const savedFilePath = await this.saveNotebook(notebook);
@@ -90,23 +119,18 @@ export default class SyncNotebooks {
 						});
 					}
 				} catch (e) {
+					failedNotebooks++;
 					lastError = e instanceof Error ? e.message : String(e);
 					console.error(`[weread plugin] 同步书籍 ${meta.title} 失败`, e);
 				}
-
-				if (syncedNotebooks % 10 === 0 || syncedNotebooks === filterMetaArr.length) {
-					const progress = (syncedNotebooks / filterMetaArr.length) * 100;
-					progressNotice.setMessage(
-						`微信读书笔记同步中, 请稍后！正在更新 ${
-							filterMetaArr.length
-						} 本书 ，更新进度 ${progress.toFixed(0)}%`
-					);
-				}
+			updateProgress(syncedNotebooks, next?.title);
 			}
-		} finally {
+		} catch (e) {
 			progressNotice.hide();
+			throw e;
 		}
 
+		const wasCancelled = signal?.cancelled ?? false;
 		this.saveToJounal(journalDate, metaDataArr);
 		const syncEndTime = new Date().getTime();
 		const syncTimeInMilliseconds = syncEndTime - syncStartTime;
@@ -126,11 +150,19 @@ export default class SyncNotebooks {
 		};
 		settingsStore.actions.addSyncLog(syncLog);
 
-		new Notice(
-			`微信读书笔记同步完成!, 总共 ${metaDataArr.length} 本书 ， 本次更新 ${
-				filterMetaArr.length
-			} 本书, 耗时${syncTimeInSeconds.toFixed(2)} 秒`
-		);
+		// 复用进度 notice 的 DOM 骨架，切换为完成状态，10 秒后关闭
+		const icon = wasCancelled ? '🚫' : '✅';
+		const verb = wasCancelled ? '已取消，已更新' : '完成！更新';
+		headerEl.setText(`${icon} 同步${verb} ${syncedNotebooks} 本书`);
+		barFill.style.width = '100%';
+		if (wasCancelled) barFill.style.background = 'var(--text-muted)';
+		const summaryParts = [
+			`📚 书架共 ${metaDataArr.length} 本 · 本次处理 ${total} 本`,
+			failedNotebooks > 0 ? `⚠️ ${failedNotebooks} 本同步失败` : '',
+			`⏱ 耗时 ${syncTimeInSeconds.toFixed(1)} 秒`
+		].filter(Boolean);
+		titleEl.setText(summaryParts.join(' · '));
+		setTimeout(() => progressNotice.hide(), 5000);
 		return syncedNotebooks;
 	}
 

--- a/style.css
+++ b/style.css
@@ -1134,6 +1134,40 @@
 	gap: 16px;
 }
 
+.weread-notice-progress {
+	width: 260px;
+}
+
+.weread-notice-progress-header {
+	font-size: var(--font-small);
+	margin-bottom: 6px;
+	white-space: nowrap;
+}
+
+.weread-notice-progress-track {
+	height: 4px;
+	background: var(--background-modifier-border);
+	border-radius: 2px;
+	overflow: hidden;
+	margin-bottom: 6px;
+}
+
+.weread-notice-progress-fill {
+	height: 100%;
+	width: 0%;
+	background: var(--interactive-accent);
+	border-radius: 2px;
+	transition: width 0.3s ease;
+}
+
+.weread-notice-progress-title {
+	font-size: var(--font-smallest);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-height: 1em;
+}
+
 .weread-bookshelf-summary,
 .weread-bookshelf-empty,
 .weread-bookshelf-load-more {


### PR DESCRIPTION
## Summary

- **可取消同步**：同步中按钮切换为停止图标（`square`），点击即可取消；取消以书为粒度，当前这本处理完后停止
- **Alt/Opt 强制同步**：按住 Alt（Windows）/ Opt（macOS）时，按钮图标切换为 `refresh-ccw-dot`、变为橙色，tooltip 同步更新；使用 `e.code` 检测按键，解决 macOS Electron 下 `e.key` 不可靠的问题
- **进度 Notice 优化**：
  - 固定宽度 DOM 骨架 + CSS 进度条，更新时只改属性，不触发 reflow，Notice 大小完全稳定
  - 进度和完成状态复用同一个 Notice 元素，消除关闭/弹出的闪烁
  - 书名超长时截断显示省略号，不换行
  - 完成后 5 秒自动关闭

## Test plan

- [ ] 正常同步：点击同步按钮，观察进度 Notice 宽高是否稳定，完成后是否显示汇总信息并在 5 秒后关闭
- [ ] 取消同步：同步中点击按钮，观察是否停止并显示「已取消」汇总
- [ ] 强制同步：按住 Opt/Alt 悬停同步按钮，观察图标/颜色/tooltip 是否切换；点击是否触发强制同步
- [ ] 超长书名：确认进度 Notice 中书名显示省略号而不换行