### PR TITLE
feat: 支持同步划线中点赞过的评论

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -321,6 +321,7 @@ export default class ApiManager {
 		}
 	}
 
+
 	async getChapters(bookId: string): Promise<ChapterResponse | undefined> {
 		try {
 			const url = `${this.baseUrl}/web/book/chapterInfos`;

--- a/src/models.ts
+++ b/src/models.ts
@@ -415,6 +415,21 @@ export type Review = {
 	};
 };
 
+export type LikedReview = {
+	reviewId: string;
+	chapterUid?: number;
+	chapterTitle?: string;
+	created: number;
+	createTime: string;
+	content: string;
+	mdContent?: string;
+	abstract?: string;
+	range?: string;
+	type: number;
+	authorName: string;
+	authorAvatar?: string;
+};
+
 export type ChapterHighlightReview = {
 	chapterUid?: number;
 	chapterIdx?: number;
@@ -424,6 +439,7 @@ export type ChapterHighlightReview = {
 	// highlight and review can be empty, just output title
 	highlights?: Highlight[];
 	chapterReviews?: Review[];
+	likedReviews?: LikedReview[];
 };
 
 export type RenderTemplate = {

--- a/src/parser/parseResponse.ts
+++ b/src/parser/parseResponse.ts
@@ -8,6 +8,7 @@ import type {
 	DailyNoteReferenece,
 	Highlight,
 	HighlightResponse,
+	LikedReview,
 	Metadata,
 	Notebook,
 	RefBlockDetail,
@@ -379,6 +380,48 @@ const getFa = (id: string): [string, string[]] => {
 		d += id.charCodeAt(i).toString(16);
 	}
 	return ['4', [d]];
+};
+
+export const parseLikedReviews = (resp: BookReviewResponse): LikedReview[] => {
+	if (!resp || !resp.reviews) return [];
+	const convertTags = get(settingsStore).convertTags;
+	return resp.reviews
+		.filter((reviewData) => reviewData.review.isLike === 1)
+		.map((reviewData) => {
+			const review = reviewData.review;
+			const created = review.createTime;
+			const createTime = window.moment(created * 1000).format('YYYY-MM-DD HH:mm:ss');
+			const mdContent = review.htmlContent
+				? NodeHtmlMarkdown.translate(review.htmlContent)
+				: null;
+			const content = mdContent || review.content;
+			const finalContent = convertTags ? convertTagToBiLink(content) : content;
+			return {
+				reviewId: review.reviewId?.replace(/[_~]/g, '-'),
+				chapterUid: review.chapterUid,
+				chapterTitle: review.chapterTitle || review.refMpInfo?.title,
+				created: created,
+				createTime: createTime,
+				content: finalContent,
+				mdContent: mdContent,
+				abstract: review.abstract,
+				range: review.range,
+				type: review.type,
+				authorName: review.author?.name || '匿名',
+				authorAvatar: review.author?.avatar
+			};
+		});
+};
+
+export const attachLikedReviewsToChapters = (
+	chapterHighlights: ChapterHighlightReview[],
+	likedReviews: LikedReview[]
+): void => {
+	for (const chapter of chapterHighlights) {
+		chapter.likedReviews = likedReviews.filter(
+			(review) => review.chapterUid === chapter.chapterUid
+		);
+	}
 };
 
 export const getPcUrl = (bookId: string): string => {

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -319,6 +319,7 @@ export class WereadSettingsTab extends PluginSettingTab {
 		const syncMode = get(settingsStore).syncMode;
 		if (syncMode === 'blacklist') {
 			this.saveArticleToggle();
+			this.syncLikedReviewsToggle();
 			this.noteCountLimit();
 		}
 		this.renderSyncModeBookSelection(syncMode);
@@ -489,6 +490,19 @@ export class WereadSettingsTab extends PluginSettingTab {
 				});
 			});
 	}
+	private syncLikedReviewsToggle(): void {
+		new Setting(this.containerEl)
+			.setName('同步点赞的评论')
+			.setDesc('开启后将同步划线中你点赞过的其他用户评论')
+			.addToggle((toggle) => {
+				return toggle
+					.setValue(get(settingsStore).syncLikedReviews)
+					.onChange((value) => {
+						settingsStore.actions.setSyncLikedReviews(value);
+					});
+			});
+	}
+
 	private saveReadingInfoToggle(): void {
 		new Setting(this.containerEl)
 			.setName('保存阅读元数据?')

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -103,6 +103,7 @@ export interface WereadPluginSettings {
 	wereadApiKey: string;
 	readingStatsLocation: string;
 	statsStartYear?: number;
+	syncLikedReviews: boolean;
 }
 
 const DEFAULT_SETTINGS: WereadPluginSettings = {
@@ -158,6 +159,7 @@ const DEFAULT_SETTINGS: WereadPluginSettings = {
 	wereadApiKey: '',
 	readingStatsLocation: '/',
 	statsStartYear: 0,  // 0 = use registTime from API
+	syncLikedReviews: false,
 };
 
 const createSettingsStore = () => {
@@ -747,6 +749,13 @@ const createSettingsStore = () => {
 		});
 	};
 
+	const setSyncLikedReviews = (syncLikedReviews: boolean) => {
+		store.update((state) => {
+			state.syncLikedReviews = syncLikedReviews;
+			return state;
+		});
+	};
+
 	return {
 		subscribe: store.subscribe,
 		initialise,
@@ -803,6 +812,7 @@ const createSettingsStore = () => {
 			setReadingStatsLocation,
 			setStatsStartYear,
 			setUserSignature,
+			setSyncLikedReviews,
 		}
 	};
 };

--- a/src/syncNotebooks.ts
+++ b/src/syncNotebooks.ts
@@ -16,7 +16,9 @@ import {
 	parseDailyNoteReferences,
 	parseReviews,
 	parseChapterResp,
-	parseArticleHighlightReview
+	parseArticleHighlightReview,
+	parseLikedReviews,
+	attachLikedReviewsToChapters
 } from './parser/parseResponse';
 import { settingsStore } from './settings';
 import { get } from 'svelte/store';
@@ -206,6 +208,12 @@ export default class SyncNotebooks {
 		} else {
 			chapterHighlightReview = parseChapterHighlightReview(chapters, highlights, reviews);
 		}
+
+		if (get(settingsStore).syncLikedReviews && reviewResp) {
+			const likedReviews = parseLikedReviews(reviewResp);
+			attachLikedReviewsToChapters(chapterHighlightReview, likedReviews);
+		}
+
 		const bookReview = parseChapterReviews(reviewResp);
 		return {
 			metaData: metaData,

--- a/src/themes/notebookTemplate.njk
+++ b/src/themes/notebookTemplate.njk
@@ -34,6 +34,15 @@ lastReadDate: {{ metaData.lastReadDate }}
 > ⏱ {{ highlight.createTime }} ^{{ highlight.bookmarkId }}
 {% endif %}
 {% endfor %}
+{% if chapter.likedReviews and chapter.likedReviews.length > 0 %}
+
+#### 点赞的评论
+{% for likedReview in chapter.likedReviews %}
+> 👍 {{ likedReview.content }}
+> —— {{ likedReview.authorName }}{% if likedReview.abstract %} · 原文：{{ likedReview.abstract | trim }}{% endif %}
+> ⏱ {{ likedReview.createTime }}
+{% endfor %}
+{% endif %}
 {% endfor %}
 
 # 读书笔记

--- a/src/themes/separatedTemplate.njk
+++ b/src/themes/separatedTemplate.njk
@@ -20,6 +20,15 @@ lastReadDate: {{ metaData.lastReadDate }}
 {% set deeplink = "weread://bestbookmark?bookId=" + metaData.bookId + "&chapterUid=" + highlight.chapterUid + "&rangeStart=" + rangeParts[0] + "&rangeEnd=" + rangeParts[1] %}
 > 📌 [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
 {% endfor %}
+{% if chapter.likedReviews and chapter.likedReviews.length > 0 %}
+
+#### 点赞的评论
+{% for likedReview in chapter.likedReviews %}
+> 👍 {{ likedReview.content }}
+> —— {{ likedReview.authorName }}{% if likedReview.abstract %} · 原文：{{ likedReview.abstract | trim }}{% endif %}
+> ⏱ {{ likedReview.createTime }}
+{% endfor %}
+{% endif %}
 {% endfor %}
 
 # 笔记汇总

--- a/src/themes/wereadOfficialTemplate.njk
+++ b/src/themes/wereadOfficialTemplate.njk
@@ -38,4 +38,17 @@ lastReadDate: {{ metaData.lastReadDate }}
 
 {% endif %}
 {% endfor %}
+{% if chapter.likedReviews and chapter.likedReviews.length > 0 %}
+
+#### 👍 点赞的评论
+{% for likedReview in chapter.likedReviews %}
+
+{{ likedReview.createTime }} {{ likedReview.authorName }}
+{{ likedReview.content }}
+{% if likedReview.abstract %}
+> {{ likedReview.abstract | trim }}
+{% endif %}
+
+{% endfor %}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
复用已有的 review/list 响应，按 isLike === 1 过滤出用户点赞的评论，
按章节分组后附加到 chapterHighlights，无额外网络请求。

- 新增 LikedReview 类型和 syncLikedReviews 设置开关
- 三套内置模板均支持渲染点赞评论