### PR TITLE
feat: add reading stats interactive panel view

### DIFF
--- a/docs/weread-agent-api.md
+++ b/docs/weread-agent-api.md
@@ -1,0 +1,845 @@
+# 微信读书 Agent API 文档
+
+通过统一网关调用微信读书接口，支持搜索、书架、笔记、书评、阅读统计等能力。
+
+## 基础信息
+
+| 项目 | 值 |
+|------|-----|
+| **接口地址** | `POST https://i.weread.qq.com/api/agent/gateway` |
+| **鉴权方式** | `Authorization: Bearer <API_KEY>` |
+| **Content-Type** | `application/json` |
+| **接口选择** | 请求体中的 `api_name` 字段指定 |
+
+### 请求模板
+
+```bash
+curl -X POST "https://i.weread.qq.com/api/agent/gateway" \
+  -H "Authorization: Bearer wrk-xxxxxxxx" \
+  -H "Content-Type: application/json" \
+  -d '{"api_name": "/store/search", "keyword": "三体", "skill_version": "1.0.3"}'
+```
+
+### 通用规则
+
+- 每次请求必须带 `skill_version`（当前为 `"1.0.3"`）
+- 所有业务参数**平铺在 body 顶层**，不要嵌套在 `params`/`data` 等对象内
+- 时间戳字段单位均为 Unix 秒，阅读时长字段单位均为秒
+- `errcode` 非 0 时表示错误
+
+---
+
+## 接口列表
+
+| 分类 | api_name | 说明 |
+|------|----------|------|
+| 搜索 | `/store/search` | 书城搜索（书籍、作者、有声书等） |
+| 书架 | `/shelf/sync` | 获取完整书架（含有声书、书单） |
+| 书籍 | `/book/info` | 书籍基本信息 |
+| 书籍 | `/book/chapterinfo` | 章节目录 |
+| 书籍 | `/book/getprogress` | 阅读进度 |
+| 笔记 | `/user/notebooks` | 笔记本概览（所有有笔记的书） |
+| 笔记 | `/book/bookmarklist` | 单本书划线内容列表 |
+| 笔记 | `/review/list/mine` | 单本书个人想法与点评 |
+| 笔记 | `/book/bestbookmarks` | 书籍热门划线 TOP20 |
+| 笔记 | `/book/underlines` | 章节划线热度统计 |
+| 笔记 | `/book/readreviews` | 划线下的公众想法/评论 |
+| 笔记 | `/review/single` | 单条想法详情 |
+| 书评 | `/review/list` | 书籍公开点评 |
+| 统计 | `/readdata/detail` | 阅读统计（时长/天数/偏好分析） |
+| 推荐 | `/book/recommend` | 个性化推荐 |
+| 推荐 | `/book/similar` | 相似书推荐 |
+
+---
+
+## 搜索
+
+### `/store/search` — 书城搜索
+
+**请求参数**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `keyword` | string | ✅ | 搜索关键词 |
+| `scope` | int | — | 搜索类型，见下表，默认 10（电子书） |
+| `count` | int | — | 每页数量 |
+| `maxIdx` | int | — | 翻页偏移（上一页最后一条的 `searchIdx`） |
+
+**scope 对应关系**
+
+| scope | 说明 |
+|-------|------|
+| 0 | 全部（综合搜索） |
+| 10 | 电子书 |
+| 14 | 有声书/专辑 |
+| 16 | 网文小说 |
+| 6 | 作者 |
+| 12 | 全文搜索 |
+| 13 | 书单 |
+| 2 | 公众号 |
+| 4 | 文章 |
+
+**响应示例**（搜索"三体"，scope 默认）
+
+```json
+{
+  "sid": "5un7e9Aer2",
+  "results": [
+    {
+      "title": "电子书",
+      "scope": 17,
+      "scopeCount": 26,
+      "currentCount": 3,
+      "type": 1,
+      "books": [
+        {
+          "searchIdx": 1,
+          "bookInfo": {
+            "bookId": "695233",
+            "title": "三体全集（全三册）",
+            "author": "刘慈欣",
+            "cover": "https://cdn.weread.qq.com/weread/cover/80/yuewen_695233/s_yuewen_6952331740758482.jpg",
+            "payType": 4097,
+            "type": 0,
+            "soldout": 0,
+            "newRating": 930,
+            "newRatingCount": 293405,
+            "newRatingDetail": { "title": "神作" }
+          },
+          "readingCount": 10775
+        }
+      ]
+    },
+    {
+      "title": "有声书",
+      "type": 41,
+      "scope": 14,
+      "scopeCount": 12,
+      "currentCount": 1
+    }
+  ]
+}
+```
+
+---
+
+## 书架
+
+### `/shelf/sync` — 完整书架
+
+**请求参数**：无（用户身份通过 API Key 自动注入）
+
+**书架数量计算**：`books.length + albums.length + (mp 非空 ? 1 : 0)`
+
+**响应示例**
+
+```json
+{
+  "books": [
+    {
+      "bookId": "CB_7YV4cp4egBPA6wW6x6F0K3Kf",
+      "title": "Harry Potter and the Sorcerer's Stone",
+      "author": "J.K. Rowling",
+      "cover": "https://res.weread.qq.com/...",
+      "updateTime": 1749304698,
+      "readUpdateTime": 1758035679,
+      "finishReading": 0,
+      "secret": 1,
+      "isTop": false
+    }
+  ],
+  "albums": [
+    {
+      "albumInfo": {
+        "albumId": "3110080161",
+        "name": "置身事内：中国政府与经济发展",
+        "authorName": "王大民",
+        "cover": "https://wehear-1258476243.file.myqcloud.com/...",
+        "trackCount": 30,
+        "finish": 1,
+        "finishStatus": "已完结",
+        "payType": 1,
+        "updateTime": 1706068808
+      },
+      "albumInfoExtra": {
+        "albumId": "3110080161",
+        "secret": 1,
+        "lecturePaid": 0,
+        "lectureReadUpdateTime": 1745223973,
+        "isTop": false
+      }
+    }
+  ],
+  "mp": {
+    "show": 1,
+    "book": {
+      "bookId": "mpbook",
+      "title": "文章收藏",
+      "cover": "https://...",
+      "readUpdateTime": 1751125626
+    }
+  },
+  "archive": [
+    {
+      "name": "哈利波特",
+      "bookIds": ["CB_7Q14cb4eg...", "CB_7t24ci4eg..."],
+      "albumIds": []
+    }
+  ]
+}
+```
+
+---
+
+## 书籍信息
+
+### `/book/info` — 书籍基本信息
+
+**请求参数**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `bookId` | string | ✅ | 书籍 ID |
+
+**响应示例**
+
+```json
+{
+  "bookId": "695233",
+  "title": "三体全集（全三册）",
+  "author": "刘慈欣",
+  "cover": "https://cdn.weread.qq.com/weread/cover/80/yuewen_695233/t6_yuewen_6952331740758482.jpg",
+  "intro": "【荣获世界科幻大奖"雨果奖"...】",
+  "category": "精品小说-科幻小说",
+  "publisher": "重庆出版社",
+  "publishTime": "2022-04-01 00:00:00",
+  "isbn": "",
+  "newRating": 930,
+  "newRatingCount": 293405,
+  "newRatingDetail": {
+    "good": 274343,
+    "fair": 15852,
+    "poor": 3210,
+    "recent": 598,
+    "deepV": 5071,
+    "title": "神作"
+  }
+}
+```
+
+---
+
+### `/book/chapterinfo` — 章节目录
+
+**请求参数**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `bookId` | string | ✅ | 书籍 ID |
+
+**响应示例**（截取前 3 章）
+
+```json
+{
+  "bookId": "695233",
+  "synckey": 1687693885,
+  "chapterUpdateTime": 1759043478,
+  "chapters": [
+    {
+      "chapterUid": 90,
+      "chapterIdx": 5,
+      "title": "三体1",
+      "level": 1,
+      "wordCount": 1,
+      "price": 0,
+      "paid": 0,
+      "isMPChapter": 0,
+      "updateTime": 1740758664
+    },
+    {
+      "chapterUid": 94,
+      "chapterIdx": 9,
+      "title": "1 科学边界",
+      "level": 2,
+      "wordCount": 7959,
+      "price": 0,
+      "paid": 0,
+      "isMPChapter": 0,
+      "updateTime": 1740758664
+    },
+    {
+      "chapterUid": 110,
+      "chapterIdx": 25,
+      "title": "17 三体问题",
+      "level": 2,
+      "wordCount": 9109,
+      "price": -1,
+      "paid": 0,
+      "isMPChapter": 0,
+      "updateTime": 1740758664
+    }
+  ]
+}
+```
+
+> `price: 0` 为免费章节，`price: -1` 为付费章节（需购买书籍）。`level` 为目录层级，1=一级标题，2=二级，3=三级。
+
+---
+
+### `/book/getprogress` — 阅读进度
+
+**请求参数**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `bookId` | string | ✅ | 书籍 ID |
+
+**响应示例**
+
+```json
+{
+  "bookId": "695233",
+  "book": {
+    "chapterUid": 114,
+    "chapterOffset": 848,
+    "chapterIdx": 27,
+    "progress": 15,
+    "updateTime": 1712799586,
+    "readingTime": 28223,
+    "recordReadingTime": 0,
+    "isStartReading": 1
+  },
+  "timestamp": 1779233957
+}
+```
+
+> `progress` 为 0-100 整数，表示百分比（`15` = 15%）。`readingTime` 单位秒。`finishTime` 仅在 `progress=100` 时出现。
+
+---
+
+## 笔记与划线
+
+### `/user/notebooks` — 笔记本概览
+
+获取所有有笔记的书，支持分页。
+
+**请求参数**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `count` | int | — | 每页数量，默认 20 |
+| `lastSort` | int | — | 翻页游标（上一页最后一条的 `sort` 值） |
+
+> **翻页**：`hasMore=1` 时，取本页最后一条的 `sort` 作为下次请求的 `lastSort`。
+
+**响应示例**（2 条）
+
+```json
+{
+  "synckey": 1779233400,
+  "totalBookCount": 553,
+  "totalNoteCount": 17177,
+  "hasMore": 1,
+  "books": [
+    {
+      "bookId": "3300189789",
+      "book": {
+        "bookId": "3300189789",
+        "title": "金钱的艺术",
+        "author": "[美]摩根·豪泽尔",
+        "cover": "https://cdn.weread.qq.com/..."
+      },
+      "reviewCount": 2,
+      "noteCount": 42,
+      "bookmarkCount": 1,
+      "readingProgress": 24,
+      "markedStatus": 2,
+      "sort": 1779067614
+    },
+    {
+      "bookId": "33638775",
+      "book": {
+        "bookId": "33638775",
+        "title": "苏东坡新传",
+        "author": "李一冰",
+        "cover": "https://cdn.weread.qq.com/..."
+      },
+      "reviewCount": 0,
+      "noteCount": 10,
+      "bookmarkCount": 0,
+      "readingProgress": 3,
+      "markedStatus": 2,
+      "sort": 1778550758
+    }
+  ]
+}
+```
+
+> **笔记总数** = `reviewCount + noteCount + bookmarkCount`。`noteCount` 是划线数，`reviewCount` 是想法/点评数，`bookmarkCount` 是书签数。
+
+---
+
+### `/book/bookmarklist` — 单本书划线列表
+
+**请求参数**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `bookId` | string | ✅ | 书籍 ID |
+
+**响应示例**（2 条划线）
+
+```json
+{
+  "synckey": 1740760267,
+  "updated": [
+    {
+      "bookId": "695233",
+      "bookmarkId": "695233_19_3760-3894",
+      "chapterUid": 108,
+      "markText": "地球生命真的是宇宙中偶然里的偶然，宇宙是个空荡荡的大宫殿，人类是这宫殿中唯一的一只小蚂蚁。",
+      "range": "3450-3584",
+      "createTime": 1711949794,
+      "type": 1,
+      "colorStyle": 0
+    },
+    {
+      "bookId": "695233",
+      "bookmarkId": "695233_12_2420-2507",
+      "chapterUid": 101,
+      "markText": "大树被拖走了，地面上的石块和树桩划开了树皮，使它巨大的身躯皮开肉绽。",
+      "range": "2216-2303",
+      "createTime": 1711589330,
+      "type": 1,
+      "colorStyle": 1
+    }
+  ],
+  "removed": [],
+  "chapters": [
+    { "chapterUid": 108, "chapterIdx": 23, "title": "15 红岸之四" },
+    { "chapterUid": 101, "chapterIdx": 16, "title": "8 寂静的春天" }
+  ],
+  "book": {
+    "bookId": "695233",
+    "title": "三体全集（全三册）",
+    "author": "刘慈欣"
+  }
+}
+```
+
+> `range` 格式为 `"起始-结束"`，可用于构造深度链接。`type=1` 为划线，书签已自动过滤。
+
+---
+
+### `/review/list/mine` — 个人想法与点评
+
+**请求参数**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `bookid` | string | ✅ | 书籍 ID（注意是小写 `bookid`） |
+| `synckey` | int | — | 翻页游标，默认 0 |
+| `count` | int | — | 每页数量，默认 20 |
+
+**响应示例**
+
+```json
+{
+  "synckey": 1740761771,
+  "totalCount": 1,
+  "hasMore": 0,
+  "reviews": [
+    {
+      "reviewId": "15707910_7r61CO8jM",
+      "review": {
+        "reviewId": "15707910_7r61CO8jM",
+        "bookId": "695233",
+        "content": "三维空间里人有着巨大的局限性",
+        "abstract": ""射手"假说：有一名神枪手，在一个靶子上每隔十厘米打一个洞...",
+        "range": "1277-1599",
+        "type": 1,
+        "chapterUid": 96,
+        "chapterName": "3 射手和农场主",
+        "chapterIdx": 11,
+        "createTime": 1623806624,
+        "star": 0,
+        "author": {
+          "userVid": 15707910,
+          "name": "赵小轩",
+          "avatar": "https://res.weread.qq.com/..."
+        }
+      }
+    }
+  ]
+}
+```
+
+> `type=1` 为划线想法，`type=4` 为章节点评，`type=6` 为整本书评。`abstract` 是对应的划线原文。
+
+---
+
+### `/book/bestbookmarks` — 热门划线 TOP20
+
+**请求参数**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `bookId` | string | ✅ | 书籍 ID |
+| `chapterUid` | int | — | 章节 UID，0=全书，默认 0 |
+| `synckey` | int | — | 增量同步 key，默认 0 |
+
+> 服务端固定返回前 20 条，不支持分页。
+
+**响应示例**（2 条）
+
+```json
+{
+  "synckey": 1779233154,
+  "totalCount": 973,
+  "items": [
+    {
+      "bookId": "695233",
+      "bookmarkId": "695233_145_15118-15195",
+      "chapterUid": 145,
+      "range": "15118-15195",
+      "markText": "太阳快落下去了，你们的孩子居然不害怕？ "当然不害怕，她知道明天太阳还会升起来的。"",
+      "totalCount": 58136,
+      "userVid": 29121947
+    },
+    {
+      "bookId": "695233",
+      "bookmarkId": "695233_100_4603-4634",
+      "chapterUid": 100,
+      "range": "4603-4634",
+      "markText": "在中国，任何超脱飞扬的思想都会砰然坠地的，现实的引力太沉重了。",
+      "totalCount": 56955,
+      "userVid": 276736035
+    }
+  ],
+  "chapters": [
+    { "bookId": "695233", "chapterUid": 94, "chapterIdx": 9, "title": "1 科学边界" }
+  ]
+}
+```
+
+> `totalCount` 为该段划线的人数。
+
+---
+
+### `/book/underlines` — 章节划线热度统计
+
+**请求参数**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `bookId` | string | ✅ | 书籍 ID |
+| `chapterUid` | int | ✅ | 章节 UID |
+| `synckey` | int | — | 增量同步 key，默认 0 |
+
+> 只返回热度统计（人数/得分），**不含划线原文**。适合展示"X 人划线"标签。
+
+**响应示例**
+
+```json
+{
+  "synckey": 1779233188,
+  "bookId": "695233",
+  "chapterUid": 94,
+  "underlines": [
+    { "range": "389-528", "count": 30600, "score": 877.63, "type": 2 },
+    { "range": "608-657", "count": 8058,  "score": 195.74, "type": 2 },
+    { "range": "695-706", "count": 0,     "score": 22.75,  "type": 0 }
+  ]
+}
+```
+
+---
+
+### `/book/readreviews` — 划线下的公众想法
+
+**请求参数**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `bookId` | string | ✅ | 书籍 ID |
+| `chapterUid` | int | ✅ | 章节 UID |
+| `reviews` | array | ✅ | 要查询的划线范围数组 |
+| `reviews[].range` | string | ✅ | 划线位置范围（来自 `/book/bestbookmarks`） |
+| `reviews[].count` | int | — | 每个 range 返回数量，上限 20 |
+| `reviews[].maxIdx` | int | — | 翻页偏移，默认 0 |
+| `reviews[].synckey` | int | — | 翻页游标，默认 0 |
+
+**请求示例**
+
+```json
+{
+  "api_name": "/book/readreviews",
+  "bookId": "695233",
+  "chapterUid": 94,
+  "reviews": [{"range": "389-528", "count": 2}],
+  "skill_version": "1.0.3"
+}
+```
+
+**响应示例**
+
+```json
+{
+  "bookId": "695233",
+  "chapterUid": 94,
+  "reviews": [
+    {
+      "range": "389-528",
+      "totalCount": 2660,
+      "hasMore": 1,
+      "maxIdx": 2,
+      "synckey": 1779233188,
+      "bookMarkCount": 30600,
+      "pageReviews": [
+        {
+          "reviewId": "378001216_86Qiq9XLA",
+          "likesCount": 193,
+          "review": {
+            "userVid": 378001216,
+            "content": "在中国的体制下，警察和武警配合是常态...",
+            "abstract": "1科学边界汪淼觉得，来找他的这四个人是一个奇怪的组合...",
+            "range": "389-528",
+            "chapterName": "1 科学边界",
+            "createTime": 1770821022,
+            "author": {
+              "userVid": 378001216,
+              "name": "长风不息⛵",
+              "avatar": "https://res.weread.qq.com/..."
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+### `/review/single` — 单条想法详情
+
+**请求参数**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `reviewId` | string | ✅ | 想法 ID |
+| `commentsCount` | int | — | 拉取评论数量，默认 10 |
+| `commentsDirection` | int | — | 评论排序，0=倒序，1=正序 |
+| `likesCount` | int | — | 拉取点赞数量，默认 10 |
+| `synckey` | int | — | 增量同步 key，默认 0 |
+
+---
+
+## 书评
+
+### `/review/list` — 书籍公开点评
+
+**请求参数**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `bookId` | string | ✅ | 书籍 ID |
+| `reviewListType` | int | — | 0=全部，1=推荐，2=差评，3=最新，4=一般，默认 0 |
+| `count` | int | — | 每页数量，默认 20 |
+| `maxIdx` | int | — | 翻页偏移 |
+| `synckey` | int | — | 翻页游标 |
+
+**响应示例**（1 条推荐点评，已缩略）
+
+```json
+{
+  "synckey": 1779233986,
+  "reviewsCnt": 104402,
+  "recentTotalCnt": 598,
+  "reviewsHasMore": 1,
+  "reviewsHas5Star": 1,
+  "deepVUniqueCount": 5071,
+  "friendCommentCount": 6,
+  "friendUniqueCount": 6,
+  "reviews": [
+    {
+      "idx": 1,
+      "review": {
+        "reviewId": "68566999_7ZHAfkTxE",
+        "likesCount": 3259,
+        "commentsCount": 988,
+        "review": {
+          "star": 100,
+          "content": "我非常喜欢《三体》和刘慈欣；但书中对女性角色的塑造，一言难尽...",
+          "createTime": 1745674848,
+          "isFinish": 0,
+          "chapterName": "",
+          "author": {
+            "userVid": 68566999,
+            "name": "（Eason)逐月",
+            "avatar": "https://thirdwx.qlogo.cn/..."
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+> `star` 评分：100=⭐⭐⭐⭐⭐，80=⭐⭐⭐⭐，60=⭐⭐⭐，40=⭐⭐，20=⭐。翻页用上一页最后一条的 `idx` 作为下次 `maxIdx`。
+
+---
+
+## 阅读统计
+
+### `/readdata/detail` — 阅读统计详情
+
+**请求参数**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `mode` | string | — | `weekly`=本周，`monthly`=本月（默认），`annually`=本年，`overall`=全部历史 |
+| `baseTime` | int | — | 基准时间戳，服务端归一化到周期起点；传历史时间戳可查历史周期 |
+
+**响应示例**（本月，已精简）
+
+```json
+{
+  "baseTime": 1777564800,
+  "totalReadTime": 35683,
+  "readDays": 19,
+  "dayAverageReadTime": 1784,
+  "compare": 0.247,
+  "readStat": [
+    { "stat": "读过", "counts": "9本" },
+    { "stat": "读完", "counts": "1本" },
+    { "stat": "阅读", "counts": "19天" },
+    { "stat": "笔记", "counts": "119条" }
+  ],
+  "readLongest": [
+    {
+      "book": { "bookId": "26278269", "title": "苏轼传", "author": "王水照 崔铭" },
+      "readTime": 17756,
+      "tags": ["单日阅读最久"]
+    },
+    {
+      "book": { "bookId": "3300189789", "title": "金钱的艺术", "author": "[美]摩根·豪泽尔" },
+      "readTime": 8547,
+      "tags": ["笔记最多"]
+    }
+  ],
+  "preferCategory": [
+    { "categoryTitle": "人物传记", "readingCount": 3, "readingTime": 22183 },
+    { "categoryTitle": "经济理财", "readingCount": 3, "readingTime": 11127 }
+  ],
+  "preferCategoryWord": "偏好阅读人物传记",
+  "readTimes": {
+    "1777564800": 229,
+    "1777651200": 2388,
+    "1777737600": 4502
+  }
+}
+```
+
+> `totalReadTime`、`readTime`、`readingTime` 等所有时长字段单位均为**秒**。`compare` 为与上期日均时长的对比比例，`0.247` 表示增长约 24.7%。`readTimes` key 为每天的起始时间戳，value 为当天阅读秒数。
+
+**查询历史数据示例**
+
+```json
+// 查询 2025 年全年
+{"api_name": "/readdata/detail", "mode": "annually", "baseTime": 1735689600, "skill_version": "1.0.3"}
+
+// 查询 2024 年 3 月
+{"api_name": "/readdata/detail", "mode": "monthly", "baseTime": 1709222400, "skill_version": "1.0.3"}
+
+// 查询全部历史
+{"api_name": "/readdata/detail", "mode": "overall", "skill_version": "1.0.3"}
+```
+
+---
+
+## 发现推荐
+
+### `/book/recommend` — 个性化推荐
+
+**请求参数**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `count` | int | — | 每页数量，默认 12 |
+| `maxIdx` | int | — | 翻页偏移（上一页最后一条的 `searchIdx`） |
+
+**响应示例**（3 条）
+
+```json
+{
+  "books": [
+    {
+      "bookId": "3300164559",
+      "title": "奇特的一生（精装典藏2025版）",
+      "author": "[俄]格拉宁",
+      "cover": "https://cdn.weread.qq.com/...",
+      "intro": "本书描述了一个真正和时间成为朋友的人...",
+      "category": "个人成长-人生哲学",
+      "price": 56.0,
+      "payType": 1048577,
+      "type": 0
+    },
+    {
+      "bookId": "3300027206",
+      "title": "5%的改变",
+      "author": "李松蔚",
+      "cover": "https://cdn.weread.qq.com/...",
+      "category": "心理-积极心理学",
+      "price": 49.8,
+      "payType": 1048577,
+      "type": 0
+    }
+  ]
+}
+```
+
+---
+
+### `/book/similar` — 相似书推荐
+
+**请求参数**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `bookId` | string | ✅ | 基准书籍 ID |
+| `count` | int | — | 每页数量，默认 12 |
+| `maxIdx` | int | — | 翻页偏移 |
+| `sessionId` | string | — | 翻页会话 ID（首次不传，后续传回包中的值） |
+
+---
+
+## 深度链接（URL Scheme）
+
+在 App 内跳转对应位置：
+
+| 场景 | URL 格式 |
+|------|---------|
+| 打开书籍（上次进度） | `weread://reading?bId={bookId}` |
+| 跳转到指定章节 | `weread://reading?bId={bookId}&chapterUid={chapterUid}` |
+| 跳转到划线位置 | `weread://bestbookmark?bookId={bookId}&chapterUid={chapterUid}&rangeStart={start}&rangeEnd={end}` |
+
+> `rangeStart`/`rangeEnd` 从 `range` 字段（如 `"389-528"`）解析得到。
+
+**示例**
+
+```
+weread://reading?bId=695233
+weread://reading?bId=695233&chapterUid=94
+weread://bestbookmark?bookId=695233&chapterUid=94&rangeStart=389&rangeEnd=528
+```
+
+---
+
+## 错误码
+
+| errcode | 说明 |
+|---------|------|
+| 0 | 成功 |
+| -2003 | 参数格式错误 |
+| -2012 | 登录超时，需重新鉴权 |

--- a/main.ts
+++ b/main.ts
@@ -3,6 +3,7 @@ import FileManager from './src/fileManager';
 import SyncNotebooks from './src/syncNotebooks';
 import ApiManager from './src/api';
 import WereadBookshelfService from './src/bookshelf';
+import SyncReadingStats from './src/syncReadingStats';
 import { settingsStore } from './src/settings';
 import type { ReadingOpenMode } from './src/settings';
 import { get } from 'svelte/store';
@@ -10,11 +11,13 @@ import { WereadSettingsTab } from './src/settingTab';
 import WereadBrowserWindow from './src/components/wereadBrowserWindow';
 import { WEREAD_BROWSER_VIEW_ID, WereadReadingView } from './src/components/wereadReading';
 import { WEREAD_BOOKSHELF_VIEW_ID, WereadBookshelfView } from './src/components/wereadBookshelf';
+import { WEREAD_READING_STATS_VIEW_ID, WereadReadingStatsView } from './src/components/wereadReadingStats';
 import './style.css';
 export default class WereadPlugin extends Plugin {
 	private syncNotebooks: SyncNotebooks;
 	private bookshelfService: WereadBookshelfService;
 	private fileManager: FileManager;
+	private syncReadingStats: SyncReadingStats;
 	private wereadSettingsTab!: WereadSettingsTab;
 	private syncing = false;
 	private cookieRefreshTimer: number | null = null;
@@ -33,6 +36,7 @@ export default class WereadPlugin extends Plugin {
 		const apiManager = new ApiManager();
 		this.syncNotebooks = new SyncNotebooks(fileManager, apiManager);
 		this.bookshelfService = new WereadBookshelfService(fileManager, apiManager);
+		this.syncReadingStats = new SyncReadingStats(this.app.vault, apiManager);
 
 		// 初始化时验证 Cookie 有效性
 		const settings = get(settingsStore);
@@ -118,6 +122,10 @@ export default class WereadPlugin extends Plugin {
 			WEREAD_BOOKSHELF_VIEW_ID,
 			(leaf) => new WereadBookshelfView(leaf, this, this.bookshelfService)
 		);
+		this.registerView(
+			WEREAD_READING_STATS_VIEW_ID,
+			(leaf) => new WereadReadingStatsView(leaf, apiManager, this.syncReadingStats)
+		);
 
 		this.addCommand({
 			id: 'open-weread-reading-view-tab',
@@ -140,6 +148,14 @@ export default class WereadPlugin extends Plugin {
 			name: '打开微信读书书架',
 			callback: () => {
 				this.activateBookshelfView();
+			}
+		});
+
+		this.addCommand({
+			id: 'sync-weread-reading-stats',
+			name: '同步阅读统计数据',
+			callback: () => {
+				this.syncReadingStats.sync();
 			}
 		});
 
@@ -293,6 +309,19 @@ export default class WereadPlugin extends Plugin {
 			await leaf.setViewState({ type: WEREAD_BOOKSHELF_VIEW_ID, active: true });
 		}
 
+		workspace.revealLeaf(leaf);
+	}
+
+	async activateReadingStatsView() {
+		const { workspace } = this.app;
+		const leaves = workspace.getLeavesOfType(WEREAD_READING_STATS_VIEW_ID);
+		let leaf: WorkspaceLeaf;
+		if (leaves.length > 0) {
+			leaf = leaves[0];
+		} else {
+			leaf = workspace.getLeaf('tab');
+			await leaf.setViewState({ type: WEREAD_READING_STATS_VIEW_ID, active: true });
+		}
 		workspace.revealLeaf(leaf);
 	}
 

--- a/main.ts
+++ b/main.ts
@@ -124,7 +124,7 @@ export default class WereadPlugin extends Plugin {
 		);
 		this.registerView(
 			WEREAD_READING_STATS_VIEW_ID,
-			(leaf) => new WereadReadingStatsView(leaf, apiManager, this.syncReadingStats)
+			(leaf) => new WereadReadingStatsView(leaf, apiManager, this.syncReadingStats, fileManager)
 		);
 
 		this.addCommand({

--- a/main.ts
+++ b/main.ts
@@ -124,7 +124,7 @@ export default class WereadPlugin extends Plugin {
 		);
 		this.registerView(
 			WEREAD_READING_STATS_VIEW_ID,
-			(leaf) => new WereadReadingStatsView(leaf, apiManager, this.syncReadingStats, fileManager)
+			(leaf) => new WereadReadingStatsView(leaf, apiManager, fileManager)
 		);
 
 		this.addCommand({

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-weread-plugin",
 	"name": "Weread",
-	"version": "2.0.0",
+	"version": "1.6.0",
 	"minAppVersion": "0.12.0",
 	"description": "Sync Tencent Weread highlights and annotations.",
 	"author": "hankzhao",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-weread-plugin",
 	"name": "Weread",
-	"version": "1.5.5",
+	"version": "2.0.0",
 	"minAppVersion": "0.12.0",
 	"description": "Sync Tencent Weread highlights and annotations.",
 	"author": "hankzhao",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"@types/set-cookie-parser": "2.4.10",
 				"crypto-js": "^4.1.1",
 				"electron": "^31.3.1",
+				"html-to-image": "^1.11.13",
 				"html2canvas": "^1.4.1",
 				"node-html-markdown": "^1.2.0",
 				"nunjucks": "^3.2.4",
@@ -4176,6 +4177,12 @@
 			"bin": {
 				"he": "bin/he"
 			}
+		},
+		"node_modules/html-to-image": {
+			"version": "1.11.13",
+			"resolved": "https://registry.npmmirror.com/html-to-image/-/html-to-image-1.11.13.tgz",
+			"integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+			"license": "MIT"
 		},
 		"node_modules/html2canvas": {
 			"version": "1.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
 	"name": "obsidian-weread-plugin",
-	"version": "1.5.3",
+	"version": "1.5.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-weread-plugin",
-			"version": "1.5.3",
+			"version": "1.5.5",
 			"license": "MIT",
 			"dependencies": {
 				"@types/crypto-js": "^4.1.2",
 				"@types/set-cookie-parser": "2.4.10",
 				"crypto-js": "^4.1.1",
 				"electron": "^31.3.1",
+				"html2canvas": "^1.4.1",
 				"node-html-markdown": "^1.2.0",
 				"nunjucks": "^3.2.4",
 				"sanitize-filename": "^1.6.3",
@@ -1578,6 +1579,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/base64-arraybuffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmmirror.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+			"integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		},
 		"node_modules/baseline-browser-mapping": {
 			"version": "2.10.29",
 			"resolved": "https://registry.npmmirror.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
@@ -1620,7 +1630,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmmirror.com/braces/-/braces-3.0.3.tgz",
 			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fill-range": "^7.1.1"
@@ -1950,6 +1960,15 @@
 			"resolved": "https://registry.npmmirror.com/crypto-js/-/crypto-js-4.2.0.tgz",
 			"integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
 			"license": "MIT"
+		},
+		"node_modules/css-line-break": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmmirror.com/css-line-break/-/css-line-break-2.1.0.tgz",
+			"integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+			"license": "MIT",
+			"dependencies": {
+				"utrie": "^1.0.2"
+			}
 		},
 		"node_modules/css-loader": {
 			"version": "6.11.0",
@@ -3699,7 +3718,7 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmmirror.com/fill-range/-/fill-range-7.1.1.tgz",
 			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -4158,6 +4177,19 @@
 				"he": "bin/he"
 			}
 		},
+		"node_modules/html2canvas": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmmirror.com/html2canvas/-/html2canvas-1.4.1.tgz",
+			"integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+			"license": "MIT",
+			"dependencies": {
+				"css-line-break": "^2.1.0",
+				"text-segmentation": "^1.0.3"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
 		"node_modules/http-cache-semantics": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmmirror.com/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -4411,7 +4443,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmmirror.com/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -4457,7 +4489,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmmirror.com/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-extglob": "^2.1.1"
@@ -4496,7 +4528,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
@@ -5545,7 +5577,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmmirror.com/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -5912,7 +5944,7 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-2.3.2.tgz",
 			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
@@ -7404,6 +7436,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/text-segmentation": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmmirror.com/text-segmentation/-/text-segmentation-1.0.3.tgz",
+			"integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+			"license": "MIT",
+			"dependencies": {
+				"utrie": "^1.0.2"
+			}
+		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.16",
 			"resolved": "https://registry.npmmirror.com/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -7456,7 +7497,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmmirror.com/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
@@ -7799,6 +7840,15 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/utrie": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmmirror.com/utrie/-/utrie-1.0.2.tgz",
+			"integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+			"license": "MIT",
+			"dependencies": {
+				"base64-arraybuffer": "^1.0.2"
+			}
 		},
 		"node_modules/w3c-keyname": {
 			"version": "2.2.8",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"@types/set-cookie-parser": "2.4.10",
 		"crypto-js": "^4.1.1",
 		"electron": "^31.3.1",
+		"html2canvas": "^1.4.1",
 		"node-html-markdown": "^1.2.0",
 		"nunjucks": "^3.2.4",
 		"sanitize-filename": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"@types/set-cookie-parser": "2.4.10",
 		"crypto-js": "^4.1.1",
 		"electron": "^31.3.1",
+		"html-to-image": "^1.11.13",
 		"html2canvas": "^1.4.1",
 		"node-html-markdown": "^1.2.0",
 		"nunjucks": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-weread-plugin",
-	"version": "1.5.5",
+	"version": "2.0.0",
 	"description": "This is a community plugin for tencent weread (https://r.qq.com)",
 	"main": "main.ts",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-weread-plugin",
-	"version": "2.0.0",
+	"version": "1.6.0",
 	"description": "This is a community plugin for tencent weread (https://r.qq.com)",
 	"main": "main.ts",
 	"scripts": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -433,6 +433,23 @@ export default class ApiManager {
 	}
 
 	/**
+	 * 获取用户个人信息（含个性签名）
+	 */
+	async getUserInfo(userVid: string): Promise<Record<string, unknown> | undefined> {
+		try {
+			const resp = await requestUrl({
+				url: `https://weread.qq.com/web/user?userVid=${userVid}`,
+				method: 'GET',
+				headers: this.getHeaders()
+			});
+			return resp.json;
+		} catch (e) {
+			console.warn('[weread] getUserInfo failed', e);
+			return undefined;
+		}
+	}
+
+	/**
 	 * 获取阅读统计数据
 	 */
 	async getReadingStats(mode: ReadingStatsMode, baseTime?: number): Promise<ReadingStatsResponse | undefined> {

--- a/src/api.ts
+++ b/src/api.ts
@@ -11,6 +11,7 @@ import {
 	BookDetailResponse,
 	BookProgressResponse
 } from './models';
+import type { ReadingStatsResponse, ReadingStatsMode } from './models';
 import CookieCloudManager from './cookieCloud';
 export default class ApiManager {
 	readonly baseUrl: string = 'https://weread.qq.com';
@@ -393,5 +394,50 @@ export default class ApiManager {
 			}
 		});
 		settingsStore.actions.setCookies(cookies);
+	}
+
+	/**
+	 * 通过 Agent API Gateway 调用微信读书接口（需要 API Key）
+	 */
+	async callAgentGateway<T = unknown>(apiName: string, params: Record<string, unknown> = {}): Promise<T | undefined> {
+		const apiKey = get(settingsStore).wereadApiKey;
+		if (!apiKey) {
+			new Notice('未配置微信读书 API Key，请在设置中填写');
+			return undefined;
+		}
+		try {
+			const body = {
+				api_name: apiName,
+				skill_version: '1.0.3',
+				...params
+			};
+			const req: RequestUrlParam = {
+				url: 'https://i.weread.qq.com/api/agent/gateway',
+				method: 'POST',
+				headers: {
+					'Authorization': `Bearer ${apiKey}`,
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify(body)
+			};
+			const resp = await requestUrl(req);
+			if (resp.json?.errcode && resp.json.errcode !== 0) {
+				console.error(`[weread plugin] Agent API error: ${resp.json.errmsg}`);
+				return undefined;
+			}
+			return resp.json as T;
+		} catch (e) {
+			console.error(`[weread plugin] Agent API call failed: ${apiName}`, e);
+			return undefined;
+		}
+	}
+
+	/**
+	 * 获取阅读统计数据
+	 */
+	async getReadingStats(mode: ReadingStatsMode, baseTime?: number): Promise<ReadingStatsResponse | undefined> {
+		const params: Record<string, unknown> = { mode };
+		if (baseTime !== undefined) params.baseTime = baseTime;
+		return this.callAgentGateway<ReadingStatsResponse>('/readdata/detail', params);
 	}
 }

--- a/src/components/wereadBookshelf.ts
+++ b/src/components/wereadBookshelf.ts
@@ -273,6 +273,16 @@ export class WereadBookshelfView extends ItemView {
 			  })()
 			: null;
 
+		const readingStatsButton = toolbarActions.createEl('button', {
+			cls: 'clickable-icon weread-bookshelf-icon-button weread-toolbar-icon-button',
+			attr: { 'aria-label': '同步阅读统计' }
+		});
+		setIcon(readingStatsButton, 'bar-chart-2');
+		setTooltip(readingStatsButton, '阅读统计');
+		readingStatsButton.addEventListener('click', () => {
+			(this.plugin as any).activateReadingStatsView();
+		});
+
 		const syncLogButton = toolbarActions.createEl('button', {
 			cls: 'clickable-icon weread-bookshelf-icon-button weread-toolbar-icon-button',
 			attr: { 'aria-label': '同步日志' }

--- a/src/components/wereadBookshelf.ts
+++ b/src/components/wereadBookshelf.ts
@@ -109,6 +109,18 @@ export class WereadBookshelfView extends ItemView {
 		return 'library';
 	}
 
+	onMoreOptionsMenu(menu: Menu) {
+		menu.addItem((item) =>
+			item
+				.setTitle('刷新书架')
+				.setIcon('refresh-ccw')
+				.onClick(() => {
+					this.loadBookshelf();
+				})
+		);
+		menu.addSeparator();
+	}
+
 	async onOpen() {
 		this.contentEl.empty();
 		this.contentEl.addClass('weread-bookshelf-view');

--- a/src/components/wereadReadingStats.ts
+++ b/src/components/wereadReadingStats.ts
@@ -33,15 +33,63 @@ function fmtCompare(compare?: number): { text: string; up: boolean } | null {
 // preferTime 从 6 点开始排列
 const HOUR_LABELS = ['6','7','8','9','10','11','12','13','14','15','16','17','18','19','20','21','22','23','0','1','2','3','4','5'];
 
+// ─── 时间偏移计算 ──────────────────────────────────────────────────────────────
+
+/** 根据 mode 和 offset（0=当前，-1=上一期，...）计算 baseTime（Unix 秒） */
+function calcBaseTime(mode: ReadingStatsMode, offset: number): number | undefined {
+	if (mode === 'overall') return undefined;
+	const now = new Date();
+	if (mode === 'weekly') {
+		// 本周一 0:00
+		const day = now.getDay() === 0 ? 6 : now.getDay() - 1; // 0=Mon
+		const monday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - day);
+		monday.setDate(monday.getDate() + offset * 7);
+		return Math.floor(monday.getTime() / 1000);
+	}
+	if (mode === 'monthly') {
+		// 本月 1 日 0:00
+		const d = new Date(now.getFullYear(), now.getMonth() + offset, 1);
+		return Math.floor(d.getTime() / 1000);
+	}
+	if (mode === 'annually') {
+		// 本年 1 月 1 日 0:00
+		const d = new Date(now.getFullYear() + offset, 0, 1);
+		return Math.floor(d.getTime() / 1000);
+	}
+	return undefined;
+}
+
+/** 当前期 label，如"2026年5月"、"2026年第20周"、"2026年" */
+function periodLabel(mode: ReadingStatsMode, offset: number): string {
+	if (mode === 'overall') return '全部';
+	const now = new Date();
+	if (mode === 'weekly') {
+		const day = now.getDay() === 0 ? 6 : now.getDay() - 1;
+		const monday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - day + offset * 7);
+		const sunday = new Date(monday.getTime() + 6 * 86400000);
+		const fmt = (d: Date) => `${d.getMonth() + 1}/${d.getDate()}`;
+		return `${monday.getFullYear()} · ${fmt(monday)} - ${fmt(sunday)}`;
+	}
+	if (mode === 'monthly') {
+		const d = new Date(now.getFullYear(), now.getMonth() + offset, 1);
+		return `${d.getFullYear()}年${d.getMonth() + 1}月`;
+	}
+	if (mode === 'annually') {
+		return `${now.getFullYear() + offset}年`;
+	}
+	return '';
+}
+
 // ─── View ─────────────────────────────────────────────────────────────────────
 
 export class WereadReadingStatsView extends ItemView {
 	private apiManager: ApiManager;
 	private syncReadingStats: SyncReadingStats;
 	private currentMode: ReadingStatsMode = 'monthly';
+	private currentOffset = 0; // 0=当前，-1=上一期，...
 	private data: ReadingStatsResponse | null = null;
 	private loading = false;
-	private contentEl2: HTMLElement; // renamed to avoid shadow
+	private contentEl2: HTMLElement;
 
 	constructor(leaf: WorkspaceLeaf, apiManager: ApiManager, syncReadingStats: SyncReadingStats) {
 		super(leaf);
@@ -75,12 +123,7 @@ export class WereadReadingStatsView extends ItemView {
 		this.loading = true;
 		this.renderLoading();
 
-		const now = new Date();
-		let baseTime: number | undefined;
-		if (this.currentMode === 'annually') {
-			baseTime = Math.floor(new Date(now.getFullYear(), 0, 1).getTime() / 1000);
-		}
-
+		const baseTime = calcBaseTime(this.currentMode, this.currentOffset);
 		const data = await this.apiManager.getReadingStats(this.currentMode, baseTime);
 		this.loading = false;
 		if (!data) {
@@ -126,7 +169,7 @@ export class WereadReadingStatsView extends ItemView {
 
 		const actions = header.createDiv({ cls: 'weread-stats-header-actions' });
 
-		// 同步统计文档按钮
+		// 导出 Markdown 按钮
 		const exportBtn = actions.createEl('button', {
 			cls: 'weread-stats-btn',
 			attr: { 'aria-label': '导出 Markdown' }
@@ -149,7 +192,7 @@ export class WereadReadingStatsView extends ItemView {
 		});
 	}
 
-	// ── Tab bar ───────────────────────────────────────────────────────
+	// ── Tab bar + 时间导航 ────────────────────────────────────────────
 	private renderTabBar(el: HTMLElement) {
 		const tabs: { mode: ReadingStatsMode; label: string }[] = [
 			{ mode: 'weekly', label: '本周' },
@@ -158,7 +201,10 @@ export class WereadReadingStatsView extends ItemView {
 			{ mode: 'overall', label: '全部' },
 		];
 
-		const bar = el.createDiv({ cls: 'weread-stats-tabbar' });
+		const nav = el.createDiv({ cls: 'weread-stats-nav' });
+
+		// Tab 胶囊
+		const bar = nav.createDiv({ cls: 'weread-stats-tabbar' });
 		for (const tab of tabs) {
 			const btn = bar.createEl('button', {
 				text: tab.label,
@@ -167,6 +213,41 @@ export class WereadReadingStatsView extends ItemView {
 			btn.addEventListener('click', () => {
 				if (this.currentMode === tab.mode) return;
 				this.currentMode = tab.mode;
+				this.currentOffset = 0;
+				this.data = null;
+				this.render();
+				this.loadData();
+			});
+		}
+
+		// 时间导航（overall 不需要）
+		if (this.currentMode !== 'overall') {
+			const timePicker = nav.createDiv({ cls: 'weread-stats-timepicker' });
+
+			const prevBtn = timePicker.createEl('button', { cls: 'weread-stats-timepicker-btn' });
+			setIcon(prevBtn, 'chevron-left');
+			prevBtn.addEventListener('click', () => {
+				this.currentOffset--;
+				this.data = null;
+				this.render();
+				this.loadData();
+			});
+
+			timePicker.createSpan({
+				cls: 'weread-stats-timepicker-label',
+				text: periodLabel(this.currentMode, this.currentOffset)
+			});
+
+			const nextBtn = timePicker.createEl('button', {
+				cls: 'weread-stats-timepicker-btn' + (this.currentOffset >= 0 ? ' is-disabled' : '')
+			});
+			setIcon(nextBtn, 'chevron-right');
+			if (this.currentOffset >= 0) {
+				nextBtn.setAttribute('disabled', 'true');
+			}
+			nextBtn.addEventListener('click', () => {
+				if (this.currentOffset >= 0) return;
+				this.currentOffset++;
 				this.data = null;
 				this.render();
 				this.loadData();
@@ -178,17 +259,11 @@ export class WereadReadingStatsView extends ItemView {
 	private renderKPICards(el: HTMLElement, data: ReadingStatsResponse) {
 		const grid = el.createDiv({ cls: 'weread-stats-kpi-grid' });
 
-		// 总阅读时长
 		this.makeKPICard(grid, '阅读时长', fmtDuration(data.totalReadTime), 'clock');
-
-		// 阅读天数
 		this.makeKPICard(grid, '阅读天数', `${data.readDays} 天`, 'calendar');
-
-		// 日均时长
 		this.makeKPICard(grid, '日均时长', fmtDuration(data.dayAverageReadTime), 'trending-up',
 			data.compare !== undefined ? fmtCompare(data.compare) : null);
 
-		// 从 readStat 里找读过本数和笔记数
 		const readStat = data.readStat ?? [];
 		const readCount = readStat.find(s => s.stat === '读过')?.counts ?? '—';
 		const finishCount = readStat.find(s => s.stat === '读完')?.counts ?? '—';
@@ -228,10 +303,10 @@ export class WereadReadingStatsView extends ItemView {
 		const section = el.createDiv({ cls: 'weread-stats-section' });
 
 		const modeLabel: Record<ReadingStatsMode, string> = {
-			weekly: '每日阅读时长（本周）',
-			monthly: '每日阅读时长（本月）',
-			annually: '每月阅读时长（本年）',
-			overall: '每年阅读时长（历史）'
+			weekly: '每日阅读时长',
+			monthly: '每日阅读时长',
+			annually: '每月阅读时长',
+			overall: '每年阅读时长'
 		};
 		section.createEl('h3', { text: modeLabel[this.currentMode], cls: 'weread-stats-section-title' });
 
@@ -252,19 +327,27 @@ export class WereadReadingStatsView extends ItemView {
 	// ── Bar Chart (SVG-based) ─────────────────────────────────────────
 	private renderBarChart(parent: HTMLElement, values: number[], labels: string[]) {
 		const maxVal = Math.max(...values, 1);
-		const barW = 28;
-		const gap = 6;
+		// 根据数量动态计算 bar 宽度，最小 16px 最大 40px
+		const minBarW = 16, maxBarW = 40;
+		const gap = 4;
 		const chartH = 120;
 		const labelH = 20;
-		const totalW = (barW + gap) * values.length;
 
 		const wrapper = parent.createDiv({ cls: 'weread-stats-chart-wrapper' });
+
+		// 先渲染再根据容器宽度调整
+		const barW = Math.min(maxBarW, Math.max(minBarW,
+			Math.floor((wrapper.clientWidth || 600) / values.length) - gap
+		));
+		const totalW = (barW + gap) * values.length;
+
 		const svg = wrapper.createSvg('svg', {
 			attr: {
 				viewBox: `0 0 ${totalW} ${chartH + labelH}`,
 				width: '100%',
 				height: chartH + labelH,
-				class: 'weread-stats-bar-chart'
+				class: 'weread-stats-bar-chart',
+				preserveAspectRatio: 'xMidYMid meet'
 			}
 		});
 
@@ -273,22 +356,19 @@ export class WereadReadingStatsView extends ItemView {
 			const x = i * (barW + gap);
 			const y = chartH - barH;
 
-			// bar
 			const rect = svg.createSvg('rect', {
 				attr: {
 					x: String(x),
 					y: String(y),
 					width: String(barW),
 					height: String(barH),
-					rx: '4',
+					rx: '3',
 					class: 'weread-stats-bar' + (v === maxVal ? ' is-max' : '')
 				}
 			});
 
-			// tooltip on hover via title
 			rect.createSvg('title').textContent = `${labels[i]}: ${fmtDuration(v)}`;
 
-			// label
 			const text = svg.createSvg('text', {
 				attr: {
 					x: String(x + barW / 2),
@@ -319,10 +399,8 @@ export class WereadReadingStatsView extends ItemView {
 
 			const row = list.createDiv({ cls: 'weread-stats-book-row' });
 
-			// rank
 			row.createDiv({ cls: 'weread-stats-book-rank', text: String(i + 1) });
 
-			// cover
 			if (cover) {
 				const img = row.createEl('img', { cls: 'weread-stats-book-cover' });
 				img.src = cover;
@@ -332,18 +410,15 @@ export class WereadReadingStatsView extends ItemView {
 				setIcon(placeholder, 'book');
 			}
 
-			// info
 			const info = row.createDiv({ cls: 'weread-stats-book-info' });
 			info.createDiv({ cls: 'weread-stats-book-title', text: title });
 			if (author) info.createDiv({ cls: 'weread-stats-book-author', text: author });
 
-			// tags
 			if (item.tags?.length) {
 				const tagRow = info.createDiv({ cls: 'weread-stats-book-tags' });
 				item.tags.forEach(tag => tagRow.createSpan({ cls: 'weread-stats-tag', text: tag }));
 			}
 
-			// progress bar + duration
 			const right = row.createDiv({ cls: 'weread-stats-book-right' });
 			right.createDiv({ cls: 'weread-stats-book-duration', text: fmtDuration(item.readTime) });
 			const barTrack = right.createDiv({ cls: 'weread-stats-mini-bar-track' });
@@ -364,7 +439,6 @@ export class WereadReadingStatsView extends ItemView {
 
 		const prefGrid = section.createDiv({ cls: 'weread-stats-pref-grid' });
 
-		// 分类偏好
 		if (hasCat) {
 			const cats = data.preferCategory.filter(c => c.readingTime > 0);
 			const maxCatTime = Math.max(...cats.map(c => c.readingTime), 1);
@@ -387,7 +461,6 @@ export class WereadReadingStatsView extends ItemView {
 			});
 		}
 
-		// 作者偏好
 		if (hasAuthor) {
 			const authorCard = prefGrid.createDiv({ cls: 'weread-stats-pref-card' });
 			const authorHeader = authorCard.createDiv({ cls: 'weread-stats-pref-card-header' });
@@ -401,7 +474,6 @@ export class WereadReadingStatsView extends ItemView {
 			});
 		}
 
-		// 阅读时段
 		if (hasTime) {
 			const timeCard = prefGrid.createDiv({ cls: 'weread-stats-pref-card weread-stats-pref-card-wide' });
 			const timeHeader = timeCard.createDiv({ cls: 'weread-stats-pref-card-header' });
@@ -428,7 +500,7 @@ export class WereadReadingStatsView extends ItemView {
 		}
 	}
 
-	// ── Yearly Overview (overall only) ────────────────────────────────
+	// ── Yearly Overview ────────────────────────────────────────────────
 	private renderYearlyOverview(el: HTMLElement, data: ReadingStatsResponse) {
 		if (!data.readTimes || Object.keys(data.readTimes).length === 0) return;
 		if (this.currentMode !== 'overall') return;

--- a/src/components/wereadReadingStats.ts
+++ b/src/components/wereadReadingStats.ts
@@ -1,4 +1,4 @@
-import { ItemView, Menu, WorkspaceLeaf, setIcon, TFile } from 'obsidian';
+import { ItemView, Menu, WorkspaceLeaf, setIcon, TFile, Vault } from 'obsidian';
 import ApiManager from '../api';
 import FileManager from '../fileManager';
 import { settingsStore } from '../settings';
@@ -30,6 +30,14 @@ function niceTickLabel(seconds: number): string {
 		return m === 0 ? `${h}小时` : `${h}小时${m}分`;
 	}
 	return `${mins}分钟`;
+}
+
+/** 用第 p 百分位数（0–100）代替 max，避免极值压平颜色分布 */
+function percentile(values: number[], p: number): number {
+	if (values.length === 0) return 1;
+	const sorted = [...values].sort((a, b) => a - b);
+	const idx = Math.floor((p / 100) * (sorted.length - 1));
+	return sorted[idx] || 1;
 }
 
 /** 计算"好看"的最大刻度（向上取整到整数分钟/整数半小时/整数小时） */
@@ -134,7 +142,49 @@ function buildWeekValues(
 	return { values, labels };
 }
 
-// ─── View ─────────────────────────────────────────────────────────────────────
+// ─── Daily stats disk cache ───────────────────────────────────────────────────
+
+const CACHE_DIR = '.weread-cache';
+const CACHE_FILE = `${CACHE_DIR}/daily-stats.json`;
+
+interface DailyStatsCache {
+	version: number;
+	// key = "YYYY-M-D", value = seconds
+	data: Record<string, number>;
+	// tracks which months have been fetched: key = "YYYY-M"
+	fetchedMonths: string[];
+}
+
+async function loadDailyCache(vault: Vault): Promise<DailyStatsCache> {
+	try {
+		const file = vault.getAbstractFileByPath(CACHE_FILE);
+		if (file instanceof TFile) {
+			const raw = await vault.read(file);
+			return JSON.parse(raw) as DailyStatsCache;
+		}
+	} catch (_) { /* ignore */ }
+	return { version: 1, data: {}, fetchedMonths: [] };
+}
+
+async function saveDailyCache(vault: Vault, cache: DailyStatsCache): Promise<void> {
+	try {
+		const exists = await vault.adapter.exists(CACHE_DIR);
+		if (!exists) await vault.adapter.mkdir(CACHE_DIR);
+		const json = JSON.stringify(cache);
+		const file = vault.getAbstractFileByPath(CACHE_FILE);
+		if (file instanceof TFile) {
+			await vault.modify(file, json);
+		} else {
+			await vault.create(CACHE_FILE, json);
+		}
+	} catch (e) {
+		console.error('[weread] Failed to save daily stats cache', e);
+	}
+}
+
+
+
+type ChartView = 'bar' | 'calendar' | 'heatmap';
 
 export class WereadReadingStatsView extends ItemView {
 	private apiManager: ApiManager;
@@ -144,6 +194,8 @@ export class WereadReadingStatsView extends ItemView {
 	private data: ReadingStatsResponse | null = null;
 	private loading = false;
 	private statsEl: HTMLElement;
+	// chart view preference per mode
+	private chartView: Partial<Record<ReadingStatsMode, ChartView>> = {};
 
 	constructor(leaf: WorkspaceLeaf, apiManager: ApiManager, fileManager: FileManager) {
 		super(leaf);
@@ -152,7 +204,7 @@ export class WereadReadingStatsView extends ItemView {
 	}
 
 	getViewType(): string { return WEREAD_READING_STATS_VIEW_ID; }
-	getDisplayText(): string { return '阅读统计'; }
+	getDisplayText(): string { return '微信读书阅读统计'; }
 	getIcon(): string { return 'bar-chart-2'; }
 
 	onMoreOptionsMenu(menu: Menu) {
@@ -176,7 +228,10 @@ export class WereadReadingStatsView extends ItemView {
 		this.loadData();
 	}
 
-	async onClose() { this.contentEl.empty(); }
+	async onClose() {
+		this.contentEl.empty();
+	}
+
 
 	private async loadData() {
 		const settings = get(settingsStore);
@@ -213,7 +268,7 @@ export class WereadReadingStatsView extends ItemView {
 		const titleRow = header.createDiv({ cls: 'weread-stats-title-row' });
 		const icon = titleRow.createSpan({ cls: 'weread-stats-header-icon' });
 		setIcon(icon, 'bar-chart-2');
-		titleRow.createEl('h2', { text: '阅读统计', cls: 'weread-stats-title' });
+		titleRow.createEl('h2', { text: '微信读书阅读统计', cls: 'weread-stats-title' });
 	}
 
 	// ── Tab bar + 时间导航 ────────────────────────────────────────────
@@ -348,33 +403,462 @@ export class WereadReadingStatsView extends ItemView {
 		if (!data.readTimes || Object.keys(data.readTimes).length === 0) return;
 
 		const section = el.createDiv({ cls: 'weread-stats-section' });
+
+		// Section title row with view toggle buttons
+		const titleRow = section.createDiv({ cls: 'weread-stats-section-title-row' });
+		const availableViews = this.getAvailableViews();
+		const currentView = this.chartView[this.currentMode] ?? this.getDefaultView(this.currentMode);
 		const modeLabel: Record<ReadingStatsMode, string> = {
 			weekly: '每日阅读时长', monthly: '每日阅读时长',
 			annually: '每月阅读时长', overall: '每年阅读时长'
 		};
-		section.createEl('h3', { text: modeLabel[this.currentMode], cls: 'weread-stats-section-title' });
+		// 年份tab下，heatmap视图显示每日，bar/calendar视图显示每月
+		const sectionTitle = this.currentMode === 'annually' && currentView === 'heatmap'
+			? '每日阅读时长'
+			: modeLabel[this.currentMode];
+		titleRow.createEl('h3', { text: sectionTitle, cls: 'weread-stats-section-title' });
 
-		let values: number[];
-		let labels: string[];
-
-		if (this.currentMode === 'weekly') {
-			const baseTime = calcBaseTime('weekly', this.currentOffset);
-			const built = buildWeekValues(data.readTimes, baseTime);
-			values = built.values;
-			labels = built.labels;
-		} else {
-			const entries = Object.entries(data.readTimes).sort(([a], [b]) => Number(a) - Number(b));
-			values = entries.map(([, v]) => v as number);
-			labels = entries.map(([ts]) => {
-				const d = new Date(Number(ts) * 1000);
-				if (this.currentMode === 'overall') return `${d.getFullYear()}`;
-				if (this.currentMode === 'annually') return `${d.getMonth() + 1}月`;
-				return `${d.getDate()}`;
-			});
+		if (availableViews.length > 1) {
+			const toggleGroup = titleRow.createDiv({ cls: 'weread-stats-view-toggle' });
+			const viewIcons: Record<ChartView, string> = { bar: 'bar-chart-2', calendar: 'calendar-days', heatmap: 'layout-grid' };
+			const viewTitles: Record<ChartView, string> = { bar: '柱状图', calendar: '日历', heatmap: '热力图' };
+			for (const v of availableViews) {
+				const btn = toggleGroup.createEl('button', {
+					cls: 'weread-stats-view-toggle-btn' + (currentView === v ? ' is-active' : ''),
+					attr: { title: viewTitles[v] }
+				});
+				setIcon(btn, viewIcons[v]);
+				btn.addEventListener('click', () => {
+					this.chartView[this.currentMode] = v;
+					this.render();
+				});
+			}
 		}
 
-		this.renderBarChart(section, values, labels);
+		const chartArea = section.createDiv({ cls: 'weread-stats-chart-area' });
+
+		if (currentView === 'calendar' && this.currentMode === 'monthly') {
+			this.renderMonthCalendar(chartArea, data.readTimes);
+		} else if (currentView === 'heatmap' && this.currentMode === 'annually') {
+			this.renderYearHeatmap(chartArea, data);
+		} else if (currentView === 'heatmap' && this.currentMode === 'overall') {
+			this.renderOverallHeatmap(chartArea, data);
+		} else {
+			// bar chart
+			let values: number[];
+			let labels: string[];
+			if (this.currentMode === 'weekly') {
+				const baseTime = calcBaseTime('weekly', this.currentOffset);
+				const built = buildWeekValues(data.readTimes, baseTime);
+				values = built.values;
+				labels = built.labels;
+			} else {
+				const entries = Object.entries(data.readTimes).sort(([a], [b]) => Number(a) - Number(b));
+				values = entries.map(([, v]) => v as number);
+				labels = entries.map(([ts]) => {
+					const d = new Date(Number(ts) * 1000);
+					if (this.currentMode === 'overall') return `${d.getFullYear()}`;
+					if (this.currentMode === 'annually') return `${d.getMonth() + 1}月`;
+					return `${d.getDate()}`;
+				});
+			}
+			this.renderBarChart(chartArea, values, labels);
+		}
 	}
+
+	private getAvailableViews(): ChartView[] {
+		if (this.currentMode === 'monthly') return ['bar', 'calendar'];
+		if (this.currentMode === 'annually') return ['heatmap', 'bar'];
+		if (this.currentMode === 'overall') return ['heatmap', 'bar'];
+		return ['bar'];
+	}
+
+	private getDefaultView(mode: ReadingStatsMode): ChartView {
+		if (mode === 'monthly') return 'bar';
+		if (mode === 'annually') return 'heatmap';
+		if (mode === 'overall') return 'heatmap';
+		return 'bar';
+	}
+
+	// ── Month Calendar ────────────────────────────────────────────────
+	private renderMonthCalendar(parent: HTMLElement, readTimes: Record<string, number>) {
+		// Determine year/month from baseTime or current date
+		const baseTime = calcBaseTime('monthly', this.currentOffset);
+		const refDate = baseTime ? new Date(baseTime * 1000) : new Date();
+		const year = refDate.getFullYear();
+		const month = refDate.getMonth(); // 0-indexed
+
+		// Build a map: day (1-31) -> seconds
+		const dayMap: Record<number, number> = {};
+		for (const [ts, secs] of Object.entries(readTimes)) {
+			const d = new Date(Number(ts) * 1000);
+			if (d.getFullYear() === year && d.getMonth() === month) {
+				dayMap[d.getDate()] = secs as number;
+			}
+		}
+		const dayValues = Object.values(dayMap).filter(v => v > 0);
+		const maxVal = percentile(dayValues, 95);
+
+		const cal = parent.createDiv({ cls: 'weread-calendar' });
+
+		// Weekday headers (Mon - Sun)
+		const dayNames = ['一', '二', '三', '四', '五', '六', '日'];
+		const headerRow = cal.createDiv({ cls: 'weread-calendar-header' });
+		for (const d of dayNames) {
+			headerRow.createDiv({ cls: 'weread-calendar-dow', text: d });
+		}
+
+		// First day of month (0=Sun..6=Sat) → convert to Mon-based (0=Mon..6=Sun)
+		const firstDow = new Date(year, month, 1).getDay();
+		const startOffset = firstDow === 0 ? 6 : firstDow - 1;
+		const daysInMonth = new Date(year, month + 1, 0).getDate();
+		const today = new Date();
+
+		const grid = cal.createDiv({ cls: 'weread-calendar-grid' });
+
+		// Empty cells before first day
+		for (let i = 0; i < startOffset; i++) {
+			grid.createDiv({ cls: 'weread-calendar-cell is-empty' });
+		}
+
+		for (let day = 1; day <= daysInMonth; day++) {
+			const secs = dayMap[day] ?? 0;
+			const intensity = maxVal > 0 ? Math.min(secs / maxVal, 1) : 0;
+			const cell = grid.createDiv({ cls: 'weread-calendar-cell' });
+
+			// Intensity level 0-4
+			const level = secs === 0 ? 0 : Math.max(1, Math.ceil(intensity * 4));
+			cell.addClass(`weread-cal-level-${level}`);
+
+			const isToday = today.getFullYear() === year && today.getMonth() === month && today.getDate() === day;
+			if (isToday) cell.addClass('is-today');
+
+			cell.createDiv({ cls: 'weread-calendar-day', text: String(day) });
+			if (secs > 0) {
+				cell.createDiv({ cls: 'weread-calendar-duration', text: fmtDuration(secs) });
+			}
+			if (secs > 0) {
+				cell.setAttribute('title', `${month + 1}月${day}日：${fmtDuration(secs)}`);
+			}
+		}
+
+		// Fill trailing empty cells to complete the last row
+		const totalCells = startOffset + daysInMonth;
+		const remainder = totalCells % 7;
+		if (remainder !== 0) {
+			for (let i = 0; i < 7 - remainder; i++) {
+				grid.createDiv({ cls: 'weread-calendar-cell is-empty' });
+			}
+		}
+
+	}
+
+	// ── Year Heatmap via cal-heatmap ──────────────────────────────────
+	private renderYearHeatmap(parent: HTMLElement, data: ReadingStatsResponse) {
+		if ((data as any)._dailyReadTimes) {
+			this.renderCalHeatmap(parent, (data as any)._dailyReadTimes, data.readDays);
+		} else {
+			const placeholder = parent.createDiv({ cls: 'weread-heatmap-loading' });
+			placeholder.createDiv({ cls: 'weread-stats-spinner weread-stats-spinner-sm' });
+			placeholder.createDiv({ text: '正在加载全年日数据…', cls: 'weread-stats-empty-text' });
+			this.loadAnnualDailyData(data);
+		}
+	}
+
+	private async loadAnnualDailyData(data: ReadingStatsResponse) {
+		const baseTime = calcBaseTime('annually', this.currentOffset);
+		const refDate = baseTime ? new Date(baseTime * 1000) : new Date();
+		const year = refDate.getFullYear();
+		const today = new Date();
+
+		const cache = await loadDailyCache(this.app.vault);
+		let dirty = false;
+		const BATCH = 6;
+
+		const monthTimestamps = Array.from({ length: 12 }, (_, m) =>
+			Math.floor(new Date(year, m, 1).getTime() / 1000)
+		);
+
+		// Only fetch months not yet cached (skip future months)
+		const toFetch = monthTimestamps.filter(ts => {
+			const d = new Date(ts * 1000);
+			const key = `${d.getFullYear()}-${d.getMonth()}`;
+			// Always re-fetch current month (data may change), skip past months if cached
+			const isCurrentMonth = d.getFullYear() === today.getFullYear() && d.getMonth() === today.getMonth();
+			const isFuture = d > today;
+			return !isFuture && (isCurrentMonth || !cache.fetchedMonths.includes(key));
+		});
+
+		for (let i = 0; i < toFetch.length; i += BATCH) {
+			const results = await Promise.all(
+				toFetch.slice(i, i + BATCH).map(ts => this.apiManager.getReadingStats('monthly', ts))
+			);
+			for (let j = 0; j < results.length; j++) {
+				const res = results[j];
+				const ts = toFetch[i + j];
+				const d = new Date(ts * 1000);
+				const monthKey = `${d.getFullYear()}-${d.getMonth()}`;
+				if (!res?.readTimes) continue;
+				for (const [dayTs, secs] of Object.entries(res.readTimes)) {
+					const dd = new Date(Number(dayTs) * 1000);
+					cache.data[`${dd.getFullYear()}-${dd.getMonth()}-${dd.getDate()}`] = secs as number;
+				}
+				if (!cache.fetchedMonths.includes(monthKey)) {
+					cache.fetchedMonths.push(monthKey);
+				}
+				dirty = true;
+			}
+		}
+
+		if (dirty) await saveDailyCache(this.app.vault, cache);
+
+		// Build dailyMap from cache for this year
+		const dailyMap: Record<string, number> = {};
+		for (const [k, v] of Object.entries(cache.data)) {
+			if (k.startsWith(`${year}-`)) dailyMap[k] = v;
+		}
+		(data as any)._dailyReadTimes = dailyMap;
+		this.render();
+	}
+
+	// ── Overall Heatmap (all years) ────────────────────────────────────
+	private renderOverallHeatmap(parent: HTMLElement, data: ReadingStatsResponse) {
+		if ((data as any)._allDailyReadTimes) {
+			this.renderAllYearsHeatmap(parent, (data as any)._allDailyReadTimes, data);
+		} else {
+			const placeholder = parent.createDiv({ cls: 'weread-heatmap-loading' });
+			placeholder.createDiv({ cls: 'weread-stats-spinner weread-stats-spinner-sm' });
+			placeholder.createDiv({ text: '正在加载全部阅读数据…', cls: 'weread-stats-empty-text' });
+			this.loadOverallDailyData(data);
+		}
+	}
+
+	private async loadOverallDailyData(data: ReadingStatsResponse) {
+		const today = new Date();
+		const endYear = today.getFullYear();
+		const settings = get(settingsStore);
+		const startYear = settings.statsStartYear && settings.statsStartYear > 2000
+			? settings.statsStartYear
+			: data.registTime
+				? new Date(data.registTime * 1000).getFullYear()
+				: endYear - 2;
+
+		// Collect all month timestamps from startYear to now
+		const monthTimestamps: number[] = [];
+		for (let y = startYear; y <= endYear; y++) {
+			for (let m = 0; m < 12; m++) {
+				monthTimestamps.push(Math.floor(new Date(y, m, 1).getTime() / 1000));
+			}
+		}
+
+		const cache = await loadDailyCache(this.app.vault);
+		let dirty = false;
+		const BATCH = 6;
+
+		// Only fetch uncached months (always re-fetch current month)
+		const toFetch = monthTimestamps.filter(ts => {
+			const d = new Date(ts * 1000);
+			const key = `${d.getFullYear()}-${d.getMonth()}`;
+			const isCurrentMonth = d.getFullYear() === today.getFullYear() && d.getMonth() === today.getMonth();
+			const isFuture = d > today;
+			return !isFuture && (isCurrentMonth || !cache.fetchedMonths.includes(key));
+		});
+
+		for (let i = 0; i < toFetch.length; i += BATCH) {
+			const results = await Promise.all(
+				toFetch.slice(i, i + BATCH).map(ts => this.apiManager.getReadingStats('monthly', ts))
+			);
+			for (let j = 0; j < results.length; j++) {
+				const res = results[j];
+				const ts = toFetch[i + j];
+				const d = new Date(ts * 1000);
+				const monthKey = `${d.getFullYear()}-${d.getMonth()}`;
+				if (!res?.readTimes) continue;
+				for (const [dayTs, secs] of Object.entries(res.readTimes)) {
+					const dd = new Date(Number(dayTs) * 1000);
+					cache.data[`${dd.getFullYear()}-${dd.getMonth()}-${dd.getDate()}`] = secs as number;
+				}
+				if (!cache.fetchedMonths.includes(monthKey)) {
+					cache.fetchedMonths.push(monthKey);
+				}
+				dirty = true;
+			}
+			if (i + BATCH < toFetch.length) {
+				await new Promise(r => setTimeout(r, 200));
+			}
+		}
+
+		if (dirty) await saveDailyCache(this.app.vault, cache);
+
+		(data as any)._allDailyReadTimes = cache.data;
+		(data as any)._statsStartYear = startYear;
+		this.render();
+	}
+
+	private renderAllYearsHeatmap(parent: HTMLElement, dailyMap: Record<string, number>, data: ReadingStatsResponse) {
+		const today = new Date();
+		const endYear = today.getFullYear();
+		const settings = get(settingsStore);
+		const startYear = (data as any)._statsStartYear
+			?? (settings.statsStartYear && settings.statsStartYear > 2000
+				? settings.statsStartYear
+				: data.registTime
+					? new Date(data.registTime * 1000).getFullYear()
+					: endYear - 2);
+
+		// dailyMap keys are already "YYYY-M-D" format from cache
+		const dayMap = dailyMap;
+
+		// Use p95 to avoid extreme outliers (e.g. all-day audio) skewing colours
+		const globalMax = percentile(Object.values(dayMap).filter(v => v > 0), 95);
+		const getLevel = (secs: number) => {
+			if (secs === 0) return 0;
+			const ratio = Math.min(secs / globalMax, 1);
+			if (ratio < 0.25) return 1;
+			if (ratio < 0.50) return 2;
+			if (ratio < 0.75) return 3;
+			return 4;
+		};
+
+		const wrap = parent.createDiv({ cls: 'weread-allheatmap-wrap' });
+
+		for (let year = endYear; year >= startYear; year--) {
+			const yearWrap = wrap.createDiv({ cls: 'weread-allheatmap-year' });
+			yearWrap.createDiv({ cls: 'weread-allheatmap-yearlabel', text: String(year) });
+			this.renderCalHeatmapInto(yearWrap, dayMap, year, today, getLevel);
+		}
+
+		// Legend
+		const legend = wrap.createDiv({ cls: 'weread-ghmap-legend' });
+		legend.createSpan({ cls: 'weread-ghmap-legend-text', text: '少' });
+		for (let l = 0; l <= 4; l++) {
+			legend.createDiv({ cls: `weread-ghmap-cell level-${l}` });
+		}
+		legend.createSpan({ cls: 'weread-ghmap-legend-text', text: '多' });
+	}
+
+	private renderCalHeatmapInto(
+		parent: HTMLElement,
+		dayMap: Record<string, number>,
+		year: number,
+		today: Date,
+		getLevel: (secs: number) => number
+	) {
+		const allDays: { date: Date; secs: number }[] = [];
+		for (let m = 0; m < 12; m++) {
+			const daysInMonth = new Date(year, m + 1, 0).getDate();
+			for (let d = 1; d <= daysInMonth; d++) {
+				const date = new Date(year, m, d);
+				allDays.push({ date, secs: dayMap[`${year}-${m}-${d}`] ?? 0 });
+			}
+		}
+
+		const firstDow = allDays[0].date.getDay();
+		const startPad = firstDow === 0 ? 6 : firstDow - 1;
+		const paddedDays: ({ date: Date; secs: number } | null)[] = [
+			...Array(startPad).fill(null),
+			...allDays,
+		];
+		const totalWeeks = Math.ceil(paddedDays.length / 7);
+
+		// Month → first week index
+		const monthWeek: Record<number, number> = {};
+		for (let w = 0; w < totalWeeks; w++) {
+			for (let dow = 0; dow < 7; dow++) {
+				const item = paddedDays[w * 7 + dow];
+				if (!item) continue;
+				const mo = item.date.getMonth();
+				if (!(mo in monthWeek)) monthWeek[mo] = w;
+			}
+		}
+
+		const inner = parent.createDiv({ cls: 'weread-ghmap-inner' });
+
+		// Weekday labels
+		const labelsCol = inner.createDiv({ cls: 'weread-ghmap-daylabels' });
+		const dayLabels = ['一', '三', '五'];
+		const dayRows = [0, 2, 4];
+		for (let i = 0; i < 7; i++) {
+			const idx = dayRows.indexOf(i);
+			labelsCol.createDiv({ cls: 'weread-ghmap-daylabel', text: idx >= 0 ? dayLabels[idx] : '' });
+		}
+
+		const rightCol = inner.createDiv({ cls: 'weread-ghmap-right' });
+
+		// Month labels — each label is exactly (CELL_W + GAP) px wide to align with columns
+		const CELL_W = 13;
+		const GAP = 3;
+		const COL_W = CELL_W + GAP; // 16px per week column
+		const monthRow = rightCol.createDiv({ cls: 'weread-ghmap-months' });
+		for (let w = 0; w < totalWeeks; w++) {
+			const mo = Object.entries(monthWeek).find(([, wk]) => wk === w);
+			const label = monthRow.createDiv({ cls: 'weread-ghmap-monthlabel', text: mo ? `${Number(mo[0]) + 1}月` : '' });
+			label.style.width = `${COL_W}px`;
+			label.style.flexShrink = '0';
+		}
+
+		// Cell grid
+		const grid = rightCol.createDiv({ cls: 'weread-ghmap-grid' });
+
+		for (let w = 0; w < totalWeeks; w++) {
+			const col = grid.createDiv({ cls: 'weread-ghmap-col' });
+			for (let dow = 0; dow < 7; dow++) {
+				const item = paddedDays[w * 7 + dow];
+				if (!item) { col.createDiv({ cls: 'weread-ghmap-cell is-empty' }); continue; }
+				const { date, secs } = item;
+				const level = getLevel(secs);
+				const isToday = date.toDateString() === today.toDateString();
+				const cell = col.createDiv({ cls: `weread-ghmap-cell level-${level}${isToday ? ' is-today' : ''}` });
+				const label = `${date.getMonth() + 1}月${date.getDate()}日`;
+				cell.title = secs > 0 ? `${label}：${fmtDuration(secs)}` : label;
+			}
+		}
+	}
+
+	private renderCalHeatmap(parent: HTMLElement, dailyMap: Record<string, number>, apiReadDays?: number) {
+		const baseTime = calcBaseTime('annually', this.currentOffset);
+		const refDate = baseTime ? new Date(baseTime * 1000) : new Date();
+		const year = refDate.getFullYear();
+		const today = new Date();
+
+		// Keys are already "year-month-day" strings (0-indexed month), use directly
+		const dayMap: Record<string, number> = dailyMap;
+
+		// Per-year p95 for colour scale (avoids outliers like all-day audio)
+		const yearVals = Object.entries(dayMap)
+			.filter(([k]) => k.startsWith(`${year}-`))
+			.map(([, v]) => v).filter(v => v > 0);
+		const maxVal = percentile(yearVals, 95);
+		const getLevel = (secs: number) => {
+			if (secs === 0) return 0;
+			const ratio = Math.min(secs / maxVal, 1);
+			if (ratio < 0.25) return 1;
+			if (ratio < 0.50) return 2;
+			if (ratio < 0.75) return 3;
+			return 4;
+		};
+
+		const wrap = parent.createDiv({ cls: 'weread-ghmap-wrap' });
+		this.renderCalHeatmapInto(wrap, dayMap, year, today, getLevel);
+
+		// Legend
+		const legend = wrap.createDiv({ cls: 'weread-ghmap-legend' });
+		legend.createSpan({ cls: 'weread-ghmap-legend-text', text: '少' });
+		for (let l = 0; l <= 4; l++) {
+			legend.createDiv({ cls: `weread-ghmap-cell level-${l}` });
+		}
+		legend.createSpan({ cls: 'weread-ghmap-legend-text', text: '多' });
+
+		// Summary
+		const allDays = Object.entries(dayMap).filter(([k]) => k.startsWith(`${year}-`));
+		const displayReadDays = apiReadDays ?? allDays.filter(([, v]) => v > 0).length;
+		const totalSecs = allDays.reduce((s, [, v]) => s + v, 0);
+		wrap.createDiv({
+			cls: 'weread-heatmap-summary',
+			text: `${year} 年共阅读 ${displayReadDays} 天，累计 ${fmtDuration(totalSecs)}`
+		});
+	}
+
 
 	// ── Bar Chart (SVG) with Y-axis scale ────────────────────────────
 	private renderBarChart(parent: HTMLElement, values: number[], labels: string[]) {

--- a/src/components/wereadReadingStats.ts
+++ b/src/components/wereadReadingStats.ts
@@ -309,8 +309,12 @@ export class WereadReadingStatsView extends ItemView {
 	private renderKPICards(el: HTMLElement, data: ReadingStatsResponse) {
 		const grid = el.createDiv({ cls: 'weread-stats-kpi-grid' });
 		this.makeKPICard(grid, '阅读天数', `${data.readDays} 天`, 'calendar');
-		this.makeKPICard(grid, '日均时长', fmtDuration(data.dayAverageReadTime), 'trending-up',
-			data.compare !== undefined ? fmtCompare(data.compare) : null);
+
+		// overall 模式不返回 dayAverageReadTime，跳过
+		if (this.currentMode !== 'overall') {
+			this.makeKPICard(grid, '日均时长', fmtDuration(data.dayAverageReadTime), 'trending-up',
+				data.compare !== undefined ? fmtCompare(data.compare) : null);
+		}
 
 		// 周模式不展示读过/读完/笔记（API 不返回有意义的数据）
 		if (this.currentMode !== 'weekly') {

--- a/src/components/wereadReadingStats.ts
+++ b/src/components/wereadReadingStats.ts
@@ -19,6 +19,31 @@ function fmtDuration(seconds: number): string {
 	return `${m}分钟`;
 }
 
+/** 计算"好看"的整数刻度：0、中间、最大值，尽量是整数分钟或整数小时 */
+function niceTickLabel(seconds: number): string {
+	if (seconds === 0) return '0';
+	const mins = Math.round(seconds / 60);
+	const hours = seconds / 3600;
+	if (hours >= 1 && Number.isInteger(Math.round(hours))) return `${Math.round(hours)}小时`;
+	if (mins >= 60) {
+		const h = Math.floor(mins / 60);
+		const m = mins % 60;
+		return m === 0 ? `${h}小时` : `${h}小时${m}分`;
+	}
+	return `${mins}分钟`;
+}
+
+/** 计算"好看"的最大刻度（向上取整到整数分钟/整数半小时/整数小时） */
+function niceMax(seconds: number): number {
+	if (seconds <= 0) return 60;
+	const mins = seconds / 60;
+	if (mins <= 10) return Math.ceil(mins) * 60;
+	if (mins <= 60) return Math.ceil(mins / 5) * 5 * 60;
+	if (mins <= 120) return Math.ceil(mins / 10) * 10 * 60;
+	const hours = seconds / 3600;
+	return Math.ceil(hours * 2) / 2 * 3600; // round up to half-hour
+}
+
 function fmtTs(ts: number): string {
 	if (!ts) return '—';
 	const d = new Date(ts * 1000);
@@ -31,44 +56,37 @@ function fmtCompare(compare?: number): { text: string; up: boolean } | null {
 	return { text: `${pct}%`, up: compare >= 0 };
 }
 
-// preferTime 从 6 点开始排列
 const HOUR_LABELS = ['6','7','8','9','10','11','12','13','14','15','16','17','18','19','20','21','22','23','0','1','2','3','4','5'];
-
 const WEEK_LABELS = ['一', '二', '三', '四', '五', '六', '日'];
 
 // ─── 时间偏移计算 ──────────────────────────────────────────────────────────────
 
-/** 根据 mode 和 offset（0=当前，-1=上一期，...）计算 baseTime（Unix 秒） */
 function calcBaseTime(mode: ReadingStatsMode, offset: number): number | undefined {
 	if (mode === 'overall') return undefined;
 	const now = new Date();
 	if (mode === 'weekly') {
-		// 本周一 0:00
-		const day = now.getDay() === 0 ? 6 : now.getDay() - 1; // 0=Mon
-		const monday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - day);
+		const dow = now.getDay() === 0 ? 6 : now.getDay() - 1;
+		const monday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - dow);
 		monday.setDate(monday.getDate() + offset * 7);
 		return Math.floor(monday.getTime() / 1000);
 	}
 	if (mode === 'monthly') {
-		// 本月 1 日 0:00
 		const d = new Date(now.getFullYear(), now.getMonth() + offset, 1);
 		return Math.floor(d.getTime() / 1000);
 	}
 	if (mode === 'annually') {
-		// 本年 1 月 1 日 0:00
 		const d = new Date(now.getFullYear() + offset, 0, 1);
 		return Math.floor(d.getTime() / 1000);
 	}
 	return undefined;
 }
 
-/** 当前期 label，如"2026年5月"、"2026年第20周"、"2026年" */
 function periodLabel(mode: ReadingStatsMode, offset: number): string {
 	if (mode === 'overall') return '全部';
 	const now = new Date();
 	if (mode === 'weekly') {
-		const day = now.getDay() === 0 ? 6 : now.getDay() - 1;
-		const monday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - day + offset * 7);
+		const dow = now.getDay() === 0 ? 6 : now.getDay() - 1;
+		const monday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - dow + offset * 7);
 		const sunday = new Date(monday.getTime() + 6 * 86400000);
 		const fmt = (d: Date) => `${d.getMonth() + 1}/${d.getDate()}`;
 		return `${monday.getFullYear()} · ${fmt(monday)} - ${fmt(sunday)}`;
@@ -83,6 +101,40 @@ function periodLabel(mode: ReadingStatsMode, offset: number): string {
 	return '';
 }
 
+/**
+ * 周模式：返回完整 7 天数组（一～日），每天对应秒数，
+ * 日期不在 readTimes 里则为 0
+ */
+function buildWeekValues(
+	readTimes: Record<string, number>,
+	baseTime: number | undefined
+): { values: number[]; labels: string[] } {
+	// 找到本周一的 0:00
+	let mondayTs: number;
+	if (baseTime !== undefined) {
+		mondayTs = baseTime;
+	} else {
+		const now = new Date();
+		const dow = now.getDay() === 0 ? 6 : now.getDay() - 1;
+		const monday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - dow);
+		mondayTs = Math.floor(monday.getTime() / 1000);
+	}
+
+	const values: number[] = [];
+	const labels: string[] = WEEK_LABELS.slice(); // 一二三四五六日
+	for (let d = 0; d < 7; d++) {
+		// readTimes key may be the exact day start timestamp
+		const dayTs = mondayTs + d * 86400;
+		// API may return any timestamp within that day as key; find closest match
+		const key = Object.keys(readTimes).find(k => {
+			const diff = Number(k) - dayTs;
+			return diff >= 0 && diff < 86400;
+		});
+		values.push(key ? (readTimes[key] as number) : 0);
+	}
+	return { values, labels };
+}
+
 // ─── View ─────────────────────────────────────────────────────────────────────
 
 export class WereadReadingStatsView extends ItemView {
@@ -90,7 +142,7 @@ export class WereadReadingStatsView extends ItemView {
 	private syncReadingStats: SyncReadingStats;
 	private fileManager: FileManager;
 	private currentMode: ReadingStatsMode = 'monthly';
-	private currentOffset = 0; // 0=当前，-1=上一期，...
+	private currentOffset = 0;
 	private data: ReadingStatsResponse | null = null;
 	private loading = false;
 	private contentEl2: HTMLElement;
@@ -115,26 +167,17 @@ export class WereadReadingStatsView extends ItemView {
 		this.loadData();
 	}
 
-	async onClose() {
-		this.containerEl.empty();
-	}
+	async onClose() { this.containerEl.empty(); }
 
 	private async loadData() {
 		const settings = get(settingsStore);
-		if (!settings.wereadApiKey) {
-			this.renderNoApiKey();
-			return;
-		}
+		if (!settings.wereadApiKey) { this.renderNoApiKey(); return; }
 		this.loading = true;
 		this.renderLoading();
-
 		const baseTime = calcBaseTime(this.currentMode, this.currentOffset);
 		const data = await this.apiManager.getReadingStats(this.currentMode, baseTime);
 		this.loading = false;
-		if (!data) {
-			this.renderError();
-			return;
-		}
+		if (!data) { this.renderError(); return; }
 		this.data = data;
 		this.render();
 	}
@@ -142,15 +185,8 @@ export class WereadReadingStatsView extends ItemView {
 	private render() {
 		const el = this.contentEl2;
 		el.empty();
-
-		if (!get(settingsStore).wereadApiKey) {
-			this.renderNoApiKey();
-			return;
-		}
-		if (this.loading) {
-			this.renderLoading();
-			return;
-		}
+		if (!get(settingsStore).wereadApiKey) { this.renderNoApiKey(); return; }
+		if (this.loading) { this.renderLoading(); return; }
 		if (!this.data) return;
 
 		this.renderHeader(el);
@@ -159,7 +195,7 @@ export class WereadReadingStatsView extends ItemView {
 		this.renderTimeSeries(el, this.data);
 		this.renderTopBooks(el, this.data);
 		this.renderPreferences(el, this.data);
-		if (this.currentMode === 'overall' || this.currentMode === 'annually') {
+		if (this.currentMode === 'overall') {
 			this.renderYearlyOverview(el, this.data);
 		}
 	}
@@ -173,28 +209,14 @@ export class WereadReadingStatsView extends ItemView {
 		titleRow.createEl('h2', { text: '阅读统计', cls: 'weread-stats-title' });
 
 		const actions = header.createDiv({ cls: 'weread-stats-header-actions' });
-
-		// 导出 Markdown 按钮
-		const exportBtn = actions.createEl('button', {
-			cls: 'weread-stats-btn',
-			attr: { 'aria-label': '导出 Markdown' }
-		});
+		const exportBtn = actions.createEl('button', { cls: 'weread-stats-btn', attr: { 'aria-label': '导出 Markdown' } });
 		setIcon(exportBtn, 'file-text');
 		exportBtn.createSpan({ text: '导出 Markdown' });
-		exportBtn.addEventListener('click', () => {
-			this.syncReadingStats.sync();
-		});
+		exportBtn.addEventListener('click', () => this.syncReadingStats.sync());
 
-		// 刷新按钮
-		const refreshBtn = actions.createEl('button', {
-			cls: 'weread-stats-btn weread-stats-btn-icon',
-			attr: { 'aria-label': '刷新数据' }
-		});
+		const refreshBtn = actions.createEl('button', { cls: 'weread-stats-btn weread-stats-btn-icon', attr: { 'aria-label': '刷新数据' } });
 		setIcon(refreshBtn, 'refresh-ccw');
-		refreshBtn.addEventListener('click', () => {
-			this.data = null;
-			this.loadData();
-		});
+		refreshBtn.addEventListener('click', () => { this.data = null; this.loadData(); });
 	}
 
 	// ── Tab bar + 时间导航 ────────────────────────────────────────────
@@ -205,10 +227,7 @@ export class WereadReadingStatsView extends ItemView {
 			{ mode: 'annually', label: '本年' },
 			{ mode: 'overall', label: '全部' },
 		];
-
 		const nav = el.createDiv({ cls: 'weread-stats-nav' });
-
-		// Tab 胶囊
 		const bar = nav.createDiv({ cls: 'weread-stats-tabbar' });
 		for (const tab of tabs) {
 			const btn = bar.createEl('button', {
@@ -225,67 +244,40 @@ export class WereadReadingStatsView extends ItemView {
 			});
 		}
 
-		// 时间导航（overall 不需要）
 		if (this.currentMode !== 'overall') {
 			const timePicker = nav.createDiv({ cls: 'weread-stats-timepicker' });
-
 			const prevBtn = timePicker.createEl('button', { cls: 'weread-stats-timepicker-btn' });
 			setIcon(prevBtn, 'chevron-left');
-			prevBtn.addEventListener('click', () => {
-				this.currentOffset--;
-				this.data = null;
-				this.render();
-				this.loadData();
-			});
-
-			timePicker.createSpan({
-				cls: 'weread-stats-timepicker-label',
-				text: periodLabel(this.currentMode, this.currentOffset)
-			});
-
-			const nextBtn = timePicker.createEl('button', {
-				cls: 'weread-stats-timepicker-btn' + (this.currentOffset >= 0 ? ' is-disabled' : '')
-			});
+			prevBtn.addEventListener('click', () => { this.currentOffset--; this.data = null; this.render(); this.loadData(); });
+			timePicker.createSpan({ cls: 'weread-stats-timepicker-label', text: periodLabel(this.currentMode, this.currentOffset) });
+			const nextBtn = timePicker.createEl('button', { cls: 'weread-stats-timepicker-btn' + (this.currentOffset >= 0 ? ' is-disabled' : '') });
 			setIcon(nextBtn, 'chevron-right');
-			if (this.currentOffset >= 0) {
-				nextBtn.setAttribute('disabled', 'true');
-			}
-			nextBtn.addEventListener('click', () => {
-				if (this.currentOffset >= 0) return;
-				this.currentOffset++;
-				this.data = null;
-				this.render();
-				this.loadData();
-			});
+			if (this.currentOffset >= 0) nextBtn.setAttribute('disabled', 'true');
+			nextBtn.addEventListener('click', () => { if (this.currentOffset >= 0) return; this.currentOffset++; this.data = null; this.render(); this.loadData(); });
 		}
 	}
 
 	// ── KPI Cards ─────────────────────────────────────────────────────
 	private renderKPICards(el: HTMLElement, data: ReadingStatsResponse) {
 		const grid = el.createDiv({ cls: 'weread-stats-kpi-grid' });
-
 		this.makeKPICard(grid, '阅读时长', fmtDuration(data.totalReadTime), 'clock');
 		this.makeKPICard(grid, '阅读天数', `${data.readDays} 天`, 'calendar');
 		this.makeKPICard(grid, '日均时长', fmtDuration(data.dayAverageReadTime), 'trending-up',
 			data.compare !== undefined ? fmtCompare(data.compare) : null);
 
-		const readStat = data.readStat ?? [];
-		const readCount = readStat.find(s => s.stat === '读过')?.counts ?? '—';
-		const finishCount = readStat.find(s => s.stat === '读完')?.counts ?? '—';
-		const noteCount = readStat.find(s => s.stat === '笔记')?.counts ?? '—';
-
-		this.makeKPICard(grid, '读过', readCount, 'book-open');
-		this.makeKPICard(grid, '读完', finishCount, 'check-circle');
-		this.makeKPICard(grid, '笔记', noteCount, 'pencil');
+		// 周模式不展示读过/读完/笔记（API 不返回有意义的数据）
+		if (this.currentMode !== 'weekly') {
+			const readStat = data.readStat ?? [];
+			const readCount = readStat.find(s => s.stat === '读过')?.counts ?? '—';
+			const finishCount = readStat.find(s => s.stat === '读完')?.counts ?? '—';
+			const noteCount = readStat.find(s => s.stat === '笔记')?.counts ?? '—';
+			this.makeKPICard(grid, '读过', readCount, 'book-open');
+			this.makeKPICard(grid, '读完', finishCount, 'check-circle');
+			this.makeKPICard(grid, '笔记', noteCount, 'pencil');
+		}
 	}
 
-	private makeKPICard(
-		parent: HTMLElement,
-		label: string,
-		value: string,
-		iconName: string,
-		compare?: { text: string; up: boolean } | null
-	) {
+	private makeKPICard(parent: HTMLElement, label: string, value: string, iconName: string, compare?: { text: string; up: boolean } | null) {
 		const card = parent.createDiv({ cls: 'weread-stats-kpi-card' });
 		const iconEl = card.createDiv({ cls: 'weread-stats-kpi-icon' });
 		setIcon(iconEl, iconName);
@@ -301,58 +293,52 @@ export class WereadReadingStatsView extends ItemView {
 		}
 	}
 
-	// ── Time Series Chart ─────────────────────────────────────────────
+	// ── Time Series ───────────────────────────────────────────────────
 	private renderTimeSeries(el: HTMLElement, data: ReadingStatsResponse) {
 		if (!data.readTimes || Object.keys(data.readTimes).length === 0) return;
 
 		const section = el.createDiv({ cls: 'weread-stats-section' });
-
 		const modeLabel: Record<ReadingStatsMode, string> = {
-			weekly: '每日阅读时长',
-			monthly: '每日阅读时长',
-			annually: '每月阅读时长',
-			overall: '每年阅读时长'
+			weekly: '每日阅读时长', monthly: '每日阅读时长',
+			annually: '每月阅读时长', overall: '每年阅读时长'
 		};
 		section.createEl('h3', { text: modeLabel[this.currentMode], cls: 'weread-stats-section-title' });
 
-		const entries = Object.entries(data.readTimes)
-			.sort(([a], [b]) => Number(a) - Number(b));
+		let values: number[];
+		let labels: string[];
 
-		const values = entries.map(([, v]) => v as number);
-		const labels = entries.map(([ts]) => {
-			const d = new Date(Number(ts) * 1000);
-			if (this.currentMode === 'overall') return `${d.getFullYear()}`;
-			if (this.currentMode === 'annually') return `${d.getMonth() + 1}月`;
-			if (this.currentMode === 'weekly') {
-				// getDay(): 0=Sun,1=Mon,...,6=Sat → WEEK_LABELS index: 0=Mon,...,6=Sun
-				const dow = d.getDay();
-				const idx = dow === 0 ? 6 : dow - 1;
-				return WEEK_LABELS[idx];
-			}
-			return `${d.getDate()}`;
-		});
+		if (this.currentMode === 'weekly') {
+			const baseTime = calcBaseTime('weekly', this.currentOffset);
+			const built = buildWeekValues(data.readTimes, baseTime);
+			values = built.values;
+			labels = built.labels;
+		} else {
+			const entries = Object.entries(data.readTimes).sort(([a], [b]) => Number(a) - Number(b));
+			values = entries.map(([, v]) => v as number);
+			labels = entries.map(([ts]) => {
+				const d = new Date(Number(ts) * 1000);
+				if (this.currentMode === 'overall') return `${d.getFullYear()}`;
+				if (this.currentMode === 'annually') return `${d.getMonth() + 1}月`;
+				return `${d.getDate()}`;
+			});
+		}
 
 		this.renderBarChart(section, values, labels);
 	}
 
-	// ── Bar Chart (SVG-based, with Y scale) ──────────────────────────
+	// ── Bar Chart (SVG) with Y-axis scale ────────────────────────────
 	private renderBarChart(parent: HTMLElement, values: number[], labels: string[]) {
-		const maxVal = Math.max(...values, 1);
+		const rawMax = Math.max(...values, 1);
+		const maxVal = niceMax(rawMax);
 		const gap = 4;
 		const chartH = 140;
 		const labelH = 22;
-		const scaleW = 48; // left gutter for Y-axis labels
+		const scaleW = 52; // left gutter
 
 		const wrapper = parent.createDiv({ cls: 'weread-stats-chart-wrapper' });
 
-		// compute nice scale ticks
-		const tickMax = maxVal; // seconds
-		const ticks = [0, 0.5, 1].map(f => Math.round(tickMax * f)); // 0, mid, max
-
-		// SVG fills full width; bars share space equally
 		const n = values.length;
-		// We use a fixed viewBox wide enough; bars spaced evenly
-		const barAreaW = 600; // logical width for bars
+		const barAreaW = 600;
 		const barW = Math.max(8, Math.floor(barAreaW / n) - gap);
 		const totalViewW = scaleW + barAreaW;
 
@@ -366,33 +352,21 @@ export class WereadReadingStatsView extends ItemView {
 			}
 		});
 
-		// Y-axis guide lines + labels
-		for (let ti = 0; ti < ticks.length; ti++) {
-			const tickVal = ticks[ti];
-			const yPos = chartH - (tickVal / maxVal) * chartH;
-
-			// dashed line across bar area
+		// Y-axis: 0, 50%, 100% with nice labels
+		const tickFractions = [0, 0.5, 1];
+		for (const frac of tickFractions) {
+			const tickVal = maxVal * frac;
+			const yPos = chartH - frac * chartH;
 			svg.createSvg('line', {
-				attr: {
-					x1: String(scaleW), y1: String(yPos),
-					x2: String(totalViewW), y2: String(yPos),
-					class: 'weread-stats-scale-line'
-				}
+				attr: { x1: String(scaleW), y1: String(yPos), x2: String(totalViewW), y2: String(yPos), class: 'weread-stats-scale-line' }
 			});
-
-			// label on left
 			const lbl = svg.createSvg('text', {
-				attr: {
-					x: String(scaleW - 4),
-					y: String(yPos + 4),
-					'text-anchor': 'end',
-					class: 'weread-stats-scale-label'
-				}
+				attr: { x: String(scaleW - 4), y: String(yPos + 4), 'text-anchor': 'end', class: 'weread-stats-scale-label' }
 			});
-			lbl.textContent = ti === 0 ? '0' : fmtDuration(tickVal);
+			lbl.textContent = niceTickLabel(tickVal);
 		}
 
-		// Bars + labels
+		// Bars
 		values.forEach((v, i) => {
 			const barH = Math.max((v / maxVal) * chartH, v > 0 ? 4 : 0);
 			const slotW = barAreaW / n;
@@ -400,24 +374,12 @@ export class WereadReadingStatsView extends ItemView {
 			const y = chartH - barH;
 
 			const rect = svg.createSvg('rect', {
-				attr: {
-					x: String(x),
-					y: String(y),
-					width: String(barW),
-					height: String(barH),
-					rx: '4',
-					class: 'weread-stats-bar' + (v === maxVal ? ' is-max' : '')
-				}
+				attr: { x: String(x), y: String(y), width: String(barW), height: String(barH), rx: '4', class: 'weread-stats-bar' + (v === rawMax && v > 0 ? ' is-max' : '') }
 			});
 			rect.createSvg('title').textContent = `${labels[i]}: ${fmtDuration(v)}`;
 
 			const text = svg.createSvg('text', {
-				attr: {
-					x: String(x + barW / 2),
-					y: String(chartH + labelH - 2),
-					'text-anchor': 'middle',
-					class: 'weread-stats-bar-label'
-				}
+				attr: { x: String(x + barW / 2), y: String(chartH + labelH - 2), 'text-anchor': 'middle', class: 'weread-stats-bar-label' }
 			});
 			text.textContent = labels[i];
 		});
@@ -431,8 +393,8 @@ export class WereadReadingStatsView extends ItemView {
 		section.createEl('h3', { text: `阅读时长 Top ${data.readLongest.length}`, cls: 'weread-stats-section-title' });
 
 		const maxTime = Math.max(...data.readLongest.map(b => b.readTime), 1);
-
 		const list = section.createDiv({ cls: 'weread-stats-book-list' });
+
 		data.readLongest.forEach((item, i) => {
 			const title = item.book?.title ?? item.albumInfo?.name ?? '未知';
 			const author = item.book?.author ?? item.albumInfo?.authorName ?? '';
@@ -441,22 +403,19 @@ export class WereadReadingStatsView extends ItemView {
 			const pct = (item.readTime / maxTime) * 100;
 
 			const row = list.createDiv({ cls: 'weread-stats-book-row' });
-
 			row.createDiv({ cls: 'weread-stats-book-rank', text: String(i + 1) });
 
 			if (cover) {
 				const img = row.createEl('img', { cls: 'weread-stats-book-cover' });
-				img.src = cover;
-				img.alt = title;
+				img.src = cover; img.alt = title;
 			} else {
-				const placeholder = row.createDiv({ cls: 'weread-stats-book-cover weread-stats-book-cover-placeholder' });
-				setIcon(placeholder, 'book');
+				const ph = row.createDiv({ cls: 'weread-stats-book-cover weread-stats-book-cover-placeholder' });
+				setIcon(ph, 'book');
 			}
 
 			const info = row.createDiv({ cls: 'weread-stats-book-info' });
 			info.createDiv({ cls: 'weread-stats-book-title', text: title });
 			if (author) info.createDiv({ cls: 'weread-stats-book-author', text: author });
-
 			if (item.tags?.length) {
 				const tagRow = info.createDiv({ cls: 'weread-stats-book-tags' });
 				item.tags.forEach(tag => tagRow.createSpan({ cls: 'weread-stats-tag', text: tag }));
@@ -465,18 +424,15 @@ export class WereadReadingStatsView extends ItemView {
 			const right = row.createDiv({ cls: 'weread-stats-book-right' });
 			right.createDiv({ cls: 'weread-stats-book-duration', text: fmtDuration(item.readTime) });
 			const barTrack = right.createDiv({ cls: 'weread-stats-mini-bar-track' });
-			const barFill = barTrack.createDiv({ cls: 'weread-stats-mini-bar-fill' });
-			barFill.style.width = `${pct}%`;
+			barTrack.createDiv({ cls: 'weread-stats-mini-bar-fill' }).style.width = `${pct}%`;
 
-			// 点击跳转到本地笔记
 			if (bookId) {
 				row.addClass('weread-stats-book-row-clickable');
 				row.addEventListener('click', async () => {
-					const bookIdMap = await this.fileManager.getNotebookFilesByBookId();
-					const annotationFile = bookIdMap.get(bookId);
-					if (annotationFile?.file instanceof TFile) {
-						const leaf = this.app.workspace.getLeaf(false);
-						await leaf.openFile(annotationFile.file);
+					const map = await this.fileManager.getNotebookFilesByBookId();
+					const f = map.get(bookId);
+					if (f?.file instanceof TFile) {
+						await this.app.workspace.getLeaf(false).openFile(f.file);
 					}
 				});
 			}
@@ -488,48 +444,14 @@ export class WereadReadingStatsView extends ItemView {
 		const hasCat = data.preferCategory?.some(c => c.readingTime > 0);
 		const hasAuthor = data.preferAuthor?.length;
 		const hasTime = data.preferTime?.length === 24;
-		if (!hasCat && !hasAuthor && !hasTime) return;
+		const hasPublisher = data.preferPublisher?.length;
+		if (!hasCat && !hasAuthor && !hasTime && !hasPublisher) return;
 
 		const section = el.createDiv({ cls: 'weread-stats-section' });
 		section.createEl('h3', { text: '偏好分析', cls: 'weread-stats-section-title' });
-
 		const prefGrid = section.createDiv({ cls: 'weread-stats-pref-grid' });
 
-		if (hasCat) {
-			const cats = data.preferCategory.filter(c => c.readingTime > 0);
-			const maxCatTime = Math.max(...cats.map(c => c.readingTime), 1);
-
-			const catCard = prefGrid.createDiv({ cls: 'weread-stats-pref-card' });
-			const catHeader = catCard.createDiv({ cls: 'weread-stats-pref-card-header' });
-			setIcon(catHeader.createSpan(), 'tag');
-			catHeader.createSpan({ text: '分类偏好' });
-			if (data.preferCategoryWord) {
-				catCard.createDiv({ cls: 'weread-stats-pref-subtitle', text: data.preferCategoryWord });
-			}
-
-			cats.slice(0, 6).forEach(cat => {
-				const pct = (cat.readingTime / maxCatTime) * 100;
-				const row = catCard.createDiv({ cls: 'weread-stats-pref-row' });
-				row.createSpan({ cls: 'weread-stats-pref-name', text: cat.categoryTitle });
-				const barTrack = row.createDiv({ cls: 'weread-stats-pref-bar-track' });
-				barTrack.createDiv({ cls: 'weread-stats-pref-bar-fill' }).style.width = `${pct}%`;
-				row.createSpan({ cls: 'weread-stats-pref-meta', text: fmtDuration(cat.readingTime) });
-			});
-		}
-
-		if (hasAuthor) {
-			const authorCard = prefGrid.createDiv({ cls: 'weread-stats-pref-card' });
-			const authorHeader = authorCard.createDiv({ cls: 'weread-stats-pref-card-header' });
-			setIcon(authorHeader.createSpan(), 'user');
-			authorHeader.createSpan({ text: '偏好作者' });
-
-			data.preferAuthor!.slice(0, 6).forEach(a => {
-				const row = authorCard.createDiv({ cls: 'weread-stats-pref-row' });
-				row.createSpan({ cls: 'weread-stats-pref-name', text: a.name });
-				row.createSpan({ cls: 'weread-stats-pref-meta', text: `${a.count}本 · ${a.readTime}` });
-			});
-		}
-
+		// ── 阅读时段（柱状图，加时段标签）
 		if (hasTime) {
 			const timeCard = prefGrid.createDiv({ cls: 'weread-stats-pref-card weread-stats-pref-card-wide' });
 			const timeHeader = timeCard.createDiv({ cls: 'weread-stats-pref-card-header' });
@@ -538,53 +460,184 @@ export class WereadReadingStatsView extends ItemView {
 			if (data.preferTimeWord) {
 				timeCard.createDiv({ cls: 'weread-stats-pref-subtitle', text: data.preferTimeWord });
 			}
+			this.renderHourBarChart(timeCard, data.preferTime!);
+		}
 
-			const maxTimeVal = Math.max(...data.preferTime!, 1);
-			const hourChart = timeCard.createDiv({ cls: 'weread-stats-hour-chart' });
-			data.preferTime!.forEach((v, i) => {
-				const col = hourChart.createDiv({ cls: 'weread-stats-hour-col' });
-				const barH = Math.max((v / maxTimeVal) * 48, v > 0 ? 3 : 0);
-				const bar = col.createDiv({ cls: 'weread-stats-hour-bar' });
-				bar.style.height = `${barH}px`;
-				bar.title = `${HOUR_LABELS[i]}时: ${fmtDuration(v)}`;
-				if (i % 3 === 0) {
-					col.createDiv({ cls: 'weread-stats-hour-label', text: HOUR_LABELS[i] });
-				} else {
-					col.createDiv({ cls: 'weread-stats-hour-label' });
-				}
+		// ── 分类偏好（饼图）
+		if (hasCat) {
+			const cats = data.preferCategory.filter(c => c.readingTime > 0);
+			const catCard = prefGrid.createDiv({ cls: 'weread-stats-pref-card' });
+			const catHeader = catCard.createDiv({ cls: 'weread-stats-pref-card-header' });
+			setIcon(catHeader.createSpan(), 'tag');
+			catHeader.createSpan({ text: '分类偏好' });
+			if (data.preferCategoryWord) {
+				catCard.createDiv({ cls: 'weread-stats-pref-subtitle', text: data.preferCategoryWord });
+			}
+			this.renderPieChart(catCard, cats.slice(0, 8).map(c => ({ label: c.categoryTitle, value: c.readingTime })));
+		}
+
+		// ── 偏好作者
+		if (hasAuthor) {
+			const authorCard = prefGrid.createDiv({ cls: 'weread-stats-pref-card' });
+			const authorHeader = authorCard.createDiv({ cls: 'weread-stats-pref-card-header' });
+			setIcon(authorHeader.createSpan(), 'user');
+			authorHeader.createSpan({ text: '偏好作者' });
+			data.preferAuthor!.slice(0, 6).forEach(a => {
+				const row = authorCard.createDiv({ cls: 'weread-stats-pref-row' });
+				row.createSpan({ cls: 'weread-stats-pref-name', text: a.name });
+				row.createSpan({ cls: 'weread-stats-pref-meta', text: `${a.count}本 · ${a.readTime}` });
 			});
 		}
+
+		// ── 出版方标签云
+		if (hasPublisher) {
+			const pubCard = prefGrid.createDiv({ cls: 'weread-stats-pref-card weread-stats-pref-card-wide' });
+			const pubHeader = pubCard.createDiv({ cls: 'weread-stats-pref-card-header' });
+			setIcon(pubHeader.createSpan(), 'building-2');
+			pubHeader.createSpan({ text: '偏好出版方' });
+			this.renderTagCloud(pubCard, data.preferPublisher!.slice(0, 20));
+		}
+	}
+
+	/** 24h 阅读时段柱状图，带时段分区色 */
+	private renderHourBarChart(parent: HTMLElement, preferTime: number[]) {
+		const maxVal = Math.max(...preferTime, 1);
+		const chartH = 60;
+		const labelH = 18;
+		const n = 24;
+		const barAreaW = 600;
+		const gap = 2;
+		const barW = Math.floor(barAreaW / n) - gap;
+		const totalViewW = barAreaW;
+
+		// Time-of-day segments: 凌晨 0-5(idx 18-23), 上午 6-11(0-5), 下午 12-17(6-11), 晚上 18-23(12-17)
+		const segColor = (i: number): string => {
+			if (i < 6) return 'var(--weread-hour-morning)';   // 6-11
+			if (i < 12) return 'var(--weread-hour-afternoon)'; // 12-17
+			if (i < 18) return 'var(--weread-hour-evening)';   // 18-23
+			return 'var(--weread-hour-night)';                  // 0-5
+		};
+
+		const wrapper = parent.createDiv({ cls: 'weread-stats-chart-wrapper' });
+		const svg = wrapper.createSvg('svg', {
+			attr: {
+				viewBox: `0 0 ${totalViewW} ${chartH + labelH}`,
+				width: '100%', height: chartH + labelH,
+				class: 'weread-stats-bar-chart', preserveAspectRatio: 'xMidYMid meet'
+			}
+		});
+
+		preferTime.forEach((v, i) => {
+			const barH = Math.max((v / maxVal) * chartH, v > 0 ? 2 : 0);
+			const slotW = barAreaW / n;
+			const x = i * slotW + (slotW - barW) / 2;
+			const y = chartH - barH;
+
+			const rect = svg.createSvg('rect', {
+				attr: { x: String(x), y: String(y), width: String(barW), height: String(barH), rx: '2', class: 'weread-stats-hour-seg-bar' }
+			});
+			(rect as SVGElement).setAttribute('style', `fill: ${segColor(i)}`);
+			rect.createSvg('title').textContent = `${HOUR_LABELS[i]}时: ${fmtDuration(v)}`;
+
+			// Show label every 3 hours
+			if (i % 3 === 0) {
+				const text = svg.createSvg('text', {
+					attr: { x: String(x + barW / 2), y: String(chartH + labelH - 2), 'text-anchor': 'middle', class: 'weread-stats-bar-label' }
+				});
+				text.textContent = HOUR_LABELS[i];
+			}
+		});
+
+		// Legend
+		const legend = parent.createDiv({ cls: 'weread-stats-hour-legend' });
+		[['凌晨', 'var(--weread-hour-night)'], ['上午', 'var(--weread-hour-morning)'], ['下午', 'var(--weread-hour-afternoon)'], ['晚上', 'var(--weread-hour-evening)']].forEach(([label, color]) => {
+			const item = legend.createDiv({ cls: 'weread-stats-hour-legend-item' });
+			const dot = item.createDiv({ cls: 'weread-stats-hour-legend-dot' });
+			dot.style.background = color;
+			item.createSpan({ text: label, cls: 'weread-stats-hour-legend-label' });
+		});
+	}
+
+	/** 简单 SVG 饼图 + 图例 */
+	private renderPieChart(parent: HTMLElement, items: { label: string; value: number }[]) {
+		const total = items.reduce((s, it) => s + it.value, 0);
+		if (total === 0) return;
+
+		const size = 120;
+		const cx = size / 2, cy = size / 2, r = size / 2 - 4;
+		// accent palette: rotate hue from accent color
+		const COLORS = ['#7c6af7','#a78bfa','#6366f1','#818cf8','#c4b5fd','#4f46e5','#ddd6fe','#3730a3'];
+
+		const pieWrap = parent.createDiv({ cls: 'weread-stats-pie-wrap' });
+
+		const svg = pieWrap.createSvg('svg', {
+			attr: { width: String(size), height: String(size), viewBox: `0 0 ${size} ${size}`, class: 'weread-stats-pie-svg' }
+		});
+
+		let angle = -Math.PI / 2; // start top
+		items.forEach((item, idx) => {
+			const sweep = (item.value / total) * 2 * Math.PI;
+			const x1 = cx + r * Math.cos(angle);
+			const y1 = cy + r * Math.sin(angle);
+			const x2 = cx + r * Math.cos(angle + sweep);
+			const y2 = cy + r * Math.sin(angle + sweep);
+			const large = sweep > Math.PI ? 1 : 0;
+
+			const path = svg.createSvg('path', {
+				attr: {
+					d: `M ${cx} ${cy} L ${x1} ${y1} A ${r} ${r} 0 ${large} 1 ${x2} ${y2} Z`,
+					class: 'weread-stats-pie-slice'
+				}
+			});
+			(path as SVGElement).setAttribute('style', `fill: ${COLORS[idx % COLORS.length]}`);
+			path.createSvg('title').textContent = `${item.label}: ${fmtDuration(item.value)}`;
+			angle += sweep;
+		});
+
+		// Legend
+		const legend = pieWrap.createDiv({ cls: 'weread-stats-pie-legend' });
+		items.forEach((item, idx) => {
+			const row = legend.createDiv({ cls: 'weread-stats-pie-legend-row' });
+			const dot = row.createDiv({ cls: 'weread-stats-pie-legend-dot' });
+			dot.style.background = COLORS[idx % COLORS.length];
+			const pct = Math.round((item.value / total) * 100);
+			row.createSpan({ cls: 'weread-stats-pie-legend-label', text: `${item.label} ${pct}%` });
+		});
+	}
+
+	/** 出版方标签云 */
+	private renderTagCloud(parent: HTMLElement, publishers: { name: string; count: number }[]) {
+		const maxCount = Math.max(...publishers.map(p => p.count), 1);
+		const cloud = parent.createDiv({ cls: 'weread-stats-tag-cloud' });
+		publishers.forEach(p => {
+			const ratio = p.count / maxCount;
+			const size = Math.round(11 + ratio * 10); // 11px ~ 21px
+			const opacity = 0.5 + ratio * 0.5;
+			const span = cloud.createSpan({ cls: 'weread-stats-cloud-tag', text: p.name });
+			span.style.fontSize = `${size}px`;
+			span.style.opacity = String(opacity);
+			span.title = `${p.name}: ${p.count}本`;
+		});
 	}
 
 	// ── Yearly Overview ────────────────────────────────────────────────
 	private renderYearlyOverview(el: HTMLElement, data: ReadingStatsResponse) {
 		if (!data.readTimes || Object.keys(data.readTimes).length === 0) return;
-		if (this.currentMode !== 'overall') return;
 
 		const section = el.createDiv({ cls: 'weread-stats-section' });
 		section.createEl('h3', { text: '注册信息', cls: 'weread-stats-section-title' });
-
 		const infoGrid = section.createDiv({ cls: 'weread-stats-info-grid' });
-		if (data.registTime) {
+
+		const addInfo = (label: string, value: string) => {
 			const item = infoGrid.createDiv({ cls: 'weread-stats-info-item' });
-			item.createDiv({ cls: 'weread-stats-info-label', text: '注册时间' });
-			item.createDiv({ cls: 'weread-stats-info-value', text: fmtTs(data.registTime) });
-		}
-		if (data.readRate !== undefined) {
-			const item = infoGrid.createDiv({ cls: 'weread-stats-info-item' });
-			item.createDiv({ cls: 'weread-stats-info-label', text: '文字阅读占比' });
-			item.createDiv({ cls: 'weread-stats-info-value', text: `${data.readRate}%` });
-		}
-		if (data.wrReadTime) {
-			const item = infoGrid.createDiv({ cls: 'weread-stats-info-item' });
-			item.createDiv({ cls: 'weread-stats-info-label', text: '文字阅读' });
-			item.createDiv({ cls: 'weread-stats-info-value', text: fmtDuration(data.wrReadTime) });
-		}
-		if (data.wrListenTime) {
-			const item = infoGrid.createDiv({ cls: 'weread-stats-info-item' });
-			item.createDiv({ cls: 'weread-stats-info-label', text: '听书时长' });
-			item.createDiv({ cls: 'weread-stats-info-value', text: fmtDuration(data.wrListenTime) });
-		}
+			item.createDiv({ cls: 'weread-stats-info-label', text: label });
+			item.createDiv({ cls: 'weread-stats-info-value', text: value });
+		};
+
+		if (data.registTime) addInfo('注册时间', fmtTs(data.registTime));
+		if (data.readRate !== undefined) addInfo('文字阅读占比', `${data.readRate}%`);
+		if (data.wrReadTime) addInfo('文字阅读', fmtDuration(data.wrReadTime));
+		if (data.wrListenTime) addInfo('听书时长', fmtDuration(data.wrListenTime));
 	}
 
 	// ── Empty states ──────────────────────────────────────────────────

--- a/src/components/wereadReadingStats.ts
+++ b/src/components/wereadReadingStats.ts
@@ -220,9 +220,9 @@ export class WereadReadingStatsView extends ItemView {
 	// ── Tab bar + 时间导航 ────────────────────────────────────────────
 	private renderTabBar(el: HTMLElement) {
 		const tabs: { mode: ReadingStatsMode; label: string }[] = [
-			{ mode: 'weekly', label: '本周' },
-			{ mode: 'monthly', label: '本月' },
-			{ mode: 'annually', label: '本年' },
+			{ mode: 'weekly', label: '周' },
+			{ mode: 'monthly', label: '月' },
+			{ mode: 'annually', label: '年' },
 			{ mode: 'overall', label: '全部' },
 		];
 		const nav = el.createDiv({ cls: 'weread-stats-nav' });

--- a/src/components/wereadReadingStats.ts
+++ b/src/components/wereadReadingStats.ts
@@ -1,4 +1,4 @@
-import { ItemView, Menu, WorkspaceLeaf, setIcon, TFile, Vault } from 'obsidian';
+import { ItemView, Menu, Modal, Notice, WorkspaceLeaf, setIcon, TFile, Vault } from 'obsidian';
 import ApiManager from '../api';
 import FileManager from '../fileManager';
 import { settingsStore } from '../settings';
@@ -171,12 +171,8 @@ async function saveDailyCache(vault: Vault, cache: DailyStatsCache): Promise<voi
 		const exists = await vault.adapter.exists(CACHE_DIR);
 		if (!exists) await vault.adapter.mkdir(CACHE_DIR);
 		const json = JSON.stringify(cache);
-		const file = vault.getAbstractFileByPath(CACHE_FILE);
-		if (file instanceof TFile) {
-			await vault.modify(file, json);
-		} else {
-			await vault.create(CACHE_FILE, json);
-		}
+		// Use adapter.write to always overwrite, avoids "File already exists" race condition
+		await vault.adapter.write(CACHE_FILE, json);
 	} catch (e) {
 		console.error('[weread] Failed to save daily stats cache', e);
 	}
@@ -185,6 +181,93 @@ async function saveDailyCache(vault: Vault, cache: DailyStatsCache): Promise<voi
 
 
 type ChartView = 'bar' | 'calendar' | 'heatmap';
+
+// ─── 导出预览 Modal ────────────────────────────────────────────────────────────
+class ExportPreviewModal extends Modal {
+	private dataUrl: string;
+	private filename: string;
+	private vault: Vault;
+
+	constructor(app: any, dataUrl: string, filename: string, vault: Vault) {
+		super(app);
+		this.dataUrl = dataUrl;
+		this.filename = filename;
+		this.vault = vault;
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+		contentEl.addClass('weread-export-modal');
+
+		// Title
+		const titleEl = contentEl.createEl('h2', { cls: 'weread-export-title' });
+		const titleIcon = titleEl.createSpan({ cls: 'weread-export-title-icon' });
+		setIcon(titleIcon, 'image-down');
+		titleEl.createSpan({ text: '导出阅读统计图片' });
+
+		// Preview image
+		const preview = contentEl.createDiv({ cls: 'weread-export-preview' });
+		const img = preview.createEl('img', { cls: 'weread-export-preview-img' });
+		img.src = this.dataUrl;
+
+		// Action buttons
+		const actions = contentEl.createDiv({ cls: 'weread-export-actions' });
+
+		// 1. Save to Vault
+		const vaultBtn = actions.createEl('button', { cls: 'weread-export-action-btn mod-cta' });
+		setIcon(vaultBtn.createSpan(), 'vault');
+		vaultBtn.createSpan({ text: '保存到 Vault' });
+		vaultBtn.addEventListener('click', async () => {
+			try {
+				const base64 = this.dataUrl.split(',')[1];
+				const binary = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+				const settings = get(settingsStore);
+				const folder = settings.noteLocation || '/';
+				const filePath = folder.replace(/\/$/, '') + '/' + this.filename;
+				await this.vault.adapter.writeBinary(filePath, binary.buffer);
+				new Notice(`✅ 已保存到 Vault：${filePath}`);
+				this.close();
+			} catch (e) {
+				new Notice('❌ 保存失败：' + e.message);
+			}
+		});
+
+		// 2. Save to local disk
+		const localBtn = actions.createEl('button', { cls: 'weread-export-action-btn' });
+		setIcon(localBtn.createSpan(), 'download');
+		localBtn.createSpan({ text: '保存到本地' });
+		localBtn.addEventListener('click', () => {
+			const link = document.createElement('a');
+			link.download = this.filename;
+			link.href = this.dataUrl;
+			link.click();
+			this.close();
+		});
+
+		// 3. Copy to clipboard
+		const copyBtn = actions.createEl('button', { cls: 'weread-export-action-btn' });
+		setIcon(copyBtn.createSpan(), 'copy');
+		copyBtn.createSpan({ text: '复制到剪切板' });
+		copyBtn.addEventListener('click', async () => {
+			try {
+				const base64 = this.dataUrl.split(',')[1];
+				const binary = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+				const blob = new Blob([binary], { type: 'image/png' });
+				await navigator.clipboard.write([
+					new ClipboardItem({ 'image/png': blob })
+				]);
+				new Notice('✅ 已复制到剪切板');
+				this.close();
+			} catch (e) {
+				new Notice('❌ 复制失败：' + e.message);
+			}
+		});
+	}
+
+	onClose() {
+		this.contentEl.empty();
+	}
+}
 
 export class WereadReadingStatsView extends ItemView {
 	private apiManager: ApiManager;
@@ -238,6 +321,18 @@ export class WereadReadingStatsView extends ItemView {
 		if (!settings.wereadApiKey) { this.renderNoApiKey(); return; }
 		this.loading = true;
 		this.renderLoading();
+
+		// Fetch user signature (always refresh on open)
+		if (settings.userVid) {
+			const userInfo = await this.apiManager.getUserInfo(settings.userVid);
+			const parts = [
+				(userInfo as any)?.signature,
+				(userInfo as any)?.vDesc
+			].filter(Boolean);
+			const sig = parts.join(' ｜ ');
+			if (sig) settingsStore.actions.setUserSignature(sig);
+		}
+
 		const baseTime = calcBaseTime(this.currentMode, this.currentOffset);
 		const data = await this.apiManager.getReadingStats(this.currentMode, baseTime);
 		this.loading = false;
@@ -265,10 +360,127 @@ export class WereadReadingStatsView extends ItemView {
 	// ── Header ────────────────────────────────────────────────────────
 	private renderHeader(el: HTMLElement) {
 		const header = el.createDiv({ cls: 'weread-stats-header' });
-		const titleRow = header.createDiv({ cls: 'weread-stats-title-row' });
-		const icon = titleRow.createSpan({ cls: 'weread-stats-header-icon' });
-		setIcon(icon, 'bar-chart-2');
-		titleRow.createEl('h2', { text: '微信读书阅读统计', cls: 'weread-stats-title' });
+		// Single row: user info on left, export button on right
+		const headerRow = header.createDiv({ cls: 'weread-stats-header-row' });
+
+		// Left: avatar + name + signature
+		const settings = get(settingsStore);
+		const userName = settings.user;
+		const userAvatar = settings.userAvatar;
+		const userSignature = settings.userSignature;
+
+		const userLeft = headerRow.createDiv({ cls: 'weread-stats-user-left' });
+		if (userAvatar) {
+			const avatarImg = userLeft.createEl('img', { cls: 'weread-stats-user-avatar' });
+			avatarImg.src = userAvatar;
+			avatarImg.alt = userName || '用户头像';
+		}
+		const userTextWrap = userLeft.createDiv({ cls: 'weread-stats-user-text' });
+		userTextWrap.createSpan({ cls: 'weread-stats-user-name', text: userName || '微信读书用户' });
+		if (userSignature) {
+			userTextWrap.createSpan({ cls: 'weread-stats-user-sub', text: userSignature });
+		}
+
+		// Right: export button
+		if (this.currentMode === 'overall' || this.currentMode === 'annually' || this.currentMode === 'monthly') {
+			const exportBtn = headerRow.createEl('button', {
+				cls: 'weread-stats-btn weread-stats-export-btn',
+				attr: { title: '导出为图片' }
+			});
+			setIcon(exportBtn, 'image-down');
+			exportBtn.createSpan({ text: '导出图片' });
+			exportBtn.addEventListener('click', () => this.exportAsImage(exportBtn));
+		}
+	}
+
+	private async exportAsImage(btn: HTMLElement) {
+		const { toPng } = require('html-to-image');
+		const { requestUrl } = require('obsidian');
+		const origText = btn.querySelector('span')?.textContent ?? '导出图片';
+		const span = btn.querySelector('span') as HTMLElement;
+		if (span) span.textContent = '生成中…';
+		btn.setAttribute('disabled', 'true');
+
+		// Hide export button during capture so it doesn't appear in the image
+		const exportBtn = this.statsEl.querySelector<HTMLElement>('.weread-stats-export-btn');
+		if (exportBtn) exportBtn.style.visibility = 'hidden';
+
+		// Pre-fetch all images via Obsidian's requestUrl (bypasses CORS),
+		// replace src with data URL, restore after capture.
+		const imgs = Array.from(this.statsEl.querySelectorAll<HTMLImageElement>('img'));
+		const origSrcs: string[] = imgs.map(img => img.src);
+		await Promise.allSettled(imgs.map(async (img, i) => {
+			try {
+				const resp = await requestUrl({ url: origSrcs[i], method: 'GET' });
+				const mime = resp.headers['content-type'] || 'image/jpeg';
+				const b64 = btoa(String.fromCharCode(...new Uint8Array(resp.arrayBuffer)));
+				img.src = `data:${mime};base64,${b64}`;
+			} catch { /* keep original, will show blank */ }
+		}));
+
+		// Inline computed fill/stroke/color on all SVG elements — html-to-image doesn't resolve CSS vars for SVG
+		type SvgRestore = { el: SVGElement; fill: string | null; stroke: string | null; style: string };
+		const svgRestores: SvgRestore[] = [];
+		this.statsEl.querySelectorAll<SVGElement>('svg, svg *').forEach(el => {
+			const cs = getComputedStyle(el);
+			const fill = cs.fill;
+			const stroke = cs.stroke;
+			svgRestores.push({ el, fill: el.getAttribute('fill'), stroke: el.getAttribute('stroke'), style: el.getAttribute('style') || '' });
+			// Always set presentation attributes with resolved rgb() values
+			el.setAttribute('fill', fill || 'none');
+			el.setAttribute('stroke', stroke || 'none');
+			// Also clear any style attr that may contain CSS vars (already captured above)
+			const styleAttr = el.getAttribute('style') || '';
+			if (styleAttr.includes('var(') || styleAttr.includes('color-mix(')) {
+				el.setAttribute('style', styleAttr
+					.replace(/fill\s*:[^;]+/g, `fill:${fill}`)
+					.replace(/stroke\s*:[^;]+/g, `stroke:${stroke}`)
+				);
+			}
+		});
+
+		// Temporarily expand scroll container so full content is captured
+		const scrollEl = this.contentEl as HTMLElement;
+		const origOverflow = scrollEl.style.overflow;
+		const origHeight = scrollEl.style.height;
+		scrollEl.style.overflow = 'visible';
+		scrollEl.style.height = 'auto';
+		await new Promise(r => requestAnimationFrame(r));
+
+		try {
+			const dataUrl = await toPng(this.statsEl, {
+				pixelRatio: 2,
+				width: this.statsEl.offsetWidth,
+				height: this.statsEl.scrollHeight,
+				skipFonts: true,
+				style: { overflow: 'visible' },
+			});
+			new ExportPreviewModal(this.app, dataUrl, this.exportFilename(), this.app.vault).open();
+		} catch (e) {
+			console.error('导出图片失败', e);
+		} finally {
+			// Restore export button visibility
+			if (exportBtn) exportBtn.style.visibility = '';
+			// Restore original image srcs
+			imgs.forEach((img, i) => { img.src = origSrcs[i]; });
+			// Restore SVG attributes
+			svgRestores.forEach(({ el, fill, stroke, style }) => {
+				if (fill === null) el.removeAttribute('fill'); else el.setAttribute('fill', fill);
+				if (stroke === null) el.removeAttribute('stroke'); else el.setAttribute('stroke', stroke);
+				if (style === '') el.removeAttribute('style'); else el.setAttribute('style', style);
+			});
+			scrollEl.style.overflow = origOverflow;
+			scrollEl.style.height = origHeight;
+			if (span) span.textContent = origText;
+			btn.removeAttribute('disabled');
+		}
+	}
+
+	private exportFilename(): string {
+		const now = new Date();
+		const date = `${now.getFullYear()}${String(now.getMonth()+1).padStart(2,'0')}${String(now.getDate()).padStart(2,'0')}`;
+		const time = `${String(now.getHours()).padStart(2,'0')}${String(now.getMinutes()).padStart(2,'0')}${String(now.getSeconds()).padStart(2,'0')}`;
+		return `weread-stats-${date}_${time}.png`;
 	}
 
 	// ── Tab bar + 时间导航 ────────────────────────────────────────────
@@ -387,7 +599,15 @@ export class WereadReadingStatsView extends ItemView {
 		const iconEl = card.createDiv({ cls: 'weread-stats-kpi-icon' });
 		setIcon(iconEl, iconName);
 		const body = card.createDiv({ cls: 'weread-stats-kpi-body' });
-		body.createDiv({ cls: 'weread-stats-kpi-value', text: value });
+		// Split number from unit so only the number is enlarged
+		const valueEl = body.createDiv({ cls: 'weread-stats-kpi-value' });
+		const match = value.match(/^([\d]+)(.*)/);
+		if (match) {
+			valueEl.createSpan({ cls: 'weread-stats-kpi-number', text: match[1] });
+			if (match[2]) valueEl.createSpan({ cls: 'weread-stats-kpi-unit', text: match[2] });
+		} else {
+			valueEl.setText(value);
+		}
 		const labelRow = body.createDiv({ cls: 'weread-stats-kpi-label-row' });
 		labelRow.createSpan({ text: label, cls: 'weread-stats-kpi-label' });
 		if (compare) {
@@ -732,7 +952,7 @@ export class WereadReadingStatsView extends ItemView {
 		const legend = wrap.createDiv({ cls: 'weread-ghmap-legend' });
 		legend.createSpan({ cls: 'weread-ghmap-legend-text', text: '少' });
 		for (let l = 0; l <= 4; l++) {
-			legend.createDiv({ cls: `weread-ghmap-cell level-${l}` });
+			legend.createDiv({ cls: `weread-ghmap-cell weread-ghmap-legend-cell level-${l}` });
 		}
 		legend.createSpan({ cls: 'weread-ghmap-legend-text', text: '多' });
 	}
@@ -785,16 +1005,11 @@ export class WereadReadingStatsView extends ItemView {
 
 		const rightCol = inner.createDiv({ cls: 'weread-ghmap-right' });
 
-		// Month labels — each label is exactly (CELL_W + GAP) px wide to align with columns
-		const CELL_W = 13;
-		const GAP = 3;
-		const COL_W = CELL_W + GAP; // 16px per week column
+		// Month labels
 		const monthRow = rightCol.createDiv({ cls: 'weread-ghmap-months' });
 		for (let w = 0; w < totalWeeks; w++) {
 			const mo = Object.entries(monthWeek).find(([, wk]) => wk === w);
-			const label = monthRow.createDiv({ cls: 'weread-ghmap-monthlabel', text: mo ? `${Number(mo[0]) + 1}月` : '' });
-			label.style.width = `${COL_W}px`;
-			label.style.flexShrink = '0';
+			monthRow.createDiv({ cls: 'weread-ghmap-monthlabel', text: mo ? `${Number(mo[0]) + 1}月` : '' });
 		}
 
 		// Cell grid
@@ -845,7 +1060,7 @@ export class WereadReadingStatsView extends ItemView {
 		const legend = wrap.createDiv({ cls: 'weread-ghmap-legend' });
 		legend.createSpan({ cls: 'weread-ghmap-legend-text', text: '少' });
 		for (let l = 0; l <= 4; l++) {
-			legend.createDiv({ cls: `weread-ghmap-cell level-${l}` });
+			legend.createDiv({ cls: `weread-ghmap-cell weread-ghmap-legend-cell level-${l}` });
 		}
 		legend.createSpan({ cls: 'weread-ghmap-legend-text', text: '多' });
 
@@ -1110,7 +1325,7 @@ export class WereadReadingStatsView extends ItemView {
 		const maxVal = Math.max(...items.map(i => i.value), 1);
 
 		const svg = parent.createSvg('svg', {
-			attr: { width: '100%', viewBox: `0 0 ${size} ${size}`, class: 'weread-stats-radar-svg', preserveAspectRatio: 'xMidYMid meet' }
+			attr: { width: '100%', viewBox: `0 0 ${size} ${size}`, class: 'weread-stats-radar-svg', preserveAspectRatio: 'xMidYMid meet', style: 'background:transparent' }
 		});
 
 		// 定义渐变

--- a/src/components/wereadReadingStats.ts
+++ b/src/components/wereadReadingStats.ts
@@ -157,9 +157,9 @@ interface DailyStatsCache {
 
 async function loadDailyCache(vault: Vault): Promise<DailyStatsCache> {
 	try {
-		const file = vault.getAbstractFileByPath(CACHE_FILE);
-		if (file instanceof TFile) {
-			const raw = await vault.read(file);
+		const exists = await vault.adapter.exists(CACHE_FILE);
+		if (exists) {
+			const raw = await vault.adapter.read(CACHE_FILE);
 			return JSON.parse(raw) as DailyStatsCache;
 		}
 	} catch (_) { /* ignore */ }
@@ -179,6 +179,18 @@ async function saveDailyCache(vault: Vault, cache: DailyStatsCache): Promise<voi
 }
 
 
+
+// ─── 导出 Loading Modal ───────────────────────────────────────────────────────
+class ExportLoadingModal extends Modal {
+	onOpen() {
+		const { contentEl } = this;
+		contentEl.addClass('weread-export-loading-modal');
+		const wrap = contentEl.createDiv({ cls: 'weread-export-loading-wrap' });
+		wrap.createDiv({ cls: 'weread-stats-spinner' });
+		wrap.createDiv({ cls: 'weread-export-loading-text', text: '正在生成图片…' });
+	}
+	onClose() { this.contentEl.empty(); }
+}
 
 type ChartView = 'bar' | 'calendar' | 'heatmap';
 
@@ -279,6 +291,8 @@ export class WereadReadingStatsView extends ItemView {
 	private statsEl: HTMLElement;
 	// chart view preference per mode
 	private chartView: Partial<Record<ReadingStatsMode, ChartView>> = {};
+	// in-memory image cache: url -> base64 data url
+	private imgCache: Map<string, string> = new Map();
 
 	constructor(leaf: WorkspaceLeaf, apiManager: ApiManager, fileManager: FileManager) {
 		super(leaf);
@@ -393,32 +407,36 @@ export class WereadReadingStatsView extends ItemView {
 		}
 	}
 
-	private async exportAsImage(btn: HTMLElement) {
+	private async exportAsImage(_btn: HTMLElement) {
 		const { toPng } = require('html-to-image');
 		const { requestUrl } = require('obsidian');
-		const origText = btn.querySelector('span')?.textContent ?? '导出图片';
-		const span = btn.querySelector('span') as HTMLElement;
-		if (span) span.textContent = '生成中…';
-		btn.setAttribute('disabled', 'true');
 
-		// Hide export button during capture so it doesn't appear in the image
+		// Show loading modal immediately
+		const loadingModal = new ExportLoadingModal(this.app);
+		loadingModal.open();
+
+		// Hide export button
 		const exportBtn = this.statsEl.querySelector<HTMLElement>('.weread-stats-export-btn');
-		if (exportBtn) exportBtn.style.visibility = 'hidden';
+		if (exportBtn) exportBtn.style.display = 'none';
 
-		// Pre-fetch all images via Obsidian's requestUrl (bypasses CORS),
-		// replace src with data URL, restore after capture.
+		// Pre-fetch images — use in-memory cache to avoid re-fetching on repeat exports
 		const imgs = Array.from(this.statsEl.querySelectorAll<HTMLImageElement>('img'));
 		const origSrcs: string[] = imgs.map(img => img.src);
 		await Promise.allSettled(imgs.map(async (img, i) => {
+			const src = origSrcs[i];
+			if (!src || src.startsWith('data:')) return;
 			try {
-				const resp = await requestUrl({ url: origSrcs[i], method: 'GET' });
-				const mime = resp.headers['content-type'] || 'image/jpeg';
-				const b64 = btoa(String.fromCharCode(...new Uint8Array(resp.arrayBuffer)));
-				img.src = `data:${mime};base64,${b64}`;
-			} catch { /* keep original, will show blank */ }
+				if (!this.imgCache.has(src)) {
+					const resp = await requestUrl({ url: src, method: 'GET' });
+					const mime = resp.headers['content-type'] || 'image/jpeg';
+					const b64 = btoa(String.fromCharCode(...new Uint8Array(resp.arrayBuffer)));
+					this.imgCache.set(src, `data:${mime};base64,${b64}`);
+				}
+				img.src = this.imgCache.get(src)!;
+			} catch { /* keep original */ }
 		}));
 
-		// Inline computed fill/stroke/color on all SVG elements — html-to-image doesn't resolve CSS vars for SVG
+		// Inline SVG fill/stroke from computed styles
 		type SvgRestore = { el: SVGElement; fill: string | null; stroke: string | null; style: string };
 		const svgRestores: SvgRestore[] = [];
 		this.statsEl.querySelectorAll<SVGElement>('svg, svg *').forEach(el => {
@@ -426,10 +444,8 @@ export class WereadReadingStatsView extends ItemView {
 			const fill = cs.fill;
 			const stroke = cs.stroke;
 			svgRestores.push({ el, fill: el.getAttribute('fill'), stroke: el.getAttribute('stroke'), style: el.getAttribute('style') || '' });
-			// Always set presentation attributes with resolved rgb() values
 			el.setAttribute('fill', fill || 'none');
 			el.setAttribute('stroke', stroke || 'none');
-			// Also clear any style attr that may contain CSS vars (already captured above)
 			const styleAttr = el.getAttribute('style') || '';
 			if (styleAttr.includes('var(') || styleAttr.includes('color-mix(')) {
 				el.setAttribute('style', styleAttr
@@ -439,40 +455,64 @@ export class WereadReadingStatsView extends ItemView {
 			}
 		});
 
-		// Temporarily expand scroll container so full content is captured
+		// Capture dimensions BEFORE any style changes
+		const captureWidth = this.statsEl.offsetWidth;
+		const captureHeight = this.statsEl.scrollHeight;
+
+		// Expand scroll container
 		const scrollEl = this.contentEl as HTMLElement;
 		const origOverflow = scrollEl.style.overflow;
 		const origHeight = scrollEl.style.height;
 		scrollEl.style.overflow = 'visible';
 		scrollEl.style.height = 'auto';
-		await new Promise(r => requestAnimationFrame(r));
+
+		// Reset scroll offsets on ancestors
+		const scrollParents: { el: Element; left: number; top: number }[] = [];
+		let ancestor: Element | null = this.statsEl.parentElement;
+		while (ancestor && ancestor !== document.body) {
+			if (ancestor.scrollLeft !== 0 || ancestor.scrollTop !== 0) {
+				scrollParents.push({ el: ancestor, left: ancestor.scrollLeft, top: ancestor.scrollTop });
+				(ancestor as HTMLElement).scrollLeft = 0;
+				(ancestor as HTMLElement).scrollTop = 0;
+			}
+			ancestor = ancestor.parentElement;
+		}
 
 		try {
 			const dataUrl = await toPng(this.statsEl, {
-				pixelRatio: 2,
-				width: this.statsEl.offsetWidth,
-				height: this.statsEl.scrollHeight,
+				pixelRatio: 1.5,
+				width: captureWidth,
+				height: captureHeight,
 				skipFonts: true,
-				style: { overflow: 'visible' },
+				cacheBust: false,
+				style: {
+					overflow: 'visible',
+					position: 'fixed',
+					left: '0',
+					top: '0',
+					margin: '0',
+				},
 			});
+			loadingModal.close();
 			new ExportPreviewModal(this.app, dataUrl, this.exportFilename(), this.app.vault).open();
 		} catch (e) {
+			loadingModal.close();
 			console.error('导出图片失败', e);
+			new Notice('❌ 导出图片失败：' + e.message);
 		} finally {
-			// Restore export button visibility
-			if (exportBtn) exportBtn.style.visibility = '';
-			// Restore original image srcs
+			if (exportBtn) exportBtn.style.display = '';
 			imgs.forEach((img, i) => { img.src = origSrcs[i]; });
-			// Restore SVG attributes
 			svgRestores.forEach(({ el, fill, stroke, style }) => {
 				if (fill === null) el.removeAttribute('fill'); else el.setAttribute('fill', fill);
 				if (stroke === null) el.removeAttribute('stroke'); else el.setAttribute('stroke', stroke);
 				if (style === '') el.removeAttribute('style'); else el.setAttribute('style', style);
 			});
+			scrollParents.forEach(({ el, left, top }) => {
+				(el as HTMLElement).scrollLeft = left;
+				(el as HTMLElement).scrollTop = top;
+			});
 			scrollEl.style.overflow = origOverflow;
 			scrollEl.style.height = origHeight;
-			if (span) span.textContent = origText;
-			btn.removeAttribute('disabled');
 		}
 	}
 
@@ -673,14 +713,36 @@ export class WereadReadingStatsView extends ItemView {
 				values = built.values;
 				labels = built.labels;
 			} else {
-				const entries = Object.entries(data.readTimes).sort(([a], [b]) => Number(a) - Number(b));
-				values = entries.map(([, v]) => v as number);
-				labels = entries.map(([ts]) => {
-					const d = new Date(Number(ts) * 1000);
-					if (this.currentMode === 'overall') return `${d.getFullYear()}`;
-					if (this.currentMode === 'annually') return `${d.getMonth() + 1}月`;
-					return `${d.getDate()}`;
-				});
+				if (this.currentMode === 'monthly') {
+					// Build full month: all days including future/unread ones
+					const baseTime = calcBaseTime('monthly', this.currentOffset);
+					const refDate = baseTime ? new Date(baseTime * 1000) : new Date();
+					const year = refDate.getFullYear();
+					const month = refDate.getMonth();
+					const daysInMonth = new Date(year, month + 1, 0).getDate();
+					const dayMap: Record<number, number> = {};
+					for (const [ts, secs] of Object.entries(data.readTimes)) {
+						const d = new Date(Number(ts) * 1000);
+						if (d.getFullYear() === year && d.getMonth() === month) {
+							dayMap[d.getDate()] = secs as number;
+						}
+					}
+					values = [];
+					labels = [];
+					for (let day = 1; day <= daysInMonth; day++) {
+						values.push(dayMap[day] ?? 0);
+						labels.push(String(day));
+					}
+				} else {
+					const entries = Object.entries(data.readTimes).sort(([a], [b]) => Number(a) - Number(b));
+					values = entries.map(([, v]) => v as number);
+					labels = entries.map(([ts]) => {
+						const d = new Date(Number(ts) * 1000);
+						if (this.currentMode === 'overall') return `${d.getFullYear()}`;
+						if (this.currentMode === 'annually') return `${d.getMonth() + 1}月`;
+						return `${d.getDate()}`;
+					});
+				}
 			}
 			this.renderBarChart(chartArea, values, labels);
 		}
@@ -799,6 +861,16 @@ export class WereadReadingStatsView extends ItemView {
 			Math.floor(new Date(year, m, 1).getTime() / 1000)
 		);
 
+		// If cache has data for this year, render immediately
+		const cachedYearData: Record<string, number> = {};
+		for (const [k, v] of Object.entries(cache.data)) {
+			if (k.startsWith(`${year}-`)) cachedYearData[k] = v;
+		}
+		if (Object.keys(cachedYearData).length > 0) {
+			(data as any)._dailyReadTimes = cachedYearData;
+			this.render();
+		}
+
 		// Only fetch months not yet cached (skip future months)
 		const toFetch = monthTimestamps.filter(ts => {
 			const d = new Date(ts * 1000);
@@ -808,6 +880,8 @@ export class WereadReadingStatsView extends ItemView {
 			const isFuture = d > today;
 			return !isFuture && (isCurrentMonth || !cache.fetchedMonths.includes(key));
 		});
+
+		if (toFetch.length === 0) return;
 
 		for (let i = 0; i < toFetch.length; i += BATCH) {
 			const results = await Promise.all(
@@ -875,6 +949,14 @@ export class WereadReadingStatsView extends ItemView {
 		let dirty = false;
 		const BATCH = 6;
 
+		// If cache has data, render immediately with cached data, then refresh current month in background
+		const hasCachedData = Object.keys(cache.data).length > 0;
+		if (hasCachedData) {
+			(data as any)._allDailyReadTimes = { ...cache.data };
+			(data as any)._statsStartYear = startYear;
+			this.render();
+		}
+
 		// Only fetch uncached months (always re-fetch current month)
 		const toFetch = monthTimestamps.filter(ts => {
 			const d = new Date(ts * 1000);
@@ -883,6 +965,16 @@ export class WereadReadingStatsView extends ItemView {
 			const isFuture = d > today;
 			return !isFuture && (isCurrentMonth || !cache.fetchedMonths.includes(key));
 		});
+
+		if (toFetch.length === 0) {
+			// Everything cached, just ensure rendered
+			if (!hasCachedData) {
+				(data as any)._allDailyReadTimes = cache.data;
+				(data as any)._statsStartYear = startYear;
+				this.render();
+			}
+			return;
+		}
 
 		for (let i = 0; i < toFetch.length; i += BATCH) {
 			const results = await Promise.all(

--- a/src/components/wereadReadingStats.ts
+++ b/src/components/wereadReadingStats.ts
@@ -196,9 +196,6 @@ export class WereadReadingStatsView extends ItemView {
 		this.renderTimeSeries(el, this.data);
 		this.renderTopBooks(el, this.data);
 		this.renderPreferences(el, this.data);
-		if (this.currentMode === 'overall') {
-			this.renderYearlyOverview(el, this.data);
-		}
 	}
 
 	// ── Header ────────────────────────────────────────────────────────
@@ -276,24 +273,27 @@ export class WereadReadingStatsView extends ItemView {
 		}
 
 		// 副标题：不同模式展示不同信息
+		// overall 模式 API 不返回 dayAverageReadTime，自己算
+		const avgReadTime = data.dayAverageReadTime || (data.readDays > 0 ? Math.round(data.totalReadTime / data.readDays) : 0);
 		const subtitleParts: string[] = [];
 		if (this.currentMode === 'overall' && data.registTime) {
 			subtitleParts.push(fmtTs(data.registTime) + '至今');
+			subtitleParts.push(`日均阅读 ${fmtDuration(avgReadTime)}`);
 			subtitleParts.push(`与微信读书相伴 ${data.readDays} 天`);
 		} else if (this.currentMode === 'annually') {
-			subtitleParts.push(`日均阅读 ${fmtDuration(data.dayAverageReadTime)}`);
+			subtitleParts.push(`日均阅读 ${fmtDuration(avgReadTime)}`);
 			if (data.compare !== undefined) {
 				const c = fmtCompare(data.compare);
 				if (c) subtitleParts.push(`比去年 ${c.up ? '↑' : '↓'}${c.text}`);
 			}
 		} else if (this.currentMode === 'monthly') {
-			subtitleParts.push(`日均阅读 ${fmtDuration(data.dayAverageReadTime)}`);
+			subtitleParts.push(`日均阅读 ${fmtDuration(avgReadTime)}`);
 			if (data.compare !== undefined) {
 				const c = fmtCompare(data.compare);
 				if (c) subtitleParts.push(`比上月 ${c.up ? '↑' : '↓'}${c.text}`);
 			}
 		} else if (this.currentMode === 'weekly') {
-			subtitleParts.push(`日均阅读 ${fmtDuration(data.dayAverageReadTime)}`);
+			subtitleParts.push(`日均阅读 ${fmtDuration(avgReadTime)}`);
 			if (data.compare !== undefined) {
 				const c = fmtCompare(data.compare);
 				if (c) subtitleParts.push(`比上周 ${c.up ? '↑' : '↓'}${c.text}`);
@@ -617,9 +617,9 @@ export class WereadReadingStatsView extends ItemView {
 	private renderPieChart(parent: HTMLElement, items: { label: string; value: number }[]) {
 		if (items.length < 3) return;
 		const n = items.length;
-		const size = 220;
+		const size = 160;
 		const cx = size / 2, cy = size / 2;
-		const maxR = size / 2 - 36; // 留出边距给标签
+		const maxR = size / 2 - 28; // 留出边距给标签
 		const maxVal = Math.max(...items.map(i => i.value), 1);
 
 		const svg = parent.createSvg('svg', {
@@ -704,26 +704,6 @@ export class WereadReadingStatsView extends ItemView {
 			span.style.opacity = String(opacity);
 			span.title = `${p.name}: ${p.count}本`;
 		});
-	}
-
-	// ── Yearly Overview ────────────────────────────────────────────────
-	private renderYearlyOverview(el: HTMLElement, data: ReadingStatsResponse) {
-		if (!data.readTimes || Object.keys(data.readTimes).length === 0) return;
-
-		const section = el.createDiv({ cls: 'weread-stats-section' });
-		section.createEl('h3', { text: '注册信息', cls: 'weread-stats-section-title' });
-		const infoGrid = section.createDiv({ cls: 'weread-stats-info-grid' });
-
-		const addInfo = (label: string, value: string) => {
-			const item = infoGrid.createDiv({ cls: 'weread-stats-info-item' });
-			item.createDiv({ cls: 'weread-stats-info-label', text: label });
-			item.createDiv({ cls: 'weread-stats-info-value', text: value });
-		};
-
-		if (data.registTime) addInfo('注册时间', fmtTs(data.registTime));
-		if (data.readRate !== undefined) addInfo('文字阅读占比', `${data.readRate}%`);
-		if (data.wrReadTime) addInfo('文字阅读', fmtDuration(data.wrReadTime));
-		if (data.wrListenTime) addInfo('听书时长', fmtDuration(data.wrListenTime));
 	}
 
 	// ── Empty states ──────────────────────────────────────────────────

--- a/src/components/wereadReadingStats.ts
+++ b/src/components/wereadReadingStats.ts
@@ -451,7 +451,7 @@ export class WereadReadingStatsView extends ItemView {
 		section.createEl('h3', { text: '偏好分析', cls: 'weread-stats-section-title' });
 		const prefGrid = section.createDiv({ cls: 'weread-stats-pref-grid' });
 
-		// ── 阅读时段（柱状图，加时段标签）
+		// ── 阅读时段（全宽柱状图）
 		if (hasTime) {
 			const timeCard = prefGrid.createDiv({ cls: 'weread-stats-pref-card weread-stats-pref-card-wide' });
 			const timeHeader = timeCard.createDiv({ cls: 'weread-stats-pref-card-header' });
@@ -463,17 +463,29 @@ export class WereadReadingStatsView extends ItemView {
 			this.renderHourBarChart(timeCard, data.preferTime!);
 		}
 
-		// ── 分类偏好（饼图）
-		if (hasCat) {
-			const cats = data.preferCategory.filter(c => c.readingTime > 0);
-			const catCard = prefGrid.createDiv({ cls: 'weread-stats-pref-card' });
-			const catHeader = catCard.createDiv({ cls: 'weread-stats-pref-card-header' });
-			setIcon(catHeader.createSpan(), 'tag');
-			catHeader.createSpan({ text: '分类偏好' });
-			if (data.preferCategoryWord) {
-				catCard.createDiv({ cls: 'weread-stats-pref-subtitle', text: data.preferCategoryWord });
+		// ── 分类偏好（饼图）+ 出版方（标签云）并排
+		if (hasCat || hasPublisher) {
+			// 分类饼图
+			if (hasCat) {
+				const cats = data.preferCategory.filter(c => c.readingTime > 0);
+				const catCard = prefGrid.createDiv({ cls: 'weread-stats-pref-card' });
+				const catHeader = catCard.createDiv({ cls: 'weread-stats-pref-card-header' });
+				setIcon(catHeader.createSpan(), 'tag');
+				catHeader.createSpan({ text: '分类偏好' });
+				if (data.preferCategoryWord) {
+					catCard.createDiv({ cls: 'weread-stats-pref-subtitle', text: data.preferCategoryWord });
+				}
+				this.renderPieChart(catCard, cats.slice(0, 8).map(c => ({ label: c.categoryTitle, value: c.readingTime })));
 			}
-			this.renderPieChart(catCard, cats.slice(0, 8).map(c => ({ label: c.categoryTitle, value: c.readingTime })));
+
+			// 出版方标签云（与分类同行，非全宽）
+			if (hasPublisher) {
+				const pubCard = prefGrid.createDiv({ cls: 'weread-stats-pref-card' });
+				const pubHeader = pubCard.createDiv({ cls: 'weread-stats-pref-card-header' });
+				setIcon(pubHeader.createSpan(), 'building-2');
+				pubHeader.createSpan({ text: '偏好出版方' });
+				this.renderTagCloud(pubCard, data.preferPublisher!.slice(0, 20));
+			}
 		}
 
 		// ── 偏好作者
@@ -487,15 +499,6 @@ export class WereadReadingStatsView extends ItemView {
 				row.createSpan({ cls: 'weread-stats-pref-name', text: a.name });
 				row.createSpan({ cls: 'weread-stats-pref-meta', text: `${a.count}本 · ${a.readTime}` });
 			});
-		}
-
-		// ── 出版方标签云
-		if (hasPublisher) {
-			const pubCard = prefGrid.createDiv({ cls: 'weread-stats-pref-card weread-stats-pref-card-wide' });
-			const pubHeader = pubCard.createDiv({ cls: 'weread-stats-pref-card-header' });
-			setIcon(pubHeader.createSpan(), 'building-2');
-			pubHeader.createSpan({ text: '偏好出版方' });
-			this.renderTagCloud(pubCard, data.preferPublisher!.slice(0, 20));
 		}
 	}
 

--- a/src/components/wereadReadingStats.ts
+++ b/src/components/wereadReadingStats.ts
@@ -1,0 +1,486 @@
+import { ItemView, WorkspaceLeaf, setIcon } from 'obsidian';
+import ApiManager from '../api';
+import SyncReadingStats from '../syncReadingStats';
+import { settingsStore } from '../settings';
+import { get } from 'svelte/store';
+import type { ReadingStatsResponse, ReadingStatsMode } from '../models';
+
+export const WEREAD_READING_STATS_VIEW_ID = 'weread-reading-stats-view';
+
+// ─── 格式化工具 ───────────────────────────────────────────────────────────────
+
+function fmtDuration(seconds: number): string {
+	if (!seconds) return '0分钟';
+	const h = Math.floor(seconds / 3600);
+	const m = Math.floor((seconds % 3600) / 60);
+	if (h > 0 && m > 0) return `${h}小时${m}分钟`;
+	if (h > 0) return `${h}小时`;
+	return `${m}分钟`;
+}
+
+function fmtTs(ts: number): string {
+	if (!ts) return '—';
+	const d = new Date(ts * 1000);
+	return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function fmtCompare(compare?: number): { text: string; up: boolean } | null {
+	if (compare === undefined || compare === null) return null;
+	const pct = Math.round(Math.abs(compare) * 100);
+	return { text: `${pct}%`, up: compare >= 0 };
+}
+
+// preferTime 从 6 点开始排列
+const HOUR_LABELS = ['6','7','8','9','10','11','12','13','14','15','16','17','18','19','20','21','22','23','0','1','2','3','4','5'];
+
+// ─── View ─────────────────────────────────────────────────────────────────────
+
+export class WereadReadingStatsView extends ItemView {
+	private apiManager: ApiManager;
+	private syncReadingStats: SyncReadingStats;
+	private currentMode: ReadingStatsMode = 'monthly';
+	private data: ReadingStatsResponse | null = null;
+	private loading = false;
+	private contentEl2: HTMLElement; // renamed to avoid shadow
+
+	constructor(leaf: WorkspaceLeaf, apiManager: ApiManager, syncReadingStats: SyncReadingStats) {
+		super(leaf);
+		this.apiManager = apiManager;
+		this.syncReadingStats = syncReadingStats;
+	}
+
+	getViewType(): string { return WEREAD_READING_STATS_VIEW_ID; }
+	getDisplayText(): string { return '阅读统计'; }
+	getIcon(): string { return 'bar-chart-2'; }
+
+	async onOpen() {
+		const { containerEl } = this;
+		containerEl.empty();
+		containerEl.addClass('weread-stats-view');
+		this.contentEl2 = containerEl.createDiv({ cls: 'weread-stats-container' });
+		this.render();
+		this.loadData();
+	}
+
+	async onClose() {
+		this.containerEl.empty();
+	}
+
+	private async loadData() {
+		const settings = get(settingsStore);
+		if (!settings.wereadApiKey) {
+			this.renderNoApiKey();
+			return;
+		}
+		this.loading = true;
+		this.renderLoading();
+
+		const now = new Date();
+		let baseTime: number | undefined;
+		if (this.currentMode === 'annually') {
+			baseTime = Math.floor(new Date(now.getFullYear(), 0, 1).getTime() / 1000);
+		}
+
+		const data = await this.apiManager.getReadingStats(this.currentMode, baseTime);
+		this.loading = false;
+		if (!data) {
+			this.renderError();
+			return;
+		}
+		this.data = data;
+		this.render();
+	}
+
+	private render() {
+		const el = this.contentEl2;
+		el.empty();
+
+		if (!get(settingsStore).wereadApiKey) {
+			this.renderNoApiKey();
+			return;
+		}
+		if (this.loading) {
+			this.renderLoading();
+			return;
+		}
+		if (!this.data) return;
+
+		this.renderHeader(el);
+		this.renderTabBar(el);
+		this.renderKPICards(el, this.data);
+		this.renderTimeSeries(el, this.data);
+		this.renderTopBooks(el, this.data);
+		this.renderPreferences(el, this.data);
+		if (this.currentMode === 'overall' || this.currentMode === 'annually') {
+			this.renderYearlyOverview(el, this.data);
+		}
+	}
+
+	// ── Header ────────────────────────────────────────────────────────
+	private renderHeader(el: HTMLElement) {
+		const header = el.createDiv({ cls: 'weread-stats-header' });
+		const titleRow = header.createDiv({ cls: 'weread-stats-title-row' });
+		const icon = titleRow.createSpan({ cls: 'weread-stats-header-icon' });
+		setIcon(icon, 'bar-chart-2');
+		titleRow.createEl('h2', { text: '阅读统计', cls: 'weread-stats-title' });
+
+		const actions = header.createDiv({ cls: 'weread-stats-header-actions' });
+
+		// 同步统计文档按钮
+		const exportBtn = actions.createEl('button', {
+			cls: 'weread-stats-btn',
+			attr: { 'aria-label': '导出 Markdown' }
+		});
+		setIcon(exportBtn, 'file-text');
+		exportBtn.createSpan({ text: '导出 Markdown' });
+		exportBtn.addEventListener('click', () => {
+			this.syncReadingStats.sync();
+		});
+
+		// 刷新按钮
+		const refreshBtn = actions.createEl('button', {
+			cls: 'weread-stats-btn weread-stats-btn-icon',
+			attr: { 'aria-label': '刷新数据' }
+		});
+		setIcon(refreshBtn, 'refresh-ccw');
+		refreshBtn.addEventListener('click', () => {
+			this.data = null;
+			this.loadData();
+		});
+	}
+
+	// ── Tab bar ───────────────────────────────────────────────────────
+	private renderTabBar(el: HTMLElement) {
+		const tabs: { mode: ReadingStatsMode; label: string }[] = [
+			{ mode: 'weekly', label: '本周' },
+			{ mode: 'monthly', label: '本月' },
+			{ mode: 'annually', label: '本年' },
+			{ mode: 'overall', label: '全部' },
+		];
+
+		const bar = el.createDiv({ cls: 'weread-stats-tabbar' });
+		for (const tab of tabs) {
+			const btn = bar.createEl('button', {
+				text: tab.label,
+				cls: 'weread-stats-tab' + (this.currentMode === tab.mode ? ' is-active' : '')
+			});
+			btn.addEventListener('click', () => {
+				if (this.currentMode === tab.mode) return;
+				this.currentMode = tab.mode;
+				this.data = null;
+				this.render();
+				this.loadData();
+			});
+		}
+	}
+
+	// ── KPI Cards ─────────────────────────────────────────────────────
+	private renderKPICards(el: HTMLElement, data: ReadingStatsResponse) {
+		const grid = el.createDiv({ cls: 'weread-stats-kpi-grid' });
+
+		// 总阅读时长
+		this.makeKPICard(grid, '阅读时长', fmtDuration(data.totalReadTime), 'clock');
+
+		// 阅读天数
+		this.makeKPICard(grid, '阅读天数', `${data.readDays} 天`, 'calendar');
+
+		// 日均时长
+		this.makeKPICard(grid, '日均时长', fmtDuration(data.dayAverageReadTime), 'trending-up',
+			data.compare !== undefined ? fmtCompare(data.compare) : null);
+
+		// 从 readStat 里找读过本数和笔记数
+		const readStat = data.readStat ?? [];
+		const readCount = readStat.find(s => s.stat === '读过')?.counts ?? '—';
+		const finishCount = readStat.find(s => s.stat === '读完')?.counts ?? '—';
+		const noteCount = readStat.find(s => s.stat === '笔记')?.counts ?? '—';
+
+		this.makeKPICard(grid, '读过', readCount, 'book-open');
+		this.makeKPICard(grid, '读完', finishCount, 'check-circle');
+		this.makeKPICard(grid, '笔记', noteCount, 'pencil');
+	}
+
+	private makeKPICard(
+		parent: HTMLElement,
+		label: string,
+		value: string,
+		iconName: string,
+		compare?: { text: string; up: boolean } | null
+	) {
+		const card = parent.createDiv({ cls: 'weread-stats-kpi-card' });
+		const iconEl = card.createDiv({ cls: 'weread-stats-kpi-icon' });
+		setIcon(iconEl, iconName);
+		const body = card.createDiv({ cls: 'weread-stats-kpi-body' });
+		body.createDiv({ cls: 'weread-stats-kpi-value', text: value });
+		const labelRow = body.createDiv({ cls: 'weread-stats-kpi-label-row' });
+		labelRow.createSpan({ text: label, cls: 'weread-stats-kpi-label' });
+		if (compare) {
+			labelRow.createSpan({
+				cls: 'weread-stats-compare-badge ' + (compare.up ? 'is-up' : 'is-down'),
+				text: (compare.up ? '↑' : '↓') + compare.text
+			});
+		}
+	}
+
+	// ── Time Series Chart ─────────────────────────────────────────────
+	private renderTimeSeries(el: HTMLElement, data: ReadingStatsResponse) {
+		if (!data.readTimes || Object.keys(data.readTimes).length === 0) return;
+
+		const section = el.createDiv({ cls: 'weread-stats-section' });
+
+		const modeLabel: Record<ReadingStatsMode, string> = {
+			weekly: '每日阅读时长（本周）',
+			monthly: '每日阅读时长（本月）',
+			annually: '每月阅读时长（本年）',
+			overall: '每年阅读时长（历史）'
+		};
+		section.createEl('h3', { text: modeLabel[this.currentMode], cls: 'weread-stats-section-title' });
+
+		const entries = Object.entries(data.readTimes)
+			.sort(([a], [b]) => Number(a) - Number(b));
+
+		const values = entries.map(([, v]) => v as number);
+		const labels = entries.map(([ts]) => {
+			const d = new Date(Number(ts) * 1000);
+			if (this.currentMode === 'overall') return `${d.getFullYear()}`;
+			if (this.currentMode === 'annually') return `${d.getMonth() + 1}月`;
+			return `${d.getDate()}`;
+		});
+
+		this.renderBarChart(section, values, labels);
+	}
+
+	// ── Bar Chart (SVG-based) ─────────────────────────────────────────
+	private renderBarChart(parent: HTMLElement, values: number[], labels: string[]) {
+		const maxVal = Math.max(...values, 1);
+		const barW = 28;
+		const gap = 6;
+		const chartH = 120;
+		const labelH = 20;
+		const totalW = (barW + gap) * values.length;
+
+		const wrapper = parent.createDiv({ cls: 'weread-stats-chart-wrapper' });
+		const svg = wrapper.createSvg('svg', {
+			attr: {
+				viewBox: `0 0 ${totalW} ${chartH + labelH}`,
+				width: '100%',
+				height: chartH + labelH,
+				class: 'weread-stats-bar-chart'
+			}
+		});
+
+		values.forEach((v, i) => {
+			const barH = Math.max((v / maxVal) * chartH, v > 0 ? 4 : 0);
+			const x = i * (barW + gap);
+			const y = chartH - barH;
+
+			// bar
+			const rect = svg.createSvg('rect', {
+				attr: {
+					x: String(x),
+					y: String(y),
+					width: String(barW),
+					height: String(barH),
+					rx: '4',
+					class: 'weread-stats-bar' + (v === maxVal ? ' is-max' : '')
+				}
+			});
+
+			// tooltip on hover via title
+			rect.createSvg('title').textContent = `${labels[i]}: ${fmtDuration(v)}`;
+
+			// label
+			const text = svg.createSvg('text', {
+				attr: {
+					x: String(x + barW / 2),
+					y: String(chartH + labelH - 2),
+					'text-anchor': 'middle',
+					class: 'weread-stats-bar-label'
+				}
+			});
+			text.textContent = labels[i];
+		});
+	}
+
+	// ── Top Books ─────────────────────────────────────────────────────
+	private renderTopBooks(el: HTMLElement, data: ReadingStatsResponse) {
+		if (!data.readLongest?.length) return;
+
+		const section = el.createDiv({ cls: 'weread-stats-section' });
+		section.createEl('h3', { text: `阅读时长 Top ${data.readLongest.length}`, cls: 'weread-stats-section-title' });
+
+		const maxTime = Math.max(...data.readLongest.map(b => b.readTime), 1);
+
+		const list = section.createDiv({ cls: 'weread-stats-book-list' });
+		data.readLongest.forEach((item, i) => {
+			const title = item.book?.title ?? item.albumInfo?.name ?? '未知';
+			const author = item.book?.author ?? item.albumInfo?.authorName ?? '';
+			const cover = item.book?.cover ?? item.albumInfo?.cover ?? '';
+			const pct = (item.readTime / maxTime) * 100;
+
+			const row = list.createDiv({ cls: 'weread-stats-book-row' });
+
+			// rank
+			row.createDiv({ cls: 'weread-stats-book-rank', text: String(i + 1) });
+
+			// cover
+			if (cover) {
+				const img = row.createEl('img', { cls: 'weread-stats-book-cover' });
+				img.src = cover;
+				img.alt = title;
+			} else {
+				const placeholder = row.createDiv({ cls: 'weread-stats-book-cover weread-stats-book-cover-placeholder' });
+				setIcon(placeholder, 'book');
+			}
+
+			// info
+			const info = row.createDiv({ cls: 'weread-stats-book-info' });
+			info.createDiv({ cls: 'weread-stats-book-title', text: title });
+			if (author) info.createDiv({ cls: 'weread-stats-book-author', text: author });
+
+			// tags
+			if (item.tags?.length) {
+				const tagRow = info.createDiv({ cls: 'weread-stats-book-tags' });
+				item.tags.forEach(tag => tagRow.createSpan({ cls: 'weread-stats-tag', text: tag }));
+			}
+
+			// progress bar + duration
+			const right = row.createDiv({ cls: 'weread-stats-book-right' });
+			right.createDiv({ cls: 'weread-stats-book-duration', text: fmtDuration(item.readTime) });
+			const barTrack = right.createDiv({ cls: 'weread-stats-mini-bar-track' });
+			const barFill = barTrack.createDiv({ cls: 'weread-stats-mini-bar-fill' });
+			barFill.style.width = `${pct}%`;
+		});
+	}
+
+	// ── Preferences ───────────────────────────────────────────────────
+	private renderPreferences(el: HTMLElement, data: ReadingStatsResponse) {
+		const hasCat = data.preferCategory?.some(c => c.readingTime > 0);
+		const hasAuthor = data.preferAuthor?.length;
+		const hasTime = data.preferTime?.length === 24;
+		if (!hasCat && !hasAuthor && !hasTime) return;
+
+		const section = el.createDiv({ cls: 'weread-stats-section' });
+		section.createEl('h3', { text: '偏好分析', cls: 'weread-stats-section-title' });
+
+		const prefGrid = section.createDiv({ cls: 'weread-stats-pref-grid' });
+
+		// 分类偏好
+		if (hasCat) {
+			const cats = data.preferCategory.filter(c => c.readingTime > 0);
+			const maxCatTime = Math.max(...cats.map(c => c.readingTime), 1);
+
+			const catCard = prefGrid.createDiv({ cls: 'weread-stats-pref-card' });
+			const catHeader = catCard.createDiv({ cls: 'weread-stats-pref-card-header' });
+			setIcon(catHeader.createSpan(), 'tag');
+			catHeader.createSpan({ text: '分类偏好' });
+			if (data.preferCategoryWord) {
+				catCard.createDiv({ cls: 'weread-stats-pref-subtitle', text: data.preferCategoryWord });
+			}
+
+			cats.slice(0, 6).forEach(cat => {
+				const pct = (cat.readingTime / maxCatTime) * 100;
+				const row = catCard.createDiv({ cls: 'weread-stats-pref-row' });
+				row.createSpan({ cls: 'weread-stats-pref-name', text: cat.categoryTitle });
+				const barTrack = row.createDiv({ cls: 'weread-stats-pref-bar-track' });
+				barTrack.createDiv({ cls: 'weread-stats-pref-bar-fill' }).style.width = `${pct}%`;
+				row.createSpan({ cls: 'weread-stats-pref-meta', text: fmtDuration(cat.readingTime) });
+			});
+		}
+
+		// 作者偏好
+		if (hasAuthor) {
+			const authorCard = prefGrid.createDiv({ cls: 'weread-stats-pref-card' });
+			const authorHeader = authorCard.createDiv({ cls: 'weread-stats-pref-card-header' });
+			setIcon(authorHeader.createSpan(), 'user');
+			authorHeader.createSpan({ text: '偏好作者' });
+
+			data.preferAuthor!.slice(0, 6).forEach(a => {
+				const row = authorCard.createDiv({ cls: 'weread-stats-pref-row' });
+				row.createSpan({ cls: 'weread-stats-pref-name', text: a.name });
+				row.createSpan({ cls: 'weread-stats-pref-meta', text: `${a.count}本 · ${a.readTime}` });
+			});
+		}
+
+		// 阅读时段
+		if (hasTime) {
+			const timeCard = prefGrid.createDiv({ cls: 'weread-stats-pref-card weread-stats-pref-card-wide' });
+			const timeHeader = timeCard.createDiv({ cls: 'weread-stats-pref-card-header' });
+			setIcon(timeHeader.createSpan(), 'clock');
+			timeHeader.createSpan({ text: '阅读时段分布' });
+			if (data.preferTimeWord) {
+				timeCard.createDiv({ cls: 'weread-stats-pref-subtitle', text: data.preferTimeWord });
+			}
+
+			const maxTimeVal = Math.max(...data.preferTime!, 1);
+			const hourChart = timeCard.createDiv({ cls: 'weread-stats-hour-chart' });
+			data.preferTime!.forEach((v, i) => {
+				const col = hourChart.createDiv({ cls: 'weread-stats-hour-col' });
+				const barH = Math.max((v / maxTimeVal) * 48, v > 0 ? 3 : 0);
+				const bar = col.createDiv({ cls: 'weread-stats-hour-bar' });
+				bar.style.height = `${barH}px`;
+				bar.title = `${HOUR_LABELS[i]}时: ${fmtDuration(v)}`;
+				if (i % 3 === 0) {
+					col.createDiv({ cls: 'weread-stats-hour-label', text: HOUR_LABELS[i] });
+				} else {
+					col.createDiv({ cls: 'weread-stats-hour-label' });
+				}
+			});
+		}
+	}
+
+	// ── Yearly Overview (overall only) ────────────────────────────────
+	private renderYearlyOverview(el: HTMLElement, data: ReadingStatsResponse) {
+		if (!data.readTimes || Object.keys(data.readTimes).length === 0) return;
+		if (this.currentMode !== 'overall') return;
+
+		const section = el.createDiv({ cls: 'weread-stats-section' });
+		section.createEl('h3', { text: '注册信息', cls: 'weread-stats-section-title' });
+
+		const infoGrid = section.createDiv({ cls: 'weread-stats-info-grid' });
+		if (data.registTime) {
+			const item = infoGrid.createDiv({ cls: 'weread-stats-info-item' });
+			item.createDiv({ cls: 'weread-stats-info-label', text: '注册时间' });
+			item.createDiv({ cls: 'weread-stats-info-value', text: fmtTs(data.registTime) });
+		}
+		if (data.readRate !== undefined) {
+			const item = infoGrid.createDiv({ cls: 'weread-stats-info-item' });
+			item.createDiv({ cls: 'weread-stats-info-label', text: '文字阅读占比' });
+			item.createDiv({ cls: 'weread-stats-info-value', text: `${data.readRate}%` });
+		}
+		if (data.wrReadTime) {
+			const item = infoGrid.createDiv({ cls: 'weread-stats-info-item' });
+			item.createDiv({ cls: 'weread-stats-info-label', text: '文字阅读' });
+			item.createDiv({ cls: 'weread-stats-info-value', text: fmtDuration(data.wrReadTime) });
+		}
+		if (data.wrListenTime) {
+			const item = infoGrid.createDiv({ cls: 'weread-stats-info-item' });
+			item.createDiv({ cls: 'weread-stats-info-label', text: '听书时长' });
+			item.createDiv({ cls: 'weread-stats-info-value', text: fmtDuration(data.wrListenTime) });
+		}
+	}
+
+	// ── Empty states ──────────────────────────────────────────────────
+	private renderLoading() {
+		this.contentEl2.empty();
+		const wrap = this.contentEl2.createDiv({ cls: 'weread-stats-empty' });
+		wrap.createDiv({ cls: 'weread-stats-spinner' });
+		wrap.createDiv({ text: '正在加载数据…', cls: 'weread-stats-empty-text' });
+	}
+
+	private renderNoApiKey() {
+		this.contentEl2.empty();
+		const wrap = this.contentEl2.createDiv({ cls: 'weread-stats-empty' });
+		setIcon(wrap.createDiv({ cls: 'weread-stats-empty-icon' }), 'key');
+		wrap.createDiv({ text: '请先在设置中填写微信读书 API Key', cls: 'weread-stats-empty-text' });
+		wrap.createDiv({ text: '设置 → 微信读书 → 阅读统计 → API Key', cls: 'weread-stats-empty-hint' });
+	}
+
+	private renderError() {
+		this.contentEl2.empty();
+		const wrap = this.contentEl2.createDiv({ cls: 'weread-stats-empty' });
+		setIcon(wrap.createDiv({ cls: 'weread-stats-empty-icon' }), 'alert-circle');
+		wrap.createDiv({ text: '数据加载失败，请检查 API Key 或网络', cls: 'weread-stats-empty-text' });
+		const retryBtn = wrap.createEl('button', { text: '重试', cls: 'weread-stats-btn' });
+		retryBtn.addEventListener('click', () => this.loadData());
+	}
+}

--- a/src/components/wereadReadingStats.ts
+++ b/src/components/wereadReadingStats.ts
@@ -1,6 +1,7 @@
-import { ItemView, WorkspaceLeaf, setIcon } from 'obsidian';
+import { ItemView, WorkspaceLeaf, setIcon, TFile } from 'obsidian';
 import ApiManager from '../api';
 import SyncReadingStats from '../syncReadingStats';
+import FileManager from '../fileManager';
 import { settingsStore } from '../settings';
 import { get } from 'svelte/store';
 import type { ReadingStatsResponse, ReadingStatsMode } from '../models';
@@ -32,6 +33,8 @@ function fmtCompare(compare?: number): { text: string; up: boolean } | null {
 
 // preferTime 从 6 点开始排列
 const HOUR_LABELS = ['6','7','8','9','10','11','12','13','14','15','16','17','18','19','20','21','22','23','0','1','2','3','4','5'];
+
+const WEEK_LABELS = ['一', '二', '三', '四', '五', '六', '日'];
 
 // ─── 时间偏移计算 ──────────────────────────────────────────────────────────────
 
@@ -85,16 +88,18 @@ function periodLabel(mode: ReadingStatsMode, offset: number): string {
 export class WereadReadingStatsView extends ItemView {
 	private apiManager: ApiManager;
 	private syncReadingStats: SyncReadingStats;
+	private fileManager: FileManager;
 	private currentMode: ReadingStatsMode = 'monthly';
 	private currentOffset = 0; // 0=当前，-1=上一期，...
 	private data: ReadingStatsResponse | null = null;
 	private loading = false;
 	private contentEl2: HTMLElement;
 
-	constructor(leaf: WorkspaceLeaf, apiManager: ApiManager, syncReadingStats: SyncReadingStats) {
+	constructor(leaf: WorkspaceLeaf, apiManager: ApiManager, syncReadingStats: SyncReadingStats, fileManager: FileManager) {
 		super(leaf);
 		this.apiManager = apiManager;
 		this.syncReadingStats = syncReadingStats;
+		this.fileManager = fileManager;
 	}
 
 	getViewType(): string { return WEREAD_READING_STATS_VIEW_ID; }
@@ -318,32 +323,42 @@ export class WereadReadingStatsView extends ItemView {
 			const d = new Date(Number(ts) * 1000);
 			if (this.currentMode === 'overall') return `${d.getFullYear()}`;
 			if (this.currentMode === 'annually') return `${d.getMonth() + 1}月`;
+			if (this.currentMode === 'weekly') {
+				// getDay(): 0=Sun,1=Mon,...,6=Sat → WEEK_LABELS index: 0=Mon,...,6=Sun
+				const dow = d.getDay();
+				const idx = dow === 0 ? 6 : dow - 1;
+				return WEEK_LABELS[idx];
+			}
 			return `${d.getDate()}`;
 		});
 
 		this.renderBarChart(section, values, labels);
 	}
 
-	// ── Bar Chart (SVG-based) ─────────────────────────────────────────
+	// ── Bar Chart (SVG-based, with Y scale) ──────────────────────────
 	private renderBarChart(parent: HTMLElement, values: number[], labels: string[]) {
 		const maxVal = Math.max(...values, 1);
-		// 根据数量动态计算 bar 宽度，最小 16px 最大 40px
-		const minBarW = 16, maxBarW = 40;
 		const gap = 4;
-		const chartH = 120;
-		const labelH = 20;
+		const chartH = 140;
+		const labelH = 22;
+		const scaleW = 48; // left gutter for Y-axis labels
 
 		const wrapper = parent.createDiv({ cls: 'weread-stats-chart-wrapper' });
 
-		// 先渲染再根据容器宽度调整
-		const barW = Math.min(maxBarW, Math.max(minBarW,
-			Math.floor((wrapper.clientWidth || 600) / values.length) - gap
-		));
-		const totalW = (barW + gap) * values.length;
+		// compute nice scale ticks
+		const tickMax = maxVal; // seconds
+		const ticks = [0, 0.5, 1].map(f => Math.round(tickMax * f)); // 0, mid, max
+
+		// SVG fills full width; bars share space equally
+		const n = values.length;
+		// We use a fixed viewBox wide enough; bars spaced evenly
+		const barAreaW = 600; // logical width for bars
+		const barW = Math.max(8, Math.floor(barAreaW / n) - gap);
+		const totalViewW = scaleW + barAreaW;
 
 		const svg = wrapper.createSvg('svg', {
 			attr: {
-				viewBox: `0 0 ${totalW} ${chartH + labelH}`,
+				viewBox: `0 0 ${totalViewW} ${chartH + labelH}`,
 				width: '100%',
 				height: chartH + labelH,
 				class: 'weread-stats-bar-chart',
@@ -351,9 +366,37 @@ export class WereadReadingStatsView extends ItemView {
 			}
 		});
 
+		// Y-axis guide lines + labels
+		for (let ti = 0; ti < ticks.length; ti++) {
+			const tickVal = ticks[ti];
+			const yPos = chartH - (tickVal / maxVal) * chartH;
+
+			// dashed line across bar area
+			svg.createSvg('line', {
+				attr: {
+					x1: String(scaleW), y1: String(yPos),
+					x2: String(totalViewW), y2: String(yPos),
+					class: 'weread-stats-scale-line'
+				}
+			});
+
+			// label on left
+			const lbl = svg.createSvg('text', {
+				attr: {
+					x: String(scaleW - 4),
+					y: String(yPos + 4),
+					'text-anchor': 'end',
+					class: 'weread-stats-scale-label'
+				}
+			});
+			lbl.textContent = ti === 0 ? '0' : fmtDuration(tickVal);
+		}
+
+		// Bars + labels
 		values.forEach((v, i) => {
 			const barH = Math.max((v / maxVal) * chartH, v > 0 ? 4 : 0);
-			const x = i * (barW + gap);
+			const slotW = barAreaW / n;
+			const x = scaleW + i * slotW + (slotW - barW) / 2;
 			const y = chartH - barH;
 
 			const rect = svg.createSvg('rect', {
@@ -362,11 +405,10 @@ export class WereadReadingStatsView extends ItemView {
 					y: String(y),
 					width: String(barW),
 					height: String(barH),
-					rx: '3',
+					rx: '4',
 					class: 'weread-stats-bar' + (v === maxVal ? ' is-max' : '')
 				}
 			});
-
 			rect.createSvg('title').textContent = `${labels[i]}: ${fmtDuration(v)}`;
 
 			const text = svg.createSvg('text', {
@@ -395,6 +437,7 @@ export class WereadReadingStatsView extends ItemView {
 			const title = item.book?.title ?? item.albumInfo?.name ?? '未知';
 			const author = item.book?.author ?? item.albumInfo?.authorName ?? '';
 			const cover = item.book?.cover ?? item.albumInfo?.cover ?? '';
+			const bookId = item.book?.bookId ?? item.albumInfo?.albumId ?? '';
 			const pct = (item.readTime / maxTime) * 100;
 
 			const row = list.createDiv({ cls: 'weread-stats-book-row' });
@@ -424,6 +467,19 @@ export class WereadReadingStatsView extends ItemView {
 			const barTrack = right.createDiv({ cls: 'weread-stats-mini-bar-track' });
 			const barFill = barTrack.createDiv({ cls: 'weread-stats-mini-bar-fill' });
 			barFill.style.width = `${pct}%`;
+
+			// 点击跳转到本地笔记
+			if (bookId) {
+				row.addClass('weread-stats-book-row-clickable');
+				row.addEventListener('click', async () => {
+					const bookIdMap = await this.fileManager.getNotebookFilesByBookId();
+					const annotationFile = bookIdMap.get(bookId);
+					if (annotationFile?.file instanceof TFile) {
+						const leaf = this.app.workspace.getLeaf(false);
+						await leaf.openFile(annotationFile.file);
+					}
+				});
+			}
 		});
 	}
 

--- a/src/components/wereadReadingStats.ts
+++ b/src/components/wereadReadingStats.ts
@@ -206,13 +206,7 @@ export class WereadReadingStatsView extends ItemView {
 		setIcon(icon, 'bar-chart-2');
 		titleRow.createEl('h2', { text: '阅读统计', cls: 'weread-stats-title' });
 
-		const actions = header.createDiv({ cls: 'weread-stats-header-actions' });
-		const exportBtn = actions.createEl('button', { cls: 'weread-stats-btn', attr: { 'aria-label': '导出 Markdown' } });
-		setIcon(exportBtn, 'file-text');
-		exportBtn.createSpan({ text: '导出 Markdown' });
-		exportBtn.addEventListener('click', () => this.syncReadingStats.sync());
-
-		const refreshBtn = actions.createEl('button', { cls: 'weread-stats-btn weread-stats-btn-icon', attr: { 'aria-label': '刷新数据' } });
+		const refreshBtn = titleRow.createEl('button', { cls: 'weread-stats-btn weread-stats-btn-icon', attr: { 'aria-label': '刷新数据' } });
 		setIcon(refreshBtn, 'refresh-ccw');
 		refreshBtn.addEventListener('click', () => { this.data = null; this.loadData(); });
 	}

--- a/src/components/wereadReadingStats.ts
+++ b/src/components/wereadReadingStats.ts
@@ -488,16 +488,19 @@ export class WereadReadingStatsView extends ItemView {
 			}
 		}
 
-		// ── 偏好作者
+		// ── 偏好作者（进度条）
 		if (hasAuthor) {
 			const authorCard = prefGrid.createDiv({ cls: 'weread-stats-pref-card' });
 			const authorHeader = authorCard.createDiv({ cls: 'weread-stats-pref-card-header' });
 			setIcon(authorHeader.createSpan(), 'user');
 			authorHeader.createSpan({ text: '偏好作者' });
+			const maxCount = Math.max(...data.preferAuthor!.map(a => a.count), 1);
 			data.preferAuthor!.slice(0, 6).forEach(a => {
-				const row = authorCard.createDiv({ cls: 'weread-stats-pref-row' });
+				const row = authorCard.createDiv({ cls: 'weread-stats-pref-row weread-stats-pref-row-author' });
 				row.createSpan({ cls: 'weread-stats-pref-name', text: a.name });
-				row.createSpan({ cls: 'weread-stats-pref-meta', text: `${a.count}本 · ${a.readTime}` });
+				const barWrap = row.createDiv({ cls: 'weread-stats-pref-bar-track' });
+				barWrap.createDiv({ cls: 'weread-stats-pref-bar-fill' }).style.width = `${(a.count / maxCount) * 100}%`;
+				row.createSpan({ cls: 'weread-stats-pref-meta', text: `${a.count}本` });
 			});
 		}
 	}
@@ -561,50 +564,81 @@ export class WereadReadingStatsView extends ItemView {
 		});
 	}
 
-	/** 简单 SVG 饼图 + 图例 */
+	/** SVG 雷达图（蜘蛛网图），带渐变填充 */
 	private renderPieChart(parent: HTMLElement, items: { label: string; value: number }[]) {
-		const total = items.reduce((s, it) => s + it.value, 0);
-		if (total === 0) return;
+		if (items.length < 3) return;
+		const n = items.length;
+		const size = 220;
+		const cx = size / 2, cy = size / 2;
+		const maxR = size / 2 - 36; // 留出边距给标签
+		const maxVal = Math.max(...items.map(i => i.value), 1);
 
-		const size = 120;
-		const cx = size / 2, cy = size / 2, r = size / 2 - 4;
-		// accent palette: rotate hue from accent color
-		const COLORS = ['#7c6af7','#a78bfa','#6366f1','#818cf8','#c4b5fd','#4f46e5','#ddd6fe','#3730a3'];
-
-		const pieWrap = parent.createDiv({ cls: 'weread-stats-pie-wrap' });
-
-		const svg = pieWrap.createSvg('svg', {
-			attr: { width: String(size), height: String(size), viewBox: `0 0 ${size} ${size}`, class: 'weread-stats-pie-svg' }
+		const svg = parent.createSvg('svg', {
+			attr: { width: '100%', viewBox: `0 0 ${size} ${size}`, class: 'weread-stats-radar-svg', preserveAspectRatio: 'xMidYMid meet' }
 		});
 
-		let angle = -Math.PI / 2; // start top
-		items.forEach((item, idx) => {
-			const sweep = (item.value / total) * 2 * Math.PI;
-			const x1 = cx + r * Math.cos(angle);
-			const y1 = cy + r * Math.sin(angle);
-			const x2 = cx + r * Math.cos(angle + sweep);
-			const y2 = cy + r * Math.sin(angle + sweep);
-			const large = sweep > Math.PI ? 1 : 0;
+		// 定义渐变
+		const defs = svg.createSvg('defs');
+		const grad = defs.createSvg('radialGradient');
+		grad.setAttribute('id', 'radarGrad');
+		grad.setAttribute('cx', '50%'); grad.setAttribute('cy', '50%'); grad.setAttribute('r', '50%');
+		const stop1 = grad.createSvg('stop');
+		stop1.setAttribute('offset', '0%'); stop1.setAttribute('stop-color', '#90c8f8'); stop1.setAttribute('stop-opacity', '0.9');
+		const stop2 = grad.createSvg('stop');
+		stop2.setAttribute('offset', '100%'); stop2.setAttribute('stop-color', '#c8e6fc'); stop2.setAttribute('stop-opacity', '0.4');
 
-			const path = svg.createSvg('path', {
-				attr: {
-					d: `M ${cx} ${cy} L ${x1} ${y1} A ${r} ${r} 0 ${large} 1 ${x2} ${y2} Z`,
-					class: 'weread-stats-pie-slice'
-				}
-			});
-			(path as SVGElement).setAttribute('style', `fill: ${COLORS[idx % COLORS.length]}`);
-			path.createSvg('title').textContent = `${item.label}: ${fmtDuration(item.value)}`;
-			angle += sweep;
+		// 坐标计算（从顶部开始，顺时针）
+		const angle = (i: number) => (2 * Math.PI * i) / n - Math.PI / 2;
+		const pt = (i: number, r: number) => ({
+			x: cx + r * Math.cos(angle(i)),
+			y: cy + r * Math.sin(angle(i))
 		});
 
-		// Legend
-		const legend = pieWrap.createDiv({ cls: 'weread-stats-pie-legend' });
-		items.forEach((item, idx) => {
-			const row = legend.createDiv({ cls: 'weread-stats-pie-legend-row' });
-			const dot = row.createDiv({ cls: 'weread-stats-pie-legend-dot' });
-			dot.style.background = COLORS[idx % COLORS.length];
-			const pct = Math.round((item.value / total) * 100);
-			row.createSpan({ cls: 'weread-stats-pie-legend-label', text: `${item.label} ${pct}%` });
+		// 背景网格圆（3 圈）
+		for (let ring = 1; ring <= 3; ring++) {
+			const r = (maxR * ring) / 3;
+			const pts = Array.from({ length: n }, (_, i) => pt(i, r));
+			const poly = svg.createSvg('polygon');
+			poly.setAttribute('points', pts.map(p => `${p.x},${p.y}`).join(' '));
+			poly.setAttribute('class', 'weread-stats-radar-ring');
+		}
+
+		// 轴线
+		for (let i = 0; i < n; i++) {
+			const end = pt(i, maxR);
+			const line = svg.createSvg('line');
+			line.setAttribute('x1', String(cx)); line.setAttribute('y1', String(cy));
+			line.setAttribute('x2', String(end.x)); line.setAttribute('y2', String(end.y));
+			line.setAttribute('class', 'weread-stats-radar-axis');
+		}
+
+		// 数据多边形
+		const dataPts = items.map((item, i) => pt(i, (item.value / maxVal) * maxR));
+		const poly = svg.createSvg('polygon');
+		poly.setAttribute('points', dataPts.map(p => `${p.x},${p.y}`).join(' '));
+		poly.setAttribute('class', 'weread-stats-radar-area');
+		poly.setAttribute('fill', 'url(#radarGrad)');
+
+		// 数据点
+		dataPts.forEach((p, i) => {
+			const circle = svg.createSvg('circle');
+			circle.setAttribute('cx', String(p.x)); circle.setAttribute('cy', String(p.y));
+			circle.setAttribute('r', '3'); circle.setAttribute('class', 'weread-stats-radar-dot');
+			circle.createSvg('title').textContent = `${items[i].label}: ${fmtDuration(items[i].value)}`;
+		});
+
+		// 轴标签（大值加粗）
+		const sortedVals = items.map(i => i.value).sort((a, b) => b - a);
+		const top2 = new Set(sortedVals.slice(0, 2));
+		items.forEach((item, i) => {
+			const labelR = maxR + 14;
+			const p = pt(i, labelR);
+			const text = svg.createSvg('text');
+			text.setAttribute('x', String(p.x)); text.setAttribute('y', String(p.y));
+			text.setAttribute('text-anchor', 'middle'); text.setAttribute('dominant-baseline', 'middle');
+			const isTop = top2.has(item.value);
+			text.setAttribute('class', isTop ? 'weread-stats-radar-label is-top' : 'weread-stats-radar-label');
+			text.textContent = item.label;
 		});
 	}
 

--- a/src/components/wereadReadingStats.ts
+++ b/src/components/wereadReadingStats.ts
@@ -191,6 +191,7 @@ export class WereadReadingStatsView extends ItemView {
 
 		this.renderHeader(el);
 		this.renderTabBar(el);
+		this.renderReadingTimeHero(el, this.data);
 		this.renderKPICards(el, this.data);
 		this.renderTimeSeries(el, this.data);
 		this.renderTopBooks(el, this.data);
@@ -257,10 +258,56 @@ export class WereadReadingStatsView extends ItemView {
 		}
 	}
 
-	// ── KPI Cards ─────────────────────────────────────────────────────
+	// ── Hero 阅读时长 ──────────────────────────────────────────────────
+	private renderReadingTimeHero(el: HTMLElement, data: ReadingStatsResponse) {
+		const hero = el.createDiv({ cls: 'weread-stats-hero' });
+
+		// 大数字：X小时 Y分钟，分别用不同字号
+		const h = Math.floor(data.totalReadTime / 3600);
+		const m = Math.floor((data.totalReadTime % 3600) / 60);
+		const numRow = hero.createDiv({ cls: 'weread-stats-hero-num' });
+		if (h > 0) {
+			numRow.createSpan({ cls: 'weread-stats-hero-big', text: String(h) });
+			numRow.createSpan({ cls: 'weread-stats-hero-unit', text: '小时' });
+		}
+		if (m > 0 || h === 0) {
+			numRow.createSpan({ cls: 'weread-stats-hero-big', text: String(m) });
+			numRow.createSpan({ cls: 'weread-stats-hero-unit', text: '分钟' });
+		}
+
+		// 副标题：不同模式展示不同信息
+		const subtitleParts: string[] = [];
+		if (this.currentMode === 'overall' && data.registTime) {
+			subtitleParts.push(fmtTs(data.registTime) + '至今');
+			subtitleParts.push(`与微信读书相伴 ${data.readDays} 天`);
+		} else if (this.currentMode === 'annually') {
+			subtitleParts.push(`日均阅读 ${fmtDuration(data.dayAverageReadTime)}`);
+			if (data.compare !== undefined) {
+				const c = fmtCompare(data.compare);
+				if (c) subtitleParts.push(`比去年 ${c.up ? '↑' : '↓'}${c.text}`);
+			}
+		} else if (this.currentMode === 'monthly') {
+			subtitleParts.push(`日均阅读 ${fmtDuration(data.dayAverageReadTime)}`);
+			if (data.compare !== undefined) {
+				const c = fmtCompare(data.compare);
+				if (c) subtitleParts.push(`比上月 ${c.up ? '↑' : '↓'}${c.text}`);
+			}
+		} else if (this.currentMode === 'weekly') {
+			subtitleParts.push(`日均阅读 ${fmtDuration(data.dayAverageReadTime)}`);
+			if (data.compare !== undefined) {
+				const c = fmtCompare(data.compare);
+				if (c) subtitleParts.push(`比上周 ${c.up ? '↑' : '↓'}${c.text}`);
+			}
+		}
+
+		if (subtitleParts.length > 0) {
+			hero.createDiv({ cls: 'weread-stats-hero-sub', text: subtitleParts.join(' · ') });
+		}
+	}
+
+	// ── KPI Cards（去掉阅读时长）─────────────────────────────────────
 	private renderKPICards(el: HTMLElement, data: ReadingStatsResponse) {
 		const grid = el.createDiv({ cls: 'weread-stats-kpi-grid' });
-		this.makeKPICard(grid, '阅读时长', fmtDuration(data.totalReadTime), 'clock');
 		this.makeKPICard(grid, '阅读天数', `${data.readDays} 天`, 'calendar');
 		this.makeKPICard(grid, '日均时长', fmtDuration(data.dayAverageReadTime), 'trending-up',
 			data.compare !== undefined ? fmtCompare(data.compare) : null);

--- a/src/components/wereadReadingStats.ts
+++ b/src/components/wereadReadingStats.ts
@@ -332,6 +332,7 @@ export class WereadReadingStatsView extends ItemView {
 		const maxVal = niceMax(rawMax);
 		const gap = 4;
 		const chartH = 140;
+		const topPad = 14;  // space above the top tick label
 		const labelH = 22;
 		const scaleW = 52; // left gutter
 
@@ -341,22 +342,23 @@ export class WereadReadingStatsView extends ItemView {
 		const barAreaW = 600;
 		const barW = Math.max(8, Math.floor(barAreaW / n) - gap);
 		const totalViewW = scaleW + barAreaW;
+		const totalViewH = topPad + chartH + labelH;
 
 		const svg = wrapper.createSvg('svg', {
 			attr: {
-				viewBox: `0 0 ${totalViewW} ${chartH + labelH}`,
+				viewBox: `0 0 ${totalViewW} ${totalViewH}`,
 				width: '100%',
-				height: chartH + labelH,
+				height: totalViewH,
 				class: 'weread-stats-bar-chart',
 				preserveAspectRatio: 'xMidYMid meet'
 			}
 		});
 
-		// Y-axis: 0, 50%, 100% with nice labels
+		// Y-axis: 0, 50%, 100% — offset down by topPad
 		const tickFractions = [0, 0.5, 1];
 		for (const frac of tickFractions) {
 			const tickVal = maxVal * frac;
-			const yPos = chartH - frac * chartH;
+			const yPos = topPad + chartH - frac * chartH;
 			svg.createSvg('line', {
 				attr: { x1: String(scaleW), y1: String(yPos), x2: String(totalViewW), y2: String(yPos), class: 'weread-stats-scale-line' }
 			});
@@ -371,7 +373,7 @@ export class WereadReadingStatsView extends ItemView {
 			const barH = Math.max((v / maxVal) * chartH, v > 0 ? 4 : 0);
 			const slotW = barAreaW / n;
 			const x = scaleW + i * slotW + (slotW - barW) / 2;
-			const y = chartH - barH;
+			const y = topPad + chartH - barH;
 
 			const rect = svg.createSvg('rect', {
 				attr: { x: String(x), y: String(y), width: String(barW), height: String(barH), rx: '4', class: 'weread-stats-bar' + (v === rawMax && v > 0 ? ' is-max' : '') }
@@ -379,7 +381,7 @@ export class WereadReadingStatsView extends ItemView {
 			rect.createSvg('title').textContent = `${labels[i]}: ${fmtDuration(v)}`;
 
 			const text = svg.createSvg('text', {
-				attr: { x: String(x + barW / 2), y: String(chartH + labelH - 2), 'text-anchor': 'middle', class: 'weread-stats-bar-label' }
+				attr: { x: String(x + barW / 2), y: String(topPad + chartH + labelH - 2), 'text-anchor': 'middle', class: 'weread-stats-bar-label' }
 			});
 			text.textContent = labels[i];
 		});

--- a/src/components/wereadReadingStats.ts
+++ b/src/components/wereadReadingStats.ts
@@ -1,6 +1,5 @@
-import { ItemView, WorkspaceLeaf, setIcon, TFile } from 'obsidian';
+import { ItemView, Menu, WorkspaceLeaf, setIcon, TFile } from 'obsidian';
 import ApiManager from '../api';
-import SyncReadingStats from '../syncReadingStats';
 import FileManager from '../fileManager';
 import { settingsStore } from '../settings';
 import { get } from 'svelte/store';
@@ -139,18 +138,16 @@ function buildWeekValues(
 
 export class WereadReadingStatsView extends ItemView {
 	private apiManager: ApiManager;
-	private syncReadingStats: SyncReadingStats;
 	private fileManager: FileManager;
 	private currentMode: ReadingStatsMode = 'monthly';
 	private currentOffset = 0;
 	private data: ReadingStatsResponse | null = null;
 	private loading = false;
-	private contentEl2: HTMLElement;
+	private statsEl: HTMLElement;
 
-	constructor(leaf: WorkspaceLeaf, apiManager: ApiManager, syncReadingStats: SyncReadingStats, fileManager: FileManager) {
+	constructor(leaf: WorkspaceLeaf, apiManager: ApiManager, fileManager: FileManager) {
 		super(leaf);
 		this.apiManager = apiManager;
-		this.syncReadingStats = syncReadingStats;
 		this.fileManager = fileManager;
 	}
 
@@ -158,16 +155,28 @@ export class WereadReadingStatsView extends ItemView {
 	getDisplayText(): string { return '阅读统计'; }
 	getIcon(): string { return 'bar-chart-2'; }
 
+	onMoreOptionsMenu(menu: Menu) {
+		menu.addItem((item) =>
+			item
+				.setTitle('刷新数据')
+				.setIcon('refresh-ccw')
+				.onClick(() => {
+					this.data = null;
+					this.loadData();
+				})
+		);
+		menu.addSeparator();
+	}
+
 	async onOpen() {
-		const { containerEl } = this;
-		containerEl.empty();
-		containerEl.addClass('weread-stats-view');
-		this.contentEl2 = containerEl.createDiv({ cls: 'weread-stats-container' });
+		this.contentEl.empty();
+		this.contentEl.addClass('weread-stats-view');
+		this.statsEl = this.contentEl.createDiv({ cls: 'weread-stats-container' });
 		this.render();
 		this.loadData();
 	}
 
-	async onClose() { this.containerEl.empty(); }
+	async onClose() { this.contentEl.empty(); }
 
 	private async loadData() {
 		const settings = get(settingsStore);
@@ -183,7 +192,7 @@ export class WereadReadingStatsView extends ItemView {
 	}
 
 	private render() {
-		const el = this.contentEl2;
+		const el = this.statsEl;
 		el.empty();
 		if (!get(settingsStore).wereadApiKey) { this.renderNoApiKey(); return; }
 		if (this.loading) { this.renderLoading(); return; }
@@ -205,10 +214,6 @@ export class WereadReadingStatsView extends ItemView {
 		const icon = titleRow.createSpan({ cls: 'weread-stats-header-icon' });
 		setIcon(icon, 'bar-chart-2');
 		titleRow.createEl('h2', { text: '阅读统计', cls: 'weread-stats-title' });
-
-		const refreshBtn = titleRow.createEl('button', { cls: 'weread-stats-btn weread-stats-btn-icon', attr: { 'aria-label': '刷新数据' } });
-		setIcon(refreshBtn, 'refresh-ccw');
-		refreshBtn.addEventListener('click', () => { this.data = null; this.loadData(); });
 	}
 
 	// ── Tab bar + 时间导航 ────────────────────────────────────────────
@@ -706,23 +711,23 @@ export class WereadReadingStatsView extends ItemView {
 
 	// ── Empty states ──────────────────────────────────────────────────
 	private renderLoading() {
-		this.contentEl2.empty();
-		const wrap = this.contentEl2.createDiv({ cls: 'weread-stats-empty' });
+		this.statsEl.empty();
+		const wrap = this.statsEl.createDiv({ cls: 'weread-stats-empty' });
 		wrap.createDiv({ cls: 'weread-stats-spinner' });
 		wrap.createDiv({ text: '正在加载数据…', cls: 'weread-stats-empty-text' });
 	}
 
 	private renderNoApiKey() {
-		this.contentEl2.empty();
-		const wrap = this.contentEl2.createDiv({ cls: 'weread-stats-empty' });
+		this.statsEl.empty();
+		const wrap = this.statsEl.createDiv({ cls: 'weread-stats-empty' });
 		setIcon(wrap.createDiv({ cls: 'weread-stats-empty-icon' }), 'key');
 		wrap.createDiv({ text: '请先在设置中填写微信读书 API Key', cls: 'weread-stats-empty-text' });
 		wrap.createDiv({ text: '设置 → 微信读书 → 阅读统计 → API Key', cls: 'weread-stats-empty-hint' });
 	}
 
 	private renderError() {
-		this.contentEl2.empty();
-		const wrap = this.contentEl2.createDiv({ cls: 'weread-stats-empty' });
+		this.statsEl.empty();
+		const wrap = this.statsEl.createDiv({ cls: 'weread-stats-empty' });
 		setIcon(wrap.createDiv({ cls: 'weread-stats-empty-icon' }), 'alert-circle');
 		wrap.createDiv({ text: '数据加载失败，请检查 API Key 或网络', cls: 'weread-stats-empty-text' });
 		const retryBtn = wrap.createEl('button', { text: '重试', cls: 'weread-stats-btn' });

--- a/src/models.ts
+++ b/src/models.ts
@@ -571,6 +571,7 @@ export type ReadingStatsResponse = {
 	preferTimeWord?: string;
 	preferTime?: number[];       // 24h 分布，从 6 点开始
 	preferAuthor?: ReadingAuthorPref[];
+	preferPublisher?: { name: string; count: number }[];
 	authorCount?: number;
 	yearReport?: YearReportEntry[];
 	registTime?: number;

--- a/src/models.ts
+++ b/src/models.ts
@@ -511,6 +511,74 @@ export type RecentBook = {
 	recentTime: number;
 };
 
+// ── 阅读统计（Agent API /readdata/detail）──────────────────────────────────
+
+export type ReadingStatsMode = 'weekly' | 'monthly' | 'annually' | 'overall';
+
+export type ReadingStatItem = {
+	stat: string;   // 如"读过""读完""阅读""笔记"
+	counts: string; // 如"98本""305天"
+};
+
+export type ReadingCategoryPref = {
+	categoryId: number;
+	categoryTitle: string;
+	parentCategoryTitle: string;
+	readingCount: number;
+	readingTime: number; // 秒
+};
+
+export type ReadingAuthorPref = {
+	authorId: number;
+	name: string;
+	count: number;
+	readTime: string; // 格式化字符串，如"5小时30分钟"
+};
+
+export type ReadingLongestItem = {
+	book?: {
+		bookId: string;
+		title: string;
+		author: string;
+		cover?: string;
+	};
+	albumInfo?: {
+		albumId: string;
+		name: string;
+		authorName: string;
+		cover?: string;
+	};
+	readTime: number; // 秒
+	tags: string[];
+};
+
+export type YearReportEntry = {
+	year: number;
+	times: number[]; // 12 个月的阅读时长（秒）
+};
+
+export type ReadingStatsResponse = {
+	baseTime: number;
+	totalReadTime: number;       // 秒
+	readDays: number;
+	dayAverageReadTime: number;  // 秒
+	compare?: number;            // 与上期日均对比，如 0.2 = +20%
+	readStat: ReadingStatItem[];
+	readLongest: ReadingLongestItem[];
+	readTimes: Record<string, number>; // key=时间戳字符串, value=秒
+	preferCategory: ReadingCategoryPref[];
+	preferCategoryWord?: string;
+	preferTimeWord?: string;
+	preferTime?: number[];       // 24h 分布，从 6 点开始
+	preferAuthor?: ReadingAuthorPref[];
+	authorCount?: number;
+	yearReport?: YearReportEntry[];
+	registTime?: number;
+	readRate?: number;
+	wrReadTime?: number;
+	wrListenTime?: number;
+};
+
 export interface Theme {
 	id: string;
 	name: string;

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -839,6 +839,19 @@ export class WereadSettingsTab extends PluginSettingTab {
 			);
 
 		new Setting(this.containerEl)
+			.setName('Heatmap 起始年份')
+			.setDesc('全部 Tab 的 Heatmap 从该年份开始展示，留空则使用注册时间。例如：2019')
+			.addText((text) =>
+				text
+					.setPlaceholder('例如：2019')
+					.setValue(get(settingsStore).statsStartYear ? String(get(settingsStore).statsStartYear) : '')
+					.onChange((value) => {
+						const year = parseInt(value.trim());
+						settingsStore.actions.setStatsStartYear(isNaN(year) ? 0 : year);
+					})
+			);
+
+		new Setting(this.containerEl)
 			.setName('同步阅读统计')
 			.setDesc('立即拉取阅读统计数据并生成 Markdown 文件')
 			.addButton((btn) =>

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -116,6 +116,7 @@ export class WereadSettingsTab extends PluginSettingTab {
 			this.insertAfter();
 		}
 		this.template();
+		this.readingStatsSettings();
 		if (Platform.isDesktopApp) {
 			this.showDebugHelp();
 		}
@@ -806,6 +807,48 @@ export class WereadSettingsTab extends PluginSettingTab {
 						settingsStore.actions.setNoteCountLimit(+value);
 					});
 			});
+	}
+
+	private readingStatsSettings(): void {
+		new Setting(this.containerEl).setName('阅读统计').setHeading();
+
+		new Setting(this.containerEl)
+			.setName('微信读书 API Key')
+			.setDesc('用于调用阅读统计等高级接口，格式：wrk-xxxxxxxx。可在微信读书开放平台申请。')
+			.addText((text) => {
+				text.setPlaceholder('wrk-xxxxxxxx')
+					.setValue(get(settingsStore).wereadApiKey ?? '')
+					.onChange((value) => {
+						settingsStore.actions.setWereadApiKey(value.trim());
+					});
+				text.inputEl.type = 'password';
+				text.inputEl.style.width = '260px';
+				return text;
+			});
+
+		new Setting(this.containerEl)
+			.setName('阅读统计保存位置')
+			.setDesc('阅读统计 Markdown 文件的保存目录（默认保存在根目录）')
+			.addText((text) =>
+				text
+					.setPlaceholder('/')
+					.setValue(get(settingsStore).readingStatsLocation ?? '/')
+					.onChange((value) => {
+						settingsStore.actions.setReadingStatsLocation(value.trim() || '/');
+					})
+			);
+
+		new Setting(this.containerEl)
+			.setName('同步阅读统计')
+			.setDesc('立即拉取阅读统计数据并生成 Markdown 文件')
+			.addButton((btn) =>
+				btn
+					.setButtonText('立即同步')
+					.setCta()
+					.onClick(() => {
+						(this.plugin as any).syncReadingStats?.sync();
+					})
+			);
 	}
 
 	private showDebugHelp() {

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -827,18 +827,6 @@ export class WereadSettingsTab extends PluginSettingTab {
 			});
 
 		new Setting(this.containerEl)
-			.setName('阅读统计保存位置')
-			.setDesc('阅读统计 Markdown 文件的保存目录（默认保存在根目录）')
-			.addText((text) =>
-				text
-					.setPlaceholder('/')
-					.setValue(get(settingsStore).readingStatsLocation ?? '/')
-					.onChange((value) => {
-						settingsStore.actions.setReadingStatsLocation(value.trim() || '/');
-					})
-			);
-
-		new Setting(this.containerEl)
 			.setName('Heatmap 起始年份')
 			.setDesc('全部 Tab 的 Heatmap 从该年份开始展示，留空则使用注册时间。例如：2019')
 			.addText((text) =>
@@ -851,17 +839,6 @@ export class WereadSettingsTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(this.containerEl)
-			.setName('同步阅读统计')
-			.setDesc('立即拉取阅读统计数据并生成 Markdown 文件')
-			.addButton((btn) =>
-				btn
-					.setButtonText('立即同步')
-					.setCta()
-					.onClick(() => {
-						(this.plugin as any).syncReadingStats?.sync();
-					})
-			);
 	}
 
 	private showDebugHelp() {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -99,6 +99,8 @@ export interface WereadPluginSettings {
 	bookshelfDefaultSyncStatusFilter: SyncStatusFilter;
 	themes: Theme[];
 	activeThemeId: string;
+	wereadApiKey: string;
+	readingStatsLocation: string;
 }
 
 const DEFAULT_SETTINGS: WereadPluginSettings = {
@@ -149,7 +151,9 @@ const DEFAULT_SETTINGS: WereadPluginSettings = {
 	bookshelfGroupByYear: true,
 	bookshelfDefaultSyncStatusFilter: 'all',
 	themes: BUILT_IN_THEMES,
-	activeThemeId: 'builtin_merged'
+	activeThemeId: 'builtin_merged',
+	wereadApiKey: '',
+	readingStatsLocation: '/'
 };
 
 const createSettingsStore = () => {
@@ -710,6 +714,20 @@ const createSettingsStore = () => {
 		return state.themes.find((t) => t.id === themeId) ?? null;
 	};
 
+	const setWereadApiKey = (apiKey: string) => {
+		store.update((state) => {
+			state.wereadApiKey = apiKey;
+			return state;
+		});
+	};
+
+	const setReadingStatsLocation = (location: string) => {
+		store.update((state) => {
+			state.readingStatsLocation = location;
+			return state;
+		});
+	};
+
 	return {
 		subscribe: store.subscribe,
 		initialise,
@@ -761,7 +779,9 @@ const createSettingsStore = () => {
 			getActiveTheme,
 			duplicateTheme,
 			importTheme,
-			exportTheme
+			exportTheme,
+			setWereadApiKey,
+			setReadingStatsLocation
 		}
 	};
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -63,6 +63,7 @@ export interface WereadPluginSettings {
 	user: string;
 	userVid: string;
 	userAvatar: string;
+	userSignature: string;
 	template: string;
 	noteCountLimit: number;
 	subFolderType: string;
@@ -117,6 +118,7 @@ const DEFAULT_SETTINGS: WereadPluginSettings = {
 	user: '',
 	userVid: '',
 	userAvatar: '',
+	userSignature: '',
 	template: '',
 	noteCountLimit: -1,
 	subFolderType: '-1',
@@ -317,6 +319,7 @@ const createSettingsStore = () => {
 			state.user = '';
 			state.userVid = '';
 			state.userAvatar = '';
+			state.userSignature = '';
 			state.isCookieValid = false;
 			return state;
 		});
@@ -387,6 +390,13 @@ const createSettingsStore = () => {
 				}
 			}
 		}
+	};
+
+	const setUserSignature = (signature: string) => {
+		store.update((state) => {
+			state.userSignature = signature;
+			return state;
+		});
 	};
 
 	const setNoteLocationFolder = (value: string) => {
@@ -792,6 +802,7 @@ const createSettingsStore = () => {
 			setWereadApiKey,
 			setReadingStatsLocation,
 			setStatsStartYear,
+			setUserSignature,
 		}
 	};
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -101,6 +101,7 @@ export interface WereadPluginSettings {
 	activeThemeId: string;
 	wereadApiKey: string;
 	readingStatsLocation: string;
+	statsStartYear?: number;
 }
 
 const DEFAULT_SETTINGS: WereadPluginSettings = {
@@ -153,7 +154,8 @@ const DEFAULT_SETTINGS: WereadPluginSettings = {
 	themes: BUILT_IN_THEMES,
 	activeThemeId: 'builtin_merged',
 	wereadApiKey: '',
-	readingStatsLocation: '/'
+	readingStatsLocation: '/',
+	statsStartYear: 0,  // 0 = use registTime from API
 };
 
 const createSettingsStore = () => {
@@ -721,6 +723,13 @@ const createSettingsStore = () => {
 		});
 	};
 
+	const setStatsStartYear = (year: number) => {
+		store.update((state) => {
+			state.statsStartYear = year;
+			return state;
+		});
+	};
+
 	const setReadingStatsLocation = (location: string) => {
 		store.update((state) => {
 			state.readingStatsLocation = location;
@@ -781,7 +790,8 @@ const createSettingsStore = () => {
 			importTheme,
 			exportTheme,
 			setWereadApiKey,
-			setReadingStatsLocation
+			setReadingStatsLocation,
+			setStatsStartYear,
 		}
 	};
 };

--- a/src/syncReadingStats.ts
+++ b/src/syncReadingStats.ts
@@ -1,0 +1,363 @@
+import { Notice, Vault } from 'obsidian';
+import ApiManager from './api';
+import { settingsStore } from './settings';
+import { get } from 'svelte/store';
+import type { ReadingStatsResponse } from './models';
+
+// ─── 格式化工具 ───────────────────────────────────────────────────────────────
+
+function fmtDuration(seconds: number): string {
+	const h = Math.floor(seconds / 3600);
+	const m = Math.floor((seconds % 3600) / 60);
+	if (h > 0 && m > 0) return `${h}小时${m}分钟`;
+	if (h > 0) return `${h}小时`;
+	return `${m}分钟`;
+}
+
+function fmtTs(ts: number): string {
+	if (!ts) return '—';
+	const d = new Date(ts * 1000);
+	return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function fmtCompare(compare?: number): string {
+	if (compare === undefined || compare === null) return '';
+	const pct = Math.round(compare * 100);
+	return pct >= 0 ? `↑${pct}%` : `↓${Math.abs(pct)}%`;
+}
+
+// 24 小时分布，preferTime 从 6 点开始排列
+const HOUR_LABELS = ['6时','7时','8时','9时','10时','11时','12时','13时','14时','15时','16时','17时','18时','19时','20时','21时','22时','23时','0时','1时','2时','3时','4时','5时'];
+
+function renderBarChart(values: number[], labels: string[], maxWidth = 20): string {
+	const maxVal = Math.max(...values, 1);
+	return values.map((v, i) => {
+		const barLen = Math.round((v / maxVal) * maxWidth);
+		const bar = '█'.repeat(barLen) + '░'.repeat(maxWidth - barLen);
+		const label = labels[i].padEnd(4, ' ');
+		return `${label} ${bar} ${fmtDuration(v)}`;
+	}).join('\n');
+}
+
+// ─── Markdown 生成 ────────────────────────────────────────────────────────────
+
+function buildMarkdown(
+	overall: ReadingStatsResponse,
+	annual: ReadingStatsResponse,
+	monthly: ReadingStatsResponse,
+	year: number,
+	month: number
+): string {
+	const now = new Date();
+	const lines: string[] = [];
+
+	// Frontmatter
+	lines.push('---');
+	lines.push(`title: 微信读书 · 阅读统计`);
+	lines.push(`updated: ${now.toISOString().slice(0, 10)}`);
+	lines.push(`tags:`);
+	lines.push(`  - 阅读统计`);
+	lines.push(`  - 微信读书`);
+	lines.push('---');
+	lines.push('');
+
+	// 标题
+	lines.push('# 📚 微信读书 · 阅读数据分析');
+	lines.push('');
+	lines.push(`> 最后更新：${now.toLocaleString('zh-CN', { hour12: false })}`);
+	lines.push('');
+
+	// ── 一、总览 ──────────────────────────────────────────────────────
+	lines.push('## 📊 一、历年总览');
+	lines.push('');
+
+	const totalH = fmtDuration(overall.totalReadTime);
+	const totalDays = overall.readDays;
+
+	lines.push(`| 指标 | 数值 |`);
+	lines.push(`|------|------|`);
+	lines.push(`| 注册时间 | ${overall.registTime ? fmtTs(overall.registTime) : '—'} |`);
+	lines.push(`| 累计阅读时长 | ${totalH} |`);
+	lines.push(`| 累计阅读天数 | ${totalDays} 天 |`);
+
+	// 阅读统计摘要（读过、读完、笔记数等）
+	if (overall.readStat?.length) {
+		for (const s of overall.readStat) {
+			lines.push(`| ${s.stat} | ${s.counts} |`);
+		}
+	}
+	lines.push('');
+
+	// 历年阅读时长分布（readTimes 是 overall 时按年分桶）
+	if (overall.readTimes && Object.keys(overall.readTimes).length > 0) {
+		lines.push('### 历年阅读时长');
+		lines.push('');
+		lines.push('| 年份 | 阅读时长 |');
+		lines.push('|------|---------|');
+		const sorted = Object.entries(overall.readTimes).sort(([a], [b]) => Number(a) - Number(b));
+		for (const [ts, secs] of sorted) {
+			const yr = new Date(Number(ts) * 1000).getFullYear();
+			lines.push(`| ${yr} | ${fmtDuration(secs as number)} |`);
+		}
+		lines.push('');
+	}
+
+	// ── 二、今年数据 ──────────────────────────────────────────────────
+	lines.push(`## 📅 二、${year} 年阅读概况`);
+	lines.push('');
+	lines.push(`| 指标 | 数值 |`);
+	lines.push(`|------|------|`);
+	lines.push(`| 总阅读时长 | ${fmtDuration(annual.totalReadTime)} |`);
+	lines.push(`| 阅读天数 | ${annual.readDays} 天 |`);
+	lines.push(`| 日均时长 | ${fmtDuration(annual.dayAverageReadTime)} |`);
+	if (annual.readStat?.length) {
+		for (const s of annual.readStat) {
+			lines.push(`| ${s.stat} | ${s.counts} |`);
+		}
+	}
+	lines.push('');
+
+	// 今年逐月分布
+	if (annual.readTimes && Object.keys(annual.readTimes).length > 0) {
+		lines.push(`### ${year} 年逐月阅读时长`);
+		lines.push('');
+		const monthEntries = Object.entries(annual.readTimes)
+			.sort(([a], [b]) => Number(a) - Number(b));
+		const monthVals = monthEntries.map(([, v]) => v as number);
+		const monthLabels = monthEntries.map(([ts]) => {
+			const d = new Date(Number(ts) * 1000);
+			return `${d.getMonth() + 1}月`;
+		});
+		lines.push('```');
+		lines.push(renderBarChart(monthVals, monthLabels, 24));
+		lines.push('```');
+		lines.push('');
+	}
+
+	// 今年读得最多的书
+	if (annual.readLongest?.length) {
+		lines.push(`### ${year} 年阅读时长 TOP${annual.readLongest.length}`);
+		lines.push('');
+		lines.push('| # | 书名 | 作者 | 阅读时长 | 标签 |');
+		lines.push('|---|------|------|---------|------|');
+		annual.readLongest.forEach((item, i) => {
+			const title = item.book?.title ?? item.albumInfo?.name ?? '—';
+			const author = item.book?.author ?? item.albumInfo?.authorName ?? '—';
+			const tags = item.tags?.join('、') ?? '';
+			lines.push(`| ${i + 1} | ${title} | ${author} | ${fmtDuration(item.readTime)} | ${tags} |`);
+		});
+		lines.push('');
+	}
+
+	// 今年偏好分类
+	if (annual.preferCategory?.length) {
+		lines.push(`### ${year} 年偏好分类`);
+		lines.push('');
+		lines.push('| 分类 | 阅读本数 | 阅读时长 |');
+		lines.push('|------|---------|---------|');
+		for (const cat of annual.preferCategory) {
+			if (cat.readingTime > 0) {
+				lines.push(`| ${cat.categoryTitle} | ${cat.readingCount} 本 | ${fmtDuration(cat.readingTime)} |`);
+			}
+		}
+		lines.push('');
+	}
+
+	// 今年偏好作者
+	if (annual.preferAuthor?.length) {
+		lines.push(`### ${year} 年偏好作者`);
+		lines.push('');
+		lines.push('| 作者 | 阅读本数 | 阅读时长 |');
+		lines.push('|------|---------|---------|');
+		for (const a of annual.preferAuthor) {
+			lines.push(`| ${a.name} | ${a.count} 本 | ${a.readTime} |`);
+		}
+		lines.push('');
+	}
+
+	// ── 三、本月数据 ──────────────────────────────────────────────────
+	lines.push(`## 🗓️ 三、${year} 年 ${month} 月阅读概况`);
+	lines.push('');
+	lines.push(`| 指标 | 数值 |`);
+	lines.push(`|------|------|`);
+	lines.push(`| 本月阅读时长 | ${fmtDuration(monthly.totalReadTime)} |`);
+	lines.push(`| 阅读天数 | ${monthly.readDays} 天 |`);
+	lines.push(`| 日均时长 | ${fmtDuration(monthly.dayAverageReadTime)} |`);
+	if (monthly.compare !== undefined) {
+		const cmp = fmtCompare(monthly.compare);
+		if (cmp) lines.push(`| 与上月日均对比 | ${cmp} |`);
+	}
+	if (monthly.readStat?.length) {
+		for (const s of monthly.readStat) {
+			lines.push(`| ${s.stat} | ${s.counts} |`);
+		}
+	}
+	lines.push('');
+
+	// 本月每日分布
+	if (monthly.readTimes && Object.keys(monthly.readTimes).length > 0) {
+		lines.push(`### ${month} 月每日阅读时长`);
+		lines.push('');
+		const dayEntries = Object.entries(monthly.readTimes)
+			.sort(([a], [b]) => Number(a) - Number(b));
+		const dayVals = dayEntries.map(([, v]) => v as number);
+		const dayLabels = dayEntries.map(([ts]) => {
+			const d = new Date(Number(ts) * 1000);
+			return `${d.getDate()}日`;
+		});
+		lines.push('```');
+		lines.push(renderBarChart(dayVals, dayLabels, 20));
+		lines.push('```');
+		lines.push('');
+	}
+
+	// 本月读得最多的书
+	if (monthly.readLongest?.length) {
+		lines.push(`### ${month} 月阅读时长 TOP${monthly.readLongest.length}`);
+		lines.push('');
+		lines.push('| # | 书名 | 作者 | 阅读时长 | 标签 |');
+		lines.push('|---|------|------|---------|------|');
+		monthly.readLongest.forEach((item, i) => {
+			const title = item.book?.title ?? item.albumInfo?.name ?? '—';
+			const author = item.book?.author ?? item.albumInfo?.authorName ?? '—';
+			const tags = item.tags?.join('、') ?? '';
+			lines.push(`| ${i + 1} | ${title} | ${author} | ${fmtDuration(item.readTime)} | ${tags} |`);
+		});
+		lines.push('');
+	}
+
+	// 本月偏好分类
+	if (monthly.preferCategory?.length) {
+		lines.push(`### ${month} 月偏好分类`);
+		lines.push('');
+		lines.push('| 分类 | 阅读本数 | 阅读时长 |');
+		lines.push('|------|---------|---------|');
+		for (const cat of monthly.preferCategory) {
+			if (cat.readingTime > 0) {
+				lines.push(`| ${cat.categoryTitle} | ${cat.readingCount} 本 | ${fmtDuration(cat.readingTime)} |`);
+			}
+		}
+		lines.push('');
+	}
+
+	// ── 四、阅读偏好分析 ─────────────────────────────────────────────
+	lines.push('## 🎯 四、阅读偏好分析（年度）');
+	lines.push('');
+
+	if (annual.preferCategoryWord) {
+		lines.push(`> ${annual.preferCategoryWord}`);
+		lines.push('');
+	}
+
+	// 阅读时段分布
+	if (annual.preferTime?.length === 24) {
+		lines.push('### 阅读时段分布');
+		lines.push('');
+		if (annual.preferTimeWord) {
+			lines.push(`> ${annual.preferTimeWord}`);
+			lines.push('');
+		}
+		lines.push('```');
+		lines.push(renderBarChart(annual.preferTime, HOUR_LABELS, 20));
+		lines.push('```');
+		lines.push('');
+	}
+
+	// 文字/听书占比
+	if (annual.readRate !== undefined && annual.wrReadTime && annual.wrListenTime) {
+		lines.push('### 阅读方式');
+		lines.push('');
+		lines.push('| 方式 | 时长 | 占比 |');
+		lines.push('|------|------|------|');
+		lines.push(`| 文字阅读 | ${fmtDuration(annual.wrReadTime)} | ${annual.readRate}% |`);
+		lines.push(`| 听书 | ${fmtDuration(annual.wrListenTime)} | ${100 - annual.readRate}% |`);
+		lines.push('');
+	}
+
+	return lines.join('\n');
+}
+
+// ─── 主入口 ───────────────────────────────────────────────────────────────────
+
+export default class SyncReadingStats {
+	constructor(
+		private vault: Vault,
+		private apiManager: ApiManager
+	) {}
+
+	async sync(): Promise<void> {
+		const settings = get(settingsStore);
+		if (!settings.wereadApiKey) {
+			new Notice('请先在设置中填写微信读书 API Key（wrk-xxx）', 5000);
+			return;
+		}
+
+		const notice = new Notice('正在获取阅读统计数据…', 0);
+
+		try {
+			const now = new Date();
+			const year = now.getFullYear();
+			const month = now.getMonth() + 1;
+
+			// 年初时间戳（用于查询本年）
+			const yearStart = Math.floor(new Date(year, 0, 1).getTime() / 1000);
+
+			notice.setMessage('获取历史总计…');
+			const overall = await this.apiManager.getReadingStats('overall');
+			if (!overall) {
+				notice.hide();
+				new Notice('获取阅读统计失败，请检查 API Key 是否正确', 5000);
+				return;
+			}
+
+			notice.setMessage(`获取 ${year} 年数据…`);
+			const annual = await this.apiManager.getReadingStats('annually', yearStart);
+			if (!annual) {
+				notice.hide();
+				new Notice('获取年度统计失败', 5000);
+				return;
+			}
+
+			notice.setMessage(`获取 ${year} 年 ${month} 月数据…`);
+			const monthly = await this.apiManager.getReadingStats('monthly');
+			if (!monthly) {
+				notice.hide();
+				new Notice('获取月度统计失败', 5000);
+				return;
+			}
+
+			notice.setMessage('生成统计文档…');
+			const content = buildMarkdown(overall, annual, monthly, year, month);
+			await this.saveFile(content, settings.readingStatsLocation);
+			notice.hide();
+			new Notice('✅ 阅读统计已同步', 4000);
+		} catch (e) {
+			notice.hide();
+			new Notice('阅读统计同步失败，请查看控制台', 5000);
+			console.error('[weread plugin] 阅读统计同步失败', e);
+		}
+	}
+
+	private async saveFile(content: string, folder: string): Promise<void> {
+		// 确保目录存在
+		const safeFolder = folder.endsWith('/') ? folder.slice(0, -1) : folder;
+		const dir = safeFolder === '' ? '' : safeFolder;
+		if (dir) {
+			const exists = await this.vault.adapter.exists(dir);
+			if (!exists) {
+				await this.vault.createFolder(dir);
+			}
+		}
+
+		const filePath = dir ? `${dir}/微信读书阅读统计.md` : '微信读书阅读统计.md';
+		const exists = await this.vault.adapter.exists(filePath);
+		if (exists) {
+			const file = this.vault.getAbstractFileByPath(filePath);
+			if (file) {
+				await this.vault.modify(file as any, content);
+				return;
+			}
+		}
+		await this.vault.create(filePath, content);
+	}
+}

--- a/style.css
+++ b/style.css
@@ -2361,7 +2361,7 @@
 }
 
 .weread-stats-tab.is-active {
-	background: rgba(var(--interactive-accent-rgb), 0.15);
+	background: color-mix(in srgb, var(--interactive-accent) 18%, transparent);
 	color: var(--text-accent);
 	font-weight: 600;
 	box-shadow: 0 1px 4px rgba(0,0,0,0.15);
@@ -3325,4 +3325,24 @@
 
 .weread-export-action-btn.mod-cta:hover {
 	background: var(--interactive-accent-hover);
+}
+
+/* ── Export Loading Modal ──────────────────────────────────────────────────── */
+.weread-export-loading-modal .modal-content {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 40px 60px;
+}
+
+.weread-export-loading-wrap {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 16px;
+}
+
+.weread-export-loading-text {
+	font-size: 0.95em;
+	color: var(--text-muted);
 }

--- a/style.css
+++ b/style.css
@@ -2429,6 +2429,8 @@
 /* ── Sections ────────────────────────────────────────────────────────────── */
 .weread-stats-section {
 	margin-bottom: 28px;
+	width: 100%;
+	box-sizing: border-box;
 }
 
 .weread-stats-section-title {
@@ -2472,6 +2474,18 @@
 	font-size: 10px;
 }
 
+/* Y-axis scale */
+.weread-stats-scale-line {
+	stroke: var(--background-modifier-border);
+	stroke-width: 1;
+	stroke-dasharray: 4 3;
+}
+
+.weread-stats-scale-label {
+	fill: var(--text-faint);
+	font-size: 9px;
+}
+
 /* ── Top Books ───────────────────────────────────────────────────────────── */
 .weread-stats-book-list {
 	display: flex;
@@ -2487,6 +2501,16 @@
 	background: var(--background-secondary);
 	border-radius: 8px;
 	border: 1px solid var(--background-modifier-border);
+	transition: background 0.15s;
+}
+
+.weread-stats-book-row-clickable {
+	cursor: pointer;
+}
+
+.weread-stats-book-row-clickable:hover {
+	background: var(--background-modifier-hover);
+	border-color: var(--text-accent);
 }
 
 .weread-stats-book-rank {

--- a/style.css
+++ b/style.css
@@ -2210,11 +2210,17 @@
 .weread-stats-view {
 	overflow-y: auto;
 	height: 100%;
+	/* cal-heatmap heat colors — adapt to accent color */
+	--weread-heat-0: var(--background-modifier-border);
+	--weread-heat-1: rgba(var(--interactive-accent-rgb), 0.20);
+	--weread-heat-2: rgba(var(--interactive-accent-rgb), 0.42);
+	--weread-heat-3: rgba(var(--interactive-accent-rgb), 0.65);
+	--weread-heat-4: rgba(var(--interactive-accent-rgb), 0.88);
 }
 
 .weread-stats-container {
 	padding: 16px 20px 32px;
-	max-width: 900px;
+	max-width: 910px;
 	margin: 0 auto;
 }
 
@@ -2312,10 +2318,11 @@
 }
 
 .weread-stats-tab.is-active {
-	background: var(--background-primary);
+	background: rgba(var(--interactive-accent-rgb), 0.15);
 	color: var(--text-accent);
 	font-weight: 600;
-	box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+	box-shadow: 0 1px 4px rgba(0,0,0,0.15);
+	border-radius: 9px;
 }
 
 /* ── Time Picker ─────────────────────────────────────────────────────────── */
@@ -2481,10 +2488,289 @@
 	font-size: 0.95em;
 	font-weight: 600;
 	color: var(--text-muted);
-	margin: 0 0 12px;
+	margin: 0;
 	text-transform: uppercase;
 	letter-spacing: 0.04em;
 }
+
+/* ── Section title row with toggle ──────────────────────────────────────── */
+.weread-stats-section-title-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 12px;
+}
+
+.weread-stats-view-toggle {
+	display: flex;
+	gap: 2px;
+	background: var(--background-secondary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 8px;
+	padding: 2px;
+}
+
+.weread-stats-view-toggle-btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	border: none;
+	background: transparent;
+	color: var(--text-muted);
+	cursor: pointer;
+	border-radius: 6px;
+	padding: 0;
+	transition: background 0.15s, color 0.15s;
+}
+
+.weread-stats-view-toggle-btn:hover {
+	background: var(--background-modifier-hover);
+	color: var(--text-normal);
+}
+
+.weread-stats-view-toggle-btn.is-active {
+	background: rgba(var(--interactive-accent-rgb), 0.15);
+	color: var(--text-accent);
+}
+
+/* ── Month Calendar ──────────────────────────────────────────────────────── */
+.weread-calendar {
+	width: 100%;
+}
+
+.weread-calendar-header {
+	display: grid;
+	grid-template-columns: repeat(7, 1fr);
+	gap: 4px;
+	margin-bottom: 4px;
+}
+
+.weread-calendar-dow {
+	text-align: center;
+	font-size: 0.78em;
+	color: var(--text-faint);
+	font-weight: 600;
+	padding: 4px 0;
+}
+
+.weread-calendar-grid {
+	display: grid;
+	grid-template-columns: repeat(7, 1fr);
+	gap: 4px;
+}
+
+.weread-calendar-cell {
+	border-radius: 8px;
+	padding: 6px 4px 5px;
+	min-height: 56px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 2px;
+	background: var(--background-secondary);
+	border: 1px solid var(--background-modifier-border);
+	transition: transform 0.1s;
+}
+
+.weread-calendar-cell.is-empty {
+	background: transparent;
+	border-color: transparent;
+}
+
+.weread-calendar-cell:not(.is-empty):hover {
+	transform: translateY(-1px);
+}
+
+.weread-calendar-cell.is-today .weread-calendar-day {
+	color: var(--text-accent);
+	font-weight: 700;
+}
+
+.weread-calendar-day {
+	font-size: 0.82em;
+	color: var(--text-muted);
+	font-weight: 500;
+	line-height: 1;
+}
+
+.weread-calendar-duration {
+	font-size: 0.7em;
+	color: var(--text-accent);
+	font-weight: 600;
+	text-align: center;
+	line-height: 1.2;
+}
+
+/* Calendar heatmap levels — shared by month calendar & year heatmap */
+.weread-cal-level-0 { background: var(--background-secondary); }
+.weread-cal-level-1 { background: color-mix(in srgb, var(--interactive-accent) 20%, var(--background-primary)); }
+.weread-cal-level-2 { background: color-mix(in srgb, var(--interactive-accent) 42%, var(--background-primary)); }
+.weread-cal-level-3 { background: color-mix(in srgb, var(--interactive-accent) 66%, var(--background-primary)); }
+.weread-cal-level-4 { background: var(--interactive-accent); }
+
+.weread-cal-level-3 .weread-calendar-day,
+.weread-cal-level-4 .weread-calendar-day { color: var(--text-on-accent); }
+.weread-cal-level-4 .weread-calendar-duration { color: var(--text-on-accent); opacity: 0.9; }
+.weread-cal-level-3 .weread-calendar-duration { color: var(--text-on-accent); opacity: 0.85; }
+
+/* ── All-years heatmap ───────────────────────────────────────────────────── */
+.weread-allheatmap-wrap {
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+}
+
+.weread-allheatmap-year {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.weread-allheatmap-yearlabel {
+	font-size: 0.85em;
+	font-weight: 600;
+	color: var(--text-muted);
+	margin-bottom: 2px;
+}
+
+
+.weread-heatmap-loading {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 8px;
+	padding: 32px 0;
+}
+
+.weread-stats-spinner-sm {
+	width: 20px;
+	height: 20px;
+	border-width: 2px;
+}
+
+.weread-ghmap-wrap {
+	width: 100%;
+	overflow-x: auto;
+	padding-bottom: 2px; /* prevent bottom clip on hover scale */
+}
+
+.weread-ghmap-inner {
+	display: flex;
+	gap: 0;
+	padding-right: 4px;
+	min-width: max-content;
+}
+
+/* Weekday label column */
+.weread-ghmap-daylabels {
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+	padding-top: 20px;
+	flex-shrink: 0;
+	margin-right: 4px;
+}
+
+.weread-ghmap-daylabel {
+	width: 14px;
+	height: 13px;
+	font-size: 0.7em;
+	color: var(--text-faint);
+	line-height: 13px;
+	text-align: right;
+}
+
+/* Right side: months + grid */
+.weread-ghmap-right {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	overflow: visible;
+}
+
+.weread-ghmap-months {
+	display: flex;
+}
+
+.weread-ghmap-monthlabel {
+	font-size: 0.75em;
+	color: var(--text-faint);
+	font-weight: 500;
+	height: 16px;
+	line-height: 16px;
+	white-space: nowrap;
+	/* width set inline to match col width */
+}
+
+.weread-ghmap-grid {
+	display: flex;
+	gap: 3px;
+}
+
+.weread-ghmap-col {
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+}
+
+/* Individual cells */
+.weread-ghmap-cell {
+	width: 13px;
+	height: 13px;
+	border-radius: 2px;
+	cursor: default;
+	transition: opacity 0.1s, transform 0.1s;
+}
+
+.weread-ghmap-cell:hover:not(.is-empty) {
+	transform: scale(1.4);
+	z-index: 10;
+	opacity: 1 !important;
+}
+
+.weread-ghmap-cell.is-empty {
+	background: transparent !important;
+}
+
+.weread-ghmap-cell.is-today {
+	outline: 2px solid var(--text-accent);
+	outline-offset: 1px;
+}
+
+/* Intensity levels — level-0 = no reading (light grey), 1–4 = accent color */
+.weread-ghmap-cell.level-0 { background: var(--background-modifier-border); }
+.weread-ghmap-cell.level-1 { background: color-mix(in srgb, var(--interactive-accent) 28%, var(--background-primary)); }
+.weread-ghmap-cell.level-2 { background: color-mix(in srgb, var(--interactive-accent) 52%, var(--background-primary)); }
+.weread-ghmap-cell.level-3 { background: color-mix(in srgb, var(--interactive-accent) 75%, var(--background-primary)); }
+.weread-ghmap-cell.level-4 { background: var(--interactive-accent); }
+
+/* Legend */
+.weread-ghmap-legend {
+	display: flex;
+	align-items: center;
+	gap: 3px;
+	margin-top: 8px;
+	justify-content: flex-end;
+}
+
+.weread-ghmap-legend-text {
+	font-size: 0.75em;
+	color: var(--text-faint);
+	margin: 0 2px;
+}
+
+.weread-heatmap-summary {
+	font-size: 0.8em;
+	color: var(--text-muted);
+	margin-top: 8px;
+	text-align: center;
+}
+
+
+
 
 /* ── Bar Chart ───────────────────────────────────────────────────────────── */
 .weread-stats-chart-wrapper {

--- a/style.css
+++ b/style.css
@@ -2666,6 +2666,11 @@
 	overflow: hidden;
 }
 
+/* author row: wider name, progress bar fills remaining space */
+.weread-stats-pref-row-author .weread-stats-pref-name {
+	width: 80px;
+}
+
 .weread-stats-pref-bar-fill {
 	height: 100%;
 	background: var(--text-accent);
@@ -2725,41 +2730,44 @@
 }
 
 /* ── Pie Chart ───────────────────────────────────────────────────────────── */
-.weread-stats-pie-wrap {
-	display: flex;
-	align-items: flex-start;
-	gap: 16px;
-	flex-wrap: wrap;
-	margin-top: 8px;
+/* ── Radar Chart ─────────────────────────────────────────────────────────── */
+.weread-stats-radar-svg {
+	display: block;
+	margin: 8px auto 0;
 }
-.weread-stats-pie-svg {
-	flex-shrink: 0;
+
+.weread-stats-radar-ring {
+	fill: none;
+	stroke: var(--background-modifier-border);
+	stroke-width: 1;
 }
-.weread-stats-pie-slice {
-	transition: opacity 0.15s;
-	cursor: default;
+
+.weread-stats-radar-axis {
+	stroke: var(--background-modifier-border);
+	stroke-width: 1;
 }
-.weread-stats-pie-slice:hover { opacity: 0.8; }
-.weread-stats-pie-legend {
-	display: flex;
-	flex-direction: column;
-	gap: 5px;
-	justify-content: center;
+
+.weread-stats-radar-area {
+	stroke: #5aabf0;
+	stroke-width: 1.5;
+	opacity: 0.85;
 }
-.weread-stats-pie-legend-row {
-	display: flex;
-	align-items: center;
-	gap: 6px;
+
+.weread-stats-radar-dot {
+	fill: white;
+	stroke: #5aabf0;
+	stroke-width: 1.5;
 }
-.weread-stats-pie-legend-dot {
-	width: 9px;
-	height: 9px;
-	border-radius: 50%;
-	flex-shrink: 0;
+
+.weread-stats-radar-label {
+	fill: var(--text-muted);
+	font-size: 9px;
 }
-.weread-stats-pie-legend-label {
-	font-size: 0.78em;
-	color: var(--text-normal);
+
+.weread-stats-radar-label.is-top {
+	fill: var(--text-normal);
+	font-size: 11px;
+	font-weight: 600;
 }
 
 /* ── Tag Cloud ───────────────────────────────────────────────────────────── */

--- a/style.css
+++ b/style.css
@@ -2282,19 +2282,18 @@
 
 /* ── Tab Bar 胶囊 ─────────────────────────────────────────────────────────── */
 .weread-stats-tabbar {
-	display: flex;
+	display: inline-flex;
 	gap: 2px;
 	background: var(--background-secondary);
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 12px;
 	padding: 3px;
 	flex-shrink: 0;
-	width: fit-content;
 }
 
 .weread-stats-tab {
-	min-width: 52px;
-	padding: 5px 10px;
+	width: 52px;
+	padding: 5px 0;
 	text-align: center;
 	border: none;
 	background: transparent;
@@ -2304,6 +2303,7 @@
 	border-radius: 9px;
 	transition: background 0.18s, color 0.18s;
 	white-space: nowrap;
+	box-sizing: border-box;
 }
 
 .weread-stats-tab:hover {

--- a/style.css
+++ b/style.css
@@ -2361,6 +2361,43 @@
 }
 
 /* ── KPI Cards ───────────────────────────────────────────────────────────── */
+/* ── Hero 阅读时长 ───────────────────────────────────────────────────────── */
+.weread-stats-hero {
+	padding: 16px 20px 14px;
+	margin-bottom: 16px;
+	background: var(--background-secondary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 14px;
+}
+
+.weread-stats-hero-num {
+	display: flex;
+	align-items: baseline;
+	gap: 2px;
+	flex-wrap: wrap;
+	line-height: 1;
+}
+
+.weread-stats-hero-big {
+	font-size: 2.6em;
+	font-weight: 700;
+	color: var(--text-normal);
+	letter-spacing: -0.02em;
+}
+
+.weread-stats-hero-unit {
+	font-size: 1.1em;
+	font-weight: 500;
+	color: var(--text-normal);
+	margin-right: 6px;
+}
+
+.weread-stats-hero-sub {
+	margin-top: 6px;
+	font-size: 0.82em;
+	color: var(--text-muted);
+}
+
 .weread-stats-kpi-grid {
 	display: grid;
 	grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));

--- a/style.css
+++ b/style.css
@@ -2284,7 +2284,7 @@
 /* ── Tab Bar 胶囊 ─────────────────────────────────────────────────────────── */
 .weread-stats-tabbar {
 	display: flex;
-	gap: 0;
+	gap: 2px;
 	background: var(--background-secondary);
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 12px;
@@ -2293,7 +2293,7 @@
 
 .weread-stats-tab {
 	flex: 1;
-	padding: 5px 0;
+	padding: 5px 10px;
 	text-align: center;
 	border: none;
 	background: transparent;

--- a/style.css
+++ b/style.css
@@ -2289,10 +2289,12 @@
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 12px;
 	padding: 3px;
+	flex-shrink: 0;
+	width: fit-content;
 }
 
 .weread-stats-tab {
-	flex: 1;
+	min-width: 52px;
 	padding: 5px 10px;
 	text-align: center;
 	border: none;

--- a/style.css
+++ b/style.css
@@ -2275,7 +2275,6 @@
 .weread-stats-nav {
 	display: flex;
 	align-items: center;
-	justify-content: space-between;
 	flex-wrap: wrap;
 	gap: 8px;
 	margin-bottom: 20px;
@@ -2328,6 +2327,8 @@
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 10px;
 	padding: 2px 4px;
+	margin-left: auto;
+	flex-shrink: 0;
 }
 
 .weread-stats-timepicker-btn {

--- a/style.css
+++ b/style.css
@@ -2292,14 +2292,14 @@
 }
 
 .weread-stats-tab {
-	width: 52px;
-	padding: 5px 0;
+	width: 64px;
+	padding: 6px 0;
 	text-align: center;
 	border: none;
 	background: transparent;
 	color: var(--text-muted);
 	cursor: pointer;
-	font-size: 0.88em;
+	font-size: 0.9em;
 	border-radius: 9px;
 	transition: background 0.18s, color 0.18s;
 	white-space: nowrap;

--- a/style.css
+++ b/style.css
@@ -2271,36 +2271,93 @@
 	padding: 5px 8px;
 }
 
-/* ── Tab Bar ─────────────────────────────────────────────────────────────── */
+/* ── Nav (tab + timepicker row) ──────────────────────────────────────────── */
+.weread-stats-nav {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-bottom: 20px;
+}
+
+/* ── Tab Bar 胶囊 ─────────────────────────────────────────────────────────── */
 .weread-stats-tabbar {
 	display: flex;
 	gap: 4px;
-	margin-bottom: 20px;
-	border-bottom: 1px solid var(--background-modifier-border);
-	padding-bottom: 0;
+	background: var(--background-secondary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 12px;
+	padding: 3px;
 }
 
 .weread-stats-tab {
-	padding: 6px 16px;
+	padding: 5px 16px;
 	border: none;
 	background: transparent;
 	color: var(--text-muted);
 	cursor: pointer;
-	font-size: 0.9em;
-	border-bottom: 2px solid transparent;
-	margin-bottom: -1px;
-	border-radius: 0;
-	transition: color 0.15s, border-color 0.15s;
+	font-size: 0.88em;
+	border-radius: 9px;
+	transition: background 0.18s, color 0.18s;
+	white-space: nowrap;
 }
 
 .weread-stats-tab:hover {
 	color: var(--text-normal);
+	background: var(--background-modifier-hover);
 }
 
 .weread-stats-tab.is-active {
+	background: var(--background-primary);
 	color: var(--text-accent);
-	border-bottom-color: var(--text-accent);
 	font-weight: 600;
+	box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+}
+
+/* ── Time Picker ─────────────────────────────────────────────────────────── */
+.weread-stats-timepicker {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	background: var(--background-secondary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 10px;
+	padding: 2px 4px;
+}
+
+.weread-stats-timepicker-btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 26px;
+	height: 26px;
+	border: none;
+	background: transparent;
+	color: var(--text-muted);
+	cursor: pointer;
+	border-radius: 7px;
+	padding: 0;
+	transition: background 0.15s, color 0.15s;
+}
+
+.weread-stats-timepicker-btn:hover:not([disabled]) {
+	background: var(--background-modifier-hover);
+	color: var(--text-normal);
+}
+
+.weread-stats-timepicker-btn.is-disabled,
+.weread-stats-timepicker-btn[disabled] {
+	opacity: 0.3;
+	cursor: default;
+}
+
+.weread-stats-timepicker-label {
+	font-size: 0.82em;
+	color: var(--text-normal);
+	font-weight: 500;
+	padding: 0 6px;
+	white-space: nowrap;
 }
 
 /* ── KPI Cards ───────────────────────────────────────────────────────────── */
@@ -2391,6 +2448,9 @@
 
 .weread-stats-bar-chart {
 	display: block;
+	width: 100%;
+	height: auto;
+	min-width: 0;
 }
 
 .weread-stats-bar {

--- a/style.css
+++ b/style.css
@@ -2229,11 +2229,25 @@
 	margin-bottom: 16px;
 }
 
-.weread-stats-title-row {
+.weread-stats-header-row {
 	display: flex;
 	align-items: center;
-	gap: 8px;
-	margin-bottom: 8px;
+	gap: 12px;
+}
+
+.weread-stats-user-left {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	flex: 1;
+}
+
+.weread-stats-export-btn {
+	margin-left: auto;
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	font-size: 0.82em;
 }
 
 .weread-stats-header-icon {
@@ -2247,6 +2261,35 @@
 	font-size: 1.3em;
 	font-weight: 700;
 	color: var(--text-normal);
+}
+
+.weread-stats-user-avatar {
+	width: 48px;
+	height: 48px;
+	border-radius: 50% !important;
+	object-fit: cover;
+	flex-shrink: 0;
+	overflow: hidden;
+	border: 2px solid var(--background-modifier-border);
+}
+
+.weread-stats-user-text {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.weread-stats-user-name {
+	font-size: 0.95em;
+	font-weight: 600;
+	color: var(--text-normal);
+	line-height: 1.3;
+}
+
+.weread-stats-user-sub {
+	font-size: 0.78em;
+	color: var(--text-muted);
+	line-height: 1.3;
 }
 
 .weread-stats-header-actions {
@@ -2441,11 +2484,23 @@
 }
 
 .weread-stats-kpi-value {
-	font-size: 1.15em;
+	font-size: 1em;
 	font-weight: 700;
 	color: var(--text-normal);
-	line-height: 1.2;
-	word-break: break-all;
+	display: flex;
+	align-items: baseline;
+	gap: 1px;
+}
+
+.weread-stats-kpi-number {
+	font-size: 1.6em;
+	font-weight: 700;
+	line-height: 1;
+}
+
+.weread-stats-kpi-unit {
+	font-size: 0.95em;
+	font-weight: 600;
 }
 
 .weread-stats-kpi-label-row {
@@ -2653,15 +2708,14 @@
 
 .weread-ghmap-wrap {
 	width: 100%;
-	overflow-x: auto;
-	padding-bottom: 2px; /* prevent bottom clip on hover scale */
+	overflow-x: hidden;
+	padding-bottom: 2px;
 }
 
 .weread-ghmap-inner {
 	display: flex;
 	gap: 0;
-	padding-right: 4px;
-	min-width: max-content;
+	width: 100%;
 }
 
 /* Weekday label column */
@@ -2688,6 +2742,8 @@
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
+	flex: 1;
+	min-width: 0;
 	overflow: visible;
 }
 
@@ -2702,7 +2758,8 @@
 	height: 16px;
 	line-height: 16px;
 	white-space: nowrap;
-	/* width set inline to match col width */
+	overflow: hidden;
+	flex: 1;
 }
 
 .weread-ghmap-grid {
@@ -2714,12 +2771,13 @@
 	display: flex;
 	flex-direction: column;
 	gap: 3px;
+	flex: 1;
 }
 
 /* Individual cells */
 .weread-ghmap-cell {
-	width: 13px;
-	height: 13px;
+	width: 100%;
+	aspect-ratio: 1;
 	border-radius: 2px;
 	cursor: default;
 	transition: opacity 0.1s, transform 0.1s;
@@ -2754,6 +2812,13 @@
 	gap: 3px;
 	margin-top: 8px;
 	justify-content: flex-end;
+}
+
+.weread-ghmap-legend-cell {
+	width: 12px !important;
+	height: 12px !important;
+	flex: none !important;
+	aspect-ratio: unset !important;
 }
 
 .weread-ghmap-legend-text {
@@ -3180,4 +3245,84 @@
 
 @keyframes weread-spin {
 	to { transform: rotate(360deg); }
+}
+
+/* ── Export Preview Modal ────────────────────────────────────────────────── */
+.weread-export-modal .modal-content {
+	padding: 20px;
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	align-items: center;
+}
+
+.weread-export-title {
+	margin: 0 0 4px 0;
+	font-size: 1.1em;
+	font-weight: 600;
+	color: var(--text-normal);
+	align-self: flex-start;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.weread-export-title-icon {
+	display: flex;
+	align-items: center;
+	color: var(--text-accent);
+}
+
+.weread-export-preview {
+	width: 100%;
+	max-height: 60vh;
+	overflow-y: auto;
+	border-radius: 8px;
+	border: 1px solid var(--background-modifier-border);
+	background: var(--background-secondary);
+}
+
+.weread-export-preview-img {
+	width: 100%;
+	display: block;
+	border-radius: 8px;
+}
+
+.weread-export-actions {
+	display: flex;
+	gap: 10px;
+	justify-content: center;
+	flex-wrap: wrap;
+	width: 100%;
+	margin-top: 8px;
+	padding-top: 16px;
+	border-top: 1px solid var(--background-modifier-border);
+}
+
+.weread-export-action-btn {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 8px 16px;
+	border-radius: 6px;
+	font-size: 0.9em;
+	cursor: pointer;
+	border: 1px solid var(--background-modifier-border);
+	background: var(--background-secondary);
+	color: var(--text-normal);
+	transition: background 0.15s;
+}
+
+.weread-export-action-btn:hover {
+	background: var(--background-modifier-hover);
+}
+
+.weread-export-action-btn.mod-cta {
+	background: var(--interactive-accent);
+	color: var(--text-on-accent);
+	border-color: var(--interactive-accent);
+}
+
+.weread-export-action-btn.mod-cta:hover {
+	background: var(--interactive-accent-hover);
 }

--- a/style.css
+++ b/style.css
@@ -2608,7 +2608,7 @@
 /* ── Preferences ─────────────────────────────────────────────────────────── */
 .weread-stats-pref-grid {
 	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+	grid-template-columns: repeat(2, minmax(0, 1fr));
 	gap: 14px;
 }
 
@@ -2617,6 +2617,7 @@
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 10px;
 	padding: 14px;
+	min-height: 160px;
 }
 
 .weread-stats-pref-card-wide {

--- a/style.css
+++ b/style.css
@@ -2680,38 +2680,102 @@
 }
 
 /* ── Hour Chart ──────────────────────────────────────────────────────────── */
-.weread-stats-hour-chart {
-	display: flex;
-	align-items: flex-end;
-	gap: 2px;
-	height: 70px;
-}
-
-.weread-stats-hour-col {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	flex: 1;
-}
-
-.weread-stats-hour-bar {
-	width: 100%;
-	background: var(--text-accent);
-	border-radius: 2px 2px 0 0;
-	opacity: 0.7;
+/* ── Hour chart (SVG-based, replaces old div bars) ───────────────────────── */
+.weread-stats-hour-seg-bar {
 	transition: opacity 0.15s;
 	cursor: default;
 }
+.weread-stats-hour-seg-bar:hover { opacity: 0.8; }
 
-.weread-stats-hour-bar:hover {
-	opacity: 1;
+/* Time-of-day color variables */
+:root {
+	--weread-hour-morning: #7c6af7;
+	--weread-hour-afternoon: #f97316;
+	--weread-hour-evening: #ec4899;
+	--weread-hour-night: #6b7280;
+}
+.theme-dark {
+	--weread-hour-morning: #a78bfa;
+	--weread-hour-afternoon: #fb923c;
+	--weread-hour-evening: #f472b6;
+	--weread-hour-night: #9ca3af;
 }
 
-.weread-stats-hour-label {
-	font-size: 9px;
+.weread-stats-hour-legend {
+	display: flex;
+	gap: 12px;
+	flex-wrap: wrap;
+	margin-top: 8px;
+}
+.weread-stats-hour-legend-item {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+}
+.weread-stats-hour-legend-dot {
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+.weread-stats-hour-legend-label {
+	font-size: 0.76em;
 	color: var(--text-muted);
-	margin-top: 3px;
 }
+
+/* ── Pie Chart ───────────────────────────────────────────────────────────── */
+.weread-stats-pie-wrap {
+	display: flex;
+	align-items: flex-start;
+	gap: 16px;
+	flex-wrap: wrap;
+	margin-top: 8px;
+}
+.weread-stats-pie-svg {
+	flex-shrink: 0;
+}
+.weread-stats-pie-slice {
+	transition: opacity 0.15s;
+	cursor: default;
+}
+.weread-stats-pie-slice:hover { opacity: 0.8; }
+.weread-stats-pie-legend {
+	display: flex;
+	flex-direction: column;
+	gap: 5px;
+	justify-content: center;
+}
+.weread-stats-pie-legend-row {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+.weread-stats-pie-legend-dot {
+	width: 9px;
+	height: 9px;
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+.weread-stats-pie-legend-label {
+	font-size: 0.78em;
+	color: var(--text-normal);
+}
+
+/* ── Tag Cloud ───────────────────────────────────────────────────────────── */
+.weread-stats-tag-cloud {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	align-items: center;
+	padding: 8px 0;
+}
+.weread-stats-cloud-tag {
+	color: var(--text-accent);
+	cursor: default;
+	line-height: 1.4;
+	transition: opacity 0.15s;
+}
+.weread-stats-cloud-tag:hover { opacity: 1 !important; }
 
 /* ── Info Grid ───────────────────────────────────────────────────────────── */
 .weread-stats-info-grid {

--- a/style.css
+++ b/style.css
@@ -2650,7 +2650,7 @@
 /* ── Preferences ─────────────────────────────────────────────────────────── */
 .weread-stats-pref-grid {
 	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
+	grid-template-columns: repeat(3, minmax(0, 1fr));
 	gap: 14px;
 }
 

--- a/style.css
+++ b/style.css
@@ -2322,11 +2322,11 @@
 .weread-stats-timepicker {
 	display: flex;
 	align-items: center;
-	gap: 2px;
+	gap: 4px;
 	background: var(--background-secondary);
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 10px;
-	padding: 2px 4px;
+	padding: 3px 8px;
 	margin-left: auto;
 	flex-shrink: 0;
 }
@@ -2335,8 +2335,8 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: 26px;
-	height: 26px;
+	width: 28px;
+	height: 28px;
 	border: none;
 	background: transparent;
 	color: var(--text-muted);
@@ -2358,10 +2358,12 @@
 }
 
 .weread-stats-timepicker-label {
-	font-size: 0.82em;
+	font-size: 0.88em;
 	color: var(--text-normal);
 	font-weight: 500;
-	padding: 0 6px;
+	padding: 0 10px;
+	min-width: 90px;
+	text-align: center;
 	white-space: nowrap;
 }
 

--- a/style.css
+++ b/style.css
@@ -2283,7 +2283,7 @@
 /* ── Tab Bar 胶囊 ─────────────────────────────────────────────────────────── */
 .weread-stats-tabbar {
 	display: inline-flex;
-	gap: 2px;
+	gap: 6px;
 	background: var(--background-secondary);
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 12px;

--- a/style.css
+++ b/style.css
@@ -2202,3 +2202,495 @@
 	color: var(--text-accent);
 }
 
+
+/* ══════════════════════════════════════════════════════════════════════════
+   WeRead Reading Stats View
+   ══════════════════════════════════════════════════════════════════════════ */
+
+.weread-stats-view {
+	overflow-y: auto;
+	height: 100%;
+}
+
+.weread-stats-container {
+	padding: 16px 20px 32px;
+	max-width: 900px;
+	margin: 0 auto;
+}
+
+/* ── Header ──────────────────────────────────────────────────────────────── */
+.weread-stats-header {
+	margin-bottom: 16px;
+}
+
+.weread-stats-title-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 8px;
+}
+
+.weread-stats-header-icon {
+	color: var(--text-accent);
+	display: flex;
+	align-items: center;
+}
+
+.weread-stats-title {
+	margin: 0;
+	font-size: 1.3em;
+	font-weight: 700;
+	color: var(--text-normal);
+}
+
+.weread-stats-header-actions {
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.weread-stats-btn {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 5px 12px;
+	border-radius: 6px;
+	border: 1px solid var(--background-modifier-border);
+	background: var(--background-secondary);
+	color: var(--text-normal);
+	cursor: pointer;
+	font-size: 0.85em;
+	transition: background 0.15s;
+}
+
+.weread-stats-btn:hover {
+	background: var(--background-modifier-hover);
+}
+
+.weread-stats-btn-icon {
+	padding: 5px 8px;
+}
+
+/* ── Tab Bar ─────────────────────────────────────────────────────────────── */
+.weread-stats-tabbar {
+	display: flex;
+	gap: 4px;
+	margin-bottom: 20px;
+	border-bottom: 1px solid var(--background-modifier-border);
+	padding-bottom: 0;
+}
+
+.weread-stats-tab {
+	padding: 6px 16px;
+	border: none;
+	background: transparent;
+	color: var(--text-muted);
+	cursor: pointer;
+	font-size: 0.9em;
+	border-bottom: 2px solid transparent;
+	margin-bottom: -1px;
+	border-radius: 0;
+	transition: color 0.15s, border-color 0.15s;
+}
+
+.weread-stats-tab:hover {
+	color: var(--text-normal);
+}
+
+.weread-stats-tab.is-active {
+	color: var(--text-accent);
+	border-bottom-color: var(--text-accent);
+	font-weight: 600;
+}
+
+/* ── KPI Cards ───────────────────────────────────────────────────────────── */
+.weread-stats-kpi-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+	gap: 12px;
+	margin-bottom: 24px;
+}
+
+.weread-stats-kpi-card {
+	display: flex;
+	align-items: flex-start;
+	gap: 10px;
+	padding: 14px 12px;
+	background: var(--background-secondary);
+	border-radius: 10px;
+	border: 1px solid var(--background-modifier-border);
+}
+
+.weread-stats-kpi-icon {
+	color: var(--text-accent);
+	flex-shrink: 0;
+	margin-top: 2px;
+}
+
+.weread-stats-kpi-body {
+	flex: 1;
+	min-width: 0;
+}
+
+.weread-stats-kpi-value {
+	font-size: 1.15em;
+	font-weight: 700;
+	color: var(--text-normal);
+	line-height: 1.2;
+	word-break: break-all;
+}
+
+.weread-stats-kpi-label-row {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	margin-top: 3px;
+}
+
+.weread-stats-kpi-label {
+	font-size: 0.78em;
+	color: var(--text-muted);
+}
+
+.weread-stats-compare-badge {
+	font-size: 0.72em;
+	padding: 1px 5px;
+	border-radius: 4px;
+	font-weight: 600;
+}
+
+.weread-stats-compare-badge.is-up {
+	background: rgba(72, 187, 120, 0.15);
+	color: #48bb78;
+}
+
+.weread-stats-compare-badge.is-down {
+	background: rgba(229, 62, 62, 0.15);
+	color: #e53e3e;
+}
+
+/* ── Sections ────────────────────────────────────────────────────────────── */
+.weread-stats-section {
+	margin-bottom: 28px;
+}
+
+.weread-stats-section-title {
+	font-size: 0.95em;
+	font-weight: 600;
+	color: var(--text-muted);
+	margin: 0 0 12px;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+}
+
+/* ── Bar Chart ───────────────────────────────────────────────────────────── */
+.weread-stats-chart-wrapper {
+	width: 100%;
+	overflow-x: auto;
+}
+
+.weread-stats-bar-chart {
+	display: block;
+}
+
+.weread-stats-bar {
+	fill: var(--text-accent);
+	opacity: 0.6;
+	transition: opacity 0.15s;
+}
+
+.weread-stats-bar.is-max {
+	opacity: 1;
+}
+
+.weread-stats-bar:hover {
+	opacity: 0.85;
+}
+
+.weread-stats-bar-label {
+	fill: var(--text-muted);
+	font-size: 10px;
+}
+
+/* ── Top Books ───────────────────────────────────────────────────────────── */
+.weread-stats-book-list {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.weread-stats-book-row {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 10px 12px;
+	background: var(--background-secondary);
+	border-radius: 8px;
+	border: 1px solid var(--background-modifier-border);
+}
+
+.weread-stats-book-rank {
+	width: 22px;
+	height: 22px;
+	border-radius: 50%;
+	background: var(--background-modifier-border);
+	color: var(--text-muted);
+	font-size: 0.75em;
+	font-weight: 700;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+}
+
+.weread-stats-book-cover {
+	width: 36px;
+	height: 48px;
+	object-fit: cover;
+	border-radius: 4px;
+	flex-shrink: 0;
+}
+
+.weread-stats-book-cover-placeholder {
+	background: var(--background-modifier-border);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--text-muted);
+}
+
+.weread-stats-book-info {
+	flex: 1;
+	min-width: 0;
+}
+
+.weread-stats-book-title {
+	font-size: 0.9em;
+	font-weight: 600;
+	color: var(--text-normal);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.weread-stats-book-author {
+	font-size: 0.78em;
+	color: var(--text-muted);
+	margin-top: 2px;
+}
+
+.weread-stats-book-tags {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+	margin-top: 4px;
+}
+
+.weread-stats-tag {
+	font-size: 0.7em;
+	padding: 1px 6px;
+	background: var(--tag-background);
+	color: var(--tag-color);
+	border-radius: 99px;
+}
+
+.weread-stats-book-right {
+	flex-shrink: 0;
+	text-align: right;
+	min-width: 80px;
+}
+
+.weread-stats-book-duration {
+	font-size: 0.82em;
+	font-weight: 600;
+	color: var(--text-accent);
+	margin-bottom: 5px;
+}
+
+.weread-stats-mini-bar-track {
+	height: 4px;
+	background: var(--background-modifier-border);
+	border-radius: 2px;
+	overflow: hidden;
+}
+
+.weread-stats-mini-bar-fill {
+	height: 100%;
+	background: var(--text-accent);
+	border-radius: 2px;
+	transition: width 0.4s ease;
+}
+
+/* ── Preferences ─────────────────────────────────────────────────────────── */
+.weread-stats-pref-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+	gap: 14px;
+}
+
+.weread-stats-pref-card {
+	background: var(--background-secondary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 10px;
+	padding: 14px;
+}
+
+.weread-stats-pref-card-wide {
+	grid-column: 1 / -1;
+}
+
+.weread-stats-pref-card-header {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 0.88em;
+	font-weight: 600;
+	color: var(--text-normal);
+	margin-bottom: 10px;
+}
+
+.weread-stats-pref-subtitle {
+	font-size: 0.78em;
+	color: var(--text-muted);
+	margin-bottom: 10px;
+	font-style: italic;
+}
+
+.weread-stats-pref-row {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	margin-bottom: 7px;
+}
+
+.weread-stats-pref-name {
+	width: 72px;
+	font-size: 0.8em;
+	color: var(--text-normal);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	flex-shrink: 0;
+}
+
+.weread-stats-pref-bar-track {
+	flex: 1;
+	height: 6px;
+	background: var(--background-modifier-border);
+	border-radius: 3px;
+	overflow: hidden;
+}
+
+.weread-stats-pref-bar-fill {
+	height: 100%;
+	background: var(--text-accent);
+	border-radius: 3px;
+	transition: width 0.4s ease;
+}
+
+.weread-stats-pref-meta {
+	font-size: 0.75em;
+	color: var(--text-muted);
+	flex-shrink: 0;
+	white-space: nowrap;
+}
+
+/* ── Hour Chart ──────────────────────────────────────────────────────────── */
+.weread-stats-hour-chart {
+	display: flex;
+	align-items: flex-end;
+	gap: 2px;
+	height: 70px;
+}
+
+.weread-stats-hour-col {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	flex: 1;
+}
+
+.weread-stats-hour-bar {
+	width: 100%;
+	background: var(--text-accent);
+	border-radius: 2px 2px 0 0;
+	opacity: 0.7;
+	transition: opacity 0.15s;
+	cursor: default;
+}
+
+.weread-stats-hour-bar:hover {
+	opacity: 1;
+}
+
+.weread-stats-hour-label {
+	font-size: 9px;
+	color: var(--text-muted);
+	margin-top: 3px;
+}
+
+/* ── Info Grid ───────────────────────────────────────────────────────────── */
+.weread-stats-info-grid {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 16px;
+}
+
+.weread-stats-info-item {
+	background: var(--background-secondary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 8px;
+	padding: 10px 16px;
+}
+
+.weread-stats-info-label {
+	font-size: 0.75em;
+	color: var(--text-muted);
+	margin-bottom: 3px;
+}
+
+.weread-stats-info-value {
+	font-size: 1em;
+	font-weight: 600;
+	color: var(--text-normal);
+}
+
+/* ── Empty States ────────────────────────────────────────────────────────── */
+.weread-stats-empty {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	padding: 60px 20px;
+	gap: 12px;
+	text-align: center;
+}
+
+.weread-stats-empty-icon {
+	color: var(--text-muted);
+	opacity: 0.5;
+}
+
+.weread-stats-empty-text {
+	color: var(--text-normal);
+	font-size: 0.95em;
+}
+
+.weread-stats-empty-hint {
+	color: var(--text-muted);
+	font-size: 0.82em;
+}
+
+/* ── Spinner ─────────────────────────────────────────────────────────────── */
+.weread-stats-spinner {
+	width: 32px;
+	height: 32px;
+	border: 3px solid var(--background-modifier-border);
+	border-top-color: var(--text-accent);
+	border-radius: 50%;
+	animation: weread-spin 0.8s linear infinite;
+}
+
+@keyframes weread-spin {
+	to { transform: rotate(360deg); }
+}

--- a/style.css
+++ b/style.css
@@ -2284,7 +2284,7 @@
 /* ── Tab Bar 胶囊 ─────────────────────────────────────────────────────────── */
 .weread-stats-tabbar {
 	display: flex;
-	gap: 4px;
+	gap: 0;
 	background: var(--background-secondary);
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 12px;
@@ -2292,7 +2292,9 @@
 }
 
 .weread-stats-tab {
-	padding: 5px 16px;
+	flex: 1;
+	padding: 5px 0;
+	text-align: center;
 	border: none;
 	background: transparent;
 	color: var(--text-muted);
@@ -2400,7 +2402,7 @@
 
 .weread-stats-kpi-grid {
 	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+	grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
 	gap: 12px;
 	margin-bottom: 24px;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,7 +59,7 @@ module.exports = {
 			'~': path.resolve(__dirname, 'src')
 		},
 		extensions: ['.ts', '.tsx', '.js', '.svelte'],
-		mainFields: ['svelte', 'browser', 'module', 'main']
+		mainFields: ['svelte', 'browser', 'module', 'main'],
 	},
 	externals: {
 		electron: 'commonjs2 electron',


### PR DESCRIPTION
## Summary

### 阅读统计面板（全新功能）
- 新增 \`WereadReadingStatsView\`（ItemView），点击书架工具栏 📊 图标即可打开
- **多维度 Tab**：本周 / 本月 / 本年 / 全部，切换后自动请求对应数据，Tab 选中状态使用强调色浅背景高亮
- **用户信息卡片**：顶部展示头像（圆形）、用户名、个性签名，右侧提供导出图片按钮
- **KPI 卡片**：阅读时长、阅读天数、日均时长（附环比徽章）、读过、读完、笔记数；数字字号放大，单位保持正常大小
- **SVG 柱状图**：按天/月/年粒度展示阅读时长分布；月视图补全当月所有日期（含未来日期）
- **年度热力图**：GitHub 风格热力图，自适应宽度无横向滚动条，图例尺寸修复
- **Top 书单**：封面、作者、标签、Mini 进度条、阅读时长排行
- **偏好分析**：分类偏好条形图、偏好作者列表、24 小时阅读时段分布

### 导出图片
- 点击导出按钮显示 Loading 提示框，生成完成后弹出预览 Modal
- 预览 Modal 提供三个操作：**保存到 Vault** / **保存到本地** / **复制到剪贴板**
- 修复非分屏模式下截图偏移（内容只显示右半部分）的问题
- 修复点击导出时界面闪烁跳动的问题
- 图片缓存优化，避免重复网络请求，提升导出速度
- 文件名附加时间戳（精确到分钟）

### 缓存机制修复
- 修复 `loadDailyCache()` 缓存永远未命中的 Bug（根因：隐藏目录 `.weread-cache/` 不在 Obsidian Vault 索引中，`getAbstractFileByPath` 始终返回 null）
- 改用 `vault.adapter.exists` / `vault.adapter.read` 读取隐藏目录，全部/年度 Tab 首次加载速度大幅提升

### API 与设置
- 新增 `callAgentGateway()` / `getReadingStats()` 方法，对接微信读书 `/readdata/detail` 接口
- 新增 `getUserInfo(userVid)` 方法，获取用户头像、昵称、个性签名
- 新增设置项：API Key 输入
- 移除废弃设置项：「阅读统计保存位置」和「同步阅读统计」

### 文档
- `docs/weread-agent-api.md` 记录 Agent Gateway 全量接口与示例数据

## Test plan

- [ ] 在设置中填写 `wereadApiKey`（格式 `wrk-xxx`），点击书架工具栏 📊 图标，面板正常打开
- [ ] 切换 本周 / 本月 / 本年 / 全部 Tab，数据正常刷新，选中 Tab 有强调色背景
- [ ] KPI 卡片、柱状图、Top 书单、偏好分析数据正常展示；数字放大，单位正常
- [ ] 月视图柱状图显示当月所有天（包含未来日期）
- [ ] 年度热力图无横向滚动条，图例大小正常
- [ ] 顶部正确展示头像（圆形）、用户名、个性签名
- [ ] 点击「导出图片」显示 Loading，生成后弹出预览 Modal，三个保存选项均正常工作
- [ ] 非分屏模式下导出图片内容完整，无偏移、无闪烁
- [ ] 第二次进入全部/年度 Tab 时，缓存命中，无明显加载延迟
- [ ] 无 API Key 时显示引导提示；网络错误时显示重试按钮