### PR TITLE
feat: 2.0 API Key 扫码获取，详情页重构，热门划线

### DIFF
--- a/docs/superpowers/plans/2026-06-01-popular-highlights-plan.md
+++ b/docs/superpowers/plans/2026-06-01-popular-highlights-plan.md
@@ -1,0 +1,1000 @@
+# 热门划线同步功能实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 实现热门划线同步功能，支持按章节并发查询、本地文件缓存（默认7天）、以及分离式模板展示
+
+**Architecture:** 缓存层（popularHighlightsCache.ts）负责热门划线的读写，syncNotebooks.ts 集成缓存和并发查询逻辑，模板层支持合并/分离两种展示模式
+
+**Tech Stack:** TypeScript, Obsidian API, Nunjucks templates
+
+---
+
+## 文件结构
+
+```
+src/
+├── popularHighlightsCache.ts   # 新增：热门划线缓存管理类
+├── models.ts                  # 修改：PopularHighlightCache 类型
+├── settings.ts                # 修改：新增缓存 TTL 设置项
+├── api-router.ts              # 修改：添加按章节查询方法
+├── syncNotebooks.ts           # 修改：集成缓存和并发查询
+├── renderer.ts                # 修改：扩展 RenderTemplate
+├── settingTab.ts              # 修改：添加缓存 TTL 配置项
+└── themes/
+    └── separatedWithPopularTemplate.njk  # 新增：分离式含热门划线模板
+```
+
+---
+
+## Task 1: 创建缓存管理类
+
+**Files:**
+- Create: `src/popularHighlightsCache.ts`
+- Modify: `src/models.ts` (添加类型)
+
+- [ ] **Step 1: 在 models.ts 中添加 PopularHighlightCache 类型**
+
+在 `models.ts` 文件末尾添加：
+
+```typescript
+export type PopularHighlightCache = {
+  bookId: string;
+  cachedAt: number;
+  ttl: number;
+  items: PopularHighlight[];
+  chapters: {
+    bookId: string;
+    chapterUid: number;
+    chapterIdx: number;
+    title: string;
+  }[];
+};
+```
+
+- [ ] **Step 2: 创建 popularHighlightsCache.ts**
+
+```typescript
+import { Notice } from 'obsidian';
+import { settingsStore } from './settings';
+import { get } from 'svelte/store';
+import type { PopularHighlight, PopularHighlightCache } from './models';
+
+export default class PopularHighlightsCacheManager {
+  private cacheDir: string = '.weread-cache';
+
+  /**
+   * 获取缓存目录的完整路径
+   */
+  private getCachePath(bookId: string): string {
+    return `${this.cacheDir}/popular-${bookId}.json`;
+  }
+
+  /**
+   * 检查缓存是否过期
+   */
+  private isCacheExpired(cache: PopularHighlightCache): boolean {
+    const settings = get(settingsStore);
+    const ttlMs = (settings.popularHighlightsCacheTtl ?? 7) * 24 * 60 * 60 * 1000;
+    return Date.now() > cache.cachedAt + ttlMs;
+  }
+
+  /**
+   * 读取缓存
+   */
+  async get(bookId: string): Promise<PopularHighlightCache | null> {
+    try {
+      const cachePath = this.getCachePath(bookId);
+      // 检查文件是否存在（通过异步读取）
+      const exists = await this.fileExists(cachePath);
+      if (!exists) return null;
+
+      // 读取并解析 JSON
+      const content = await this.readFile(cachePath);
+      const cache: PopularHighlightCache = JSON.parse(content);
+
+      // 检查缓存是否过期
+      if (this.isCacheExpired(cache)) {
+        console.log(`[weread plugin] 热门划线缓存已过期: ${bookId}`);
+        return null;
+      }
+
+      console.log(`[weread plugin] 热门划线缓存命中: ${bookId}`);
+      return cache;
+    } catch (e) {
+      console.error(`[weread plugin] 读取热门划线缓存失败: ${bookId}`, e);
+      return null;
+    }
+  }
+
+  /**
+   * 写入缓存
+   */
+  async set(bookId: string, items: PopularHighlight[], chapters: PopularHighlightCache['chapters']): Promise<void> {
+    try {
+      const settings = get(settingsStore);
+      const cache: PopularHighlightCache = {
+        bookId,
+        cachedAt: Date.now(),
+        ttl: settings.popularHighlightsCacheTtl ?? 7,
+        items,
+        chapters
+      };
+
+      const cachePath = this.getCachePath(bookId);
+      await this.ensureCacheDir();
+      await this.writeFile(cachePath, JSON.stringify(cache, null, 2));
+      console.log(`[weread plugin] 热门划线缓存已写入: ${bookId}`);
+    } catch (e) {
+      console.error(`[weread plugin] 写入热门划线缓存失败: ${bookId}`, e);
+    }
+  }
+
+  /**
+   * 清除单本书的缓存
+   */
+  async clear(bookId: string): Promise<void> {
+    try {
+      const cachePath = this.getCachePath(bookId);
+      const exists = await this.fileExists(cachePath);
+      if (exists) {
+        await this.deleteFile(cachePath);
+        console.log(`[weread plugin] 热门划线缓存已清除: ${bookId}`);
+      }
+    } catch (e) {
+      console.error(`[weread plugin] 清除热门划线缓存失败: ${bookId}`, e);
+    }
+  }
+
+  /**
+   * 清除所有过期缓存
+   */
+  async clearExpired(): Promise<number> {
+    try {
+      const cacheDirPath = this.cacheDir;
+      const exists = await this.fileExists(cacheDirPath);
+      if (!exists) return 0;
+
+      const files = await this.listFiles(cacheDirPath);
+      let cleared = 0;
+
+      for (const file of files) {
+        if (!file.startsWith('popular-') || !file.endsWith('.json')) continue;
+
+        try {
+          const content = await this.readFile(`${cacheDirPath}/${file}`);
+          const cache: PopularHighlightCache = JSON.parse(content);
+          if (this.isCacheExpired(cache)) {
+            await this.deleteFile(`${cacheDirPath}/${file}`);
+            cleared++;
+          }
+        } catch (e) {
+          // 忽略解析失败的文件
+        }
+      }
+
+      if (cleared > 0) {
+        console.log(`[weread plugin] 已清除 ${cleared} 个过期热门划线缓存`);
+      }
+      return cleared;
+    } catch (e) {
+      console.error('[weread plugin] 清除过期缓存失败', e);
+      return 0;
+    }
+  }
+
+  /**
+   * 确保缓存目录存在
+   */
+  private async ensureCacheDir(): Promise<void> {
+    try {
+      const exists = await this.fileExists(this.cacheDir);
+      if (!exists) {
+        await this.createDir(this.cacheDir);
+      }
+    } catch (e) {
+      // 目录已存在或其他错误，忽略
+    }
+  }
+
+  // 抽象文件系统操作（由 Obsidian 实现）
+  private async fileExists(path: string): Promise<boolean> {
+    // @ts-ignore - Vault is available in Obsidian context
+    return app.vault.getAbstractFileByPath(path) !== null;
+  }
+
+  private async readFile(path: string): Promise<string> {
+    // @ts-ignore
+    const file = app.vault.getAbstractFileByPath(path);
+    if (!file) throw new Error('File not found');
+    // @ts-ignore
+    return await app.vault.read(file);
+  }
+
+  private async writeFile(path: string, content: string): Promise<void> {
+    // @ts-ignore
+    const file = app.vault.getAbstractFileByPath(path);
+    if (file) {
+      // @ts-ignore
+      await app.vault.modify(file, content);
+    } else {
+      // @ts-ignore
+      await app.vault.create(path, content);
+    }
+  }
+
+  private async deleteFile(path: string): Promise<void> {
+    // @ts-ignore
+    const file = app.vault.getAbstractFileByPath(path);
+    if (file) {
+      // @ts-ignore
+      await app.vault.delete(file);
+    }
+  }
+
+  private async createDir(path: string): Promise<void> {
+    // @ts-ignore
+    await app.vault.createFolder(path);
+  }
+
+  private async listFiles(dirPath: string): Promise<string[]> {
+    // @ts-ignore
+    const folder = app.vault.getAbstractFileByPath(dirPath);
+    if (!folder || folder.constructor.name !== 'TFolder') return [];
+    // @ts-ignore
+    return folder.children.filter(f => f.constructor.name === 'TFile').map(f => f.name);
+  }
+}
+```
+
+- [ ] **Step 3: 提交代码**
+
+```bash
+git add src/models.ts src/popularHighlightsCache.ts
+git commit -m "feat: 添加热门划线缓存管理类
+
+- 新增 PopularHighlightsCacheManager 类
+- 支持缓存读写、过期检查、批量清理
+- 缓存存储在 .weread-cache/ 目录
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: 添加缓存 TTL 设置项
+
+**Files:**
+- Modify: `src/settings.ts:109-165` (DEFAULT_SETTINGS), `src/settings.ts:742-747` (actions)
+
+- [ ] **Step 1: 在 DEFAULT_SETTINGS 中添加 popularHighlightsCacheTtl**
+
+在 `settings.ts` 的 `DEFAULT_SETTINGS` 对象中，找到 `syncPopularHighlightsToggle: false,` 这一行，在其后添加：
+
+```typescript
+popularHighlightsCacheTtl: 7,
+```
+
+完整添加位置（约在第 139 行）：
+```typescript
+saveReadingInfoToggle: true,
+syncPopularHighlightsToggle: false,
+popularHighlightsCacheTtl: 7,
+readingOpenMode: 'TAB',
+```
+
+- [ ] **Step 2: 添加 setPopularHighlightsCacheTtl action**
+
+在 `settings.ts` 中找到 `setStatsStartYear` 的定义（约在第 742 行），在其后添加：
+
+```typescript
+const setPopularHighlightsCacheTtl = (value: number) => {
+  store.update((state) => {
+    state.popularHighlightsCacheTtl = Math.max(1, value);
+    return state;
+  });
+};
+```
+
+- [ ] **Step 3: 在 actions 对象中注册新方法**
+
+找到 `return { ... }` 中的 `actions` 对象（约在第 756 行），添加：
+
+```typescript
+setPopularHighlightsCacheTtl,
+```
+
+位置示例：
+```typescript
+setStatsStartYear,
+setReadingStatsLocation,
+setUserSignature,
+setPopularHighlightsCacheTtl,  // 新增
+```
+
+- [ ] **Step 4: 提交代码**
+
+```bash
+git add src/settings.ts
+git commit -m "feat: 添加热门划线缓存 TTL 设置项
+
+- 新增 popularHighlightsCacheTtl 配置项（默认7天）
+- 新增 setPopularHighlightsCacheTtl action
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: 添加按章节查询热门划线方法
+
+**Files:**
+- Modify: `src/api-router.ts:134-143` (添加重载方法)
+- Modify: `src/api-v2.ts:88-102` (实现按章节查询)
+
+- [ ] **Step 1: 在 api-v2.ts 中检查 getBestBookmarks 是否支持 chapterUid 参数**
+
+查看 `src/api-v2.ts` 第 88-102 行的 `getBestBookmarks` 方法：
+
+```typescript
+async getBestBookmarks(bookId: string, chapterUid = 0) {
+  return this.callAgent<{
+    synckey: number;
+    totalCount: number;
+    items: {
+      bookId: string;
+      bookmarkId: string;
+      chapterUid: number;
+      range: string;
+      markText: string;
+      totalCount: number;
+    }[];
+    chapters: { bookId: string; chapterUid: number; chapterIdx: number; title: string }[];
+  }>('/book/bestbookmarks', { bookId, chapterUid });
+}
+```
+
+该方法已支持 `chapterUid` 参数，参数名为 0 表示获取全量。
+
+- [ ] **Step 2: 在 api-router.ts 中添加并发批量获取方法**
+
+在 `src/api-router.ts` 的 `ApiRouter` 类中，找到 `getBestBookmarks` 方法（约在第 134 行），在其后添加新方法：
+
+```typescript
+/**
+ * 批量获取热门划线（按章节）
+ * @param bookId 书籍 ID
+ * @param chapterUids 章节 UID 数组
+ * @param batchSize 每批数量，默认 5
+ */
+async getBestBookmarksBatch(
+  bookId: string,
+  chapterUids: number[],
+  batchSize = 5
+): Promise<Map<number, { bookmarkId: string; range: string; markText: string; totalCount: number }[]>> {
+  const results = new Map<number, { bookmarkId: string; range: string; markText: string; totalCount: number }[]>();
+
+  for (let i = 0; i < chapterUids.length; i += batchSize) {
+    const batch = chapterUids.slice(i, i + batchSize);
+    const promises = batch.map(async (chapterUid) => {
+      const resp = await this.getBestBookmarks(bookId, chapterUid);
+      return { chapterUid, items: resp?.items ?? [] };
+    });
+
+    const settled = await Promise.allSettled(promises);
+    for (const result of settled) {
+      if (result.status === 'fulfilled') {
+        results.set(result.value.chapterUid, result.value.items);
+      } else {
+        console.warn(`[weread plugin] 获取章节热门划线失败: chapterUid=${result.reason}`);
+      }
+    }
+  }
+
+  return results;
+}
+```
+
+- [ ] **Step 3: 提交代码**
+
+```bash
+git add src/api-router.ts src/api-v2.ts
+git commit -m "feat: 添加按章节批量查询热门划线方法
+
+- ApiRouter 新增 getBestBookmarksBatch 方法
+- 支持按批次并发查询，每批 5 个章节
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: 创建分离式含热门划线模板
+
+**Files:**
+- Create: `src/themes/separatedWithPopularTemplate.njk`
+
+- [ ] **Step 1: 创建模板文件**
+
+```njk
+---
+isbn: {{ metaData.isbn }}
+lastReadDate: {{ metaData.lastReadDate }}
+---
+# {{ metaData.title }}
+> 作者：{{ metaData.author }}
+> {% if metaData.intro %}{{ metaData.intro | truncate(100) }}{% endif %}
+
+{% set hasUserHighlights = false %}
+{% for chapter in chapterHighlights %}
+  {% if chapter.highlights and chapter.highlights.length > 0 %}
+    {% set hasUserHighlights = true %}
+    {% break %}
+  {% endif %}
+{% endfor %}
+
+# 我的划线
+{% if hasUserHighlights %}
+{% for chapter in chapterHighlights %}
+{% if chapter.highlights and chapter.highlights.length > 0 %}
+## {{ chapter.chapterTitle }}
+{% for highlight in chapter.highlights %}
+{% set rangeParts = highlight.range | split("-") %}
+{% set deeplink = "weread://bestbookmark?bookId=" + metaData.bookId + "&chapterUid=" + highlight.chapterUid + "&rangeStart=" + rangeParts[0] + "&rangeEnd=" + rangeParts[1] %}
+> 📌 [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
+{% if highlight.isPopular %}
+> 🔥 {{ highlight.popularCount }} 人共读
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% else %}
+> 暂无划线
+{% endif %}
+
+{% set hasPopularHighlights = false %}
+{% if popularHighlights and popularHighlights.length > 0 %}
+{% for chapter in popularHighlights %}
+  {% if chapter.highlights and chapter.highlights.length > 0 %}
+    {% set hasPopularHighlights = true %}
+    {% break %}
+  {% endif %}
+{% endfor %}
+{% endif %}
+
+# 热门划线
+{% if hasPopularHighlights %}
+{% for chapter in popularHighlights %}
+{% if chapter.highlights and chapter.highlights.length > 0 %}
+## {{ chapter.chapterTitle }}
+{% for highlight in chapter.highlights %}
+{% set rangeParts = highlight.range | split("-") %}
+{% set deeplink = "weread://bestbookmark?bookId=" + metaData.bookId + "&chapterUid=" + highlight.chapterUid + "&rangeStart=" + rangeParts[0] + "&rangeEnd=" + rangeParts[1] %}
+> 🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
+{% if highlight.totalCount %}
+> 📊 {{ highlight.totalCount }} 人共读
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% else %}
+> 暂无热门划线
+{% endif %}
+
+# 我的笔记
+{% set hasNotes = false %}
+{% for chapter in chapterHighlights %}
+  {% if chapter.highlights %}
+    {% for highlight in chapter.highlights %}
+      {% if highlight.reviewContent %}
+        {% set hasNotes = true %}
+        {% break %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+  {% if hasNotes %}{% break %}{% endif %}
+{% endfor %}
+
+{% if hasNotes %}
+{% for chapter in chapterHighlights %}
+{% if chapter.highlights %}
+{% for highlight in chapter.highlights %}
+{% if highlight.reviewContent %}
+## {{ chapter.chapterTitle }} 的想法
+{{ highlight.reviewContent }}
+> 📌 {{ highlight.markText | trim }}
+
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% else %}
+> 暂无笔记
+{% endif %}
+
+{% if bookReview.bookReviews and bookReview.bookReviews.length > 0 %}
+# 书评
+{% for bookReview in bookReview.bookReviews %}
+## 书评 {{ loop.index }}
+{{ bookReview.createTime }}
+{{ bookReview.mdContent }}
+^{{ bookReview.reviewId }}
+{% endfor %}
+{% endif %}
+```
+
+- [ ] **Step 2: 在 settings.ts 中注册新模板为内置主题**
+
+在 `settings.ts` 中找到 `BUILT_IN_THEMES` 数组（约在第 20-51 行），在 `builtin_official` 后添加：
+
+```typescript
+{
+  id: 'builtin_separated_with_popular',
+  name: '分离式（含热门划线）',
+  description: '我的划线、热门划线、笔记分开展示，适合分析学习',
+  template: separatedWithPopularTemplate,
+  trimBlocks: true,
+  isBuiltIn: true,
+  isReadOnly: true,
+  source: 'builtin'
+},
+```
+
+然后在文件顶部添加 import：
+
+```typescript
+import separatedWithPopularTemplate from './themes/separatedWithPopularTemplate.njk';
+```
+
+- [ ] **Step 3: 提交代码**
+
+```bash
+git add src/themes/separatedWithPopularTemplate.njk src/settings.ts
+git commit -m "feat: 新增分离式（含热门划线）模板
+
+- 模板结构：我的划线 → 热门划线 → 我的笔记 → 书评
+- 热门划线标记 🔥 和共读人数
+- 注册为内置主题 builtin_separated_with_popular
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: 扩展 RenderTemplate 和 Notebook 类型
+
+**Files:**
+- Modify: `src/models.ts` (Notebook, RenderTemplate)
+
+- [ ] **Step 1: 修改 Notebook 类型**
+
+找到 `models.ts` 中的 `Notebook` 类型定义（约在第 339 行），修改为：
+
+```typescript
+export type Notebook = {
+  metaData: Metadata;
+  chapterHighlights: ChapterHighlightReview[];
+  bookReview: BookReview;
+  popularHighlights?: PopularChapterHighlight[];  // 用于分离模式
+};
+```
+
+注意：当前 `Notebook` 已包含 `popularHighlights`，不需要修改。
+
+- [ ] **Step 2: 修改 ChapterHighlightReview 类型，添加 popularHighlights**
+
+找到 `ChapterHighlightReview` 类型定义（约在第 437 行），修改为：
+
+```typescript
+export type ChapterHighlightReview = {
+  chapterUid?: number;
+  chapterIdx?: number;
+  chapterTitle: string;
+  level: number;
+  isMPChapter: number;
+  highlights?: Highlight[];
+  chapterReviews?: Review[];
+  popularHighlights?: PopularHighlight[];  // 新增：该章节的热门划线（用于分离模式）
+};
+```
+
+- [ ] **Step 3: 修改 Highlight 类型，添加 isUserHighlight**
+
+找到 `Highlight` 类型定义（约在第 389 行），添加字段：
+
+```typescript
+export type Highlight = {
+  bookmarkId: string;
+  created: number;
+  createTime: string;
+  chapterUid: number;
+  chapterIdx: number;
+  chapterTitle: string;
+  markText: string;
+  style: number;
+  colorStyle: number;
+  reviewContent?: string;
+  range: string;
+  refMpReviewId?: string;
+  isPopular?: boolean;
+  popularCount?: number;
+  isUserHighlight?: boolean;  // 新增：标记是否为用户自己的划线
+};
+```
+
+- [ ] **Step 4: 修改 RenderTemplate 类型**
+
+找到 `RenderTemplate` 类型定义（约在第 449 行），修改为：
+
+```typescript
+export type RenderTemplate = {
+  metaData: Metadata;
+  chapterHighlights: ChapterHighlightReview[];
+  bookReview: BookReview;
+  popularHighlights?: PopularChapterHighlight[];  // 用于分离模式
+  // userHighlights 和 popularHighlights 是相同的 chapterHighlights + popularHighlights
+  // 模板通过判断 isUserHighlight 来区分
+};
+```
+
+- [ ] **Step 5: 提交代码**
+
+```bash
+git add src/models.ts
+git commit -m "feat: 扩展模型类型以支持热门划线分离展示
+
+- ChapterHighlightReview 添加 popularHighlights 字段
+- Highlight 添加 isUserHighlight 字段
+- RenderTemplate 添加 popularHighlights 字段
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: 集成缓存和并发查询到 syncNotebooks.ts
+
+**Files:**
+- Modify: `src/syncNotebooks.ts:174-270` (convertToNotebook)
+
+- [ ] **Step 1: 添加缓存管理器实例**
+
+在 `SyncNotebooks` 类顶部添加：
+
+```typescript
+import PopularHighlightsCacheManager from './popularHighlightsCache';
+
+export default class SyncNotebooks {
+  private fileManager: FileManager;
+  private apiManager: ApiRouter;
+  private cacheManager: PopularHighlightsCacheManager;
+
+  constructor(fileManager: FileManager, apiManager: ApiRouter) {
+    this.fileManager = fileManager;
+    this.apiManager = apiManager;
+    this.cacheManager = new PopularHighlightsCacheManager();
+  }
+```
+
+- [ ] **Step 2: 添加获取热门划线的方法**
+
+在 `SyncNotebooks` 类中添加新方法（放在 `convertToNotebook` 方法之前）：
+
+```typescript
+/**
+ * 获取热门划线（支持缓存）
+ */
+private async getPopularHighlights(
+  bookId: string,
+  chapters: { chapterUid: number; chapterIdx: number; title: string }[]
+): Promise<PopularChapterHighlight[]> {
+  // 1. 尝试从缓存获取
+  const cached = await this.cacheManager.get(bookId);
+  if (cached) {
+    return this.groupPopularByChapter(cached.items, cached.chapters);
+  }
+
+  // 2. 缓存未命中，并发获取热门划线
+  const chapterUids = chapters.map((c) => c.chapterUid);
+  const popularByChapter = await this.apiManager.getBestBookmarksBatch(bookId, chapterUids, 5);
+
+  // 3. 转换为数组格式
+  const items: { bookmarkId: string; chapterUid: number; chapterTitle: string; range: string; markText: string; totalCount: number }[] = [];
+  const chapterMap = new Map(chapters.map((c) => [c.chapterUid, c]));
+  
+  for (const [chapterUid, highlights] of popularByChapter) {
+    const chapterInfo = chapterMap.get(chapterUid);
+    for (const h of highlights) {
+      items.push({
+        bookmarkId: h.bookmarkId,
+        chapterUid,
+        chapterTitle: chapterInfo?.title ?? '',
+        range: h.range,
+        markText: h.markText,
+        totalCount: h.totalCount
+      });
+    }
+  }
+
+  // 4. 写入缓存
+  await this.cacheManager.set(bookId, items, chapters);
+
+  // 5. 按章节分组返回
+  return this.groupPopularByChapter(items, chapters);
+}
+
+/**
+ * 按章节分组热门划线
+ */
+private groupPopularByChapter(
+  items: { chapterUid: number; chapterTitle: string; range: string; markText: string; totalCount: number; bookmarkId: string }[],
+  chapters: { chapterUid: number; chapterIdx: number; title: string }[]
+): PopularChapterHighlight[] {
+  const chapterMap = new Map(chapters.map((c) => [c.chapterUid, c]));
+  const grouped = new Map<number, { chapterUid: number; chapterIdx: number; chapterTitle: string; highlights: PopularHighlight[] }>();
+
+  for (const item of items) {
+    if (!grouped.has(item.chapterUid)) {
+      const chapterInfo = chapterMap.get(item.chapterUid);
+      grouped.set(item.chapterUid, {
+        chapterUid: item.chapterUid,
+        chapterIdx: chapterInfo?.chapterIdx ?? 0,
+        chapterTitle: chapterInfo?.title ?? item.chapterTitle,
+        highlights: []
+      });
+    }
+    grouped.get(item.chapterUid).highlights.push({
+      bookmarkId: item.bookmarkId,
+      chapterUid: item.chapterUid,
+      chapterTitle: item.chapterTitle,
+      range: item.range,
+      markText: item.markText,
+      totalCount: item.totalCount
+    });
+  }
+
+  return Array.from(grouped.values());
+}
+```
+
+- [ ] **Step 3: 修改 convertToNotebook 方法**
+
+找到 `convertToNotebook` 方法中处理热门划线的部分（约在第 210-264 行），替换为：
+
+```typescript
+const bookReview = parseChapterReviews(reviewResp);
+
+let popularHighlights: PopularChapterHighlight[] = [];
+
+if (get(settingsStore).syncPopularHighlightsToggle) {
+  // 获取章节信息用于缓存
+  const chaptersInfo = chapters.map((c) => ({
+    chapterUid: c.chapterUid ?? 0,
+    chapterIdx: c.chapterIdx ?? 0,
+    title: c.title
+  }));
+
+  // 获取热门划线（缓存优先）
+  popularHighlights = await this.getPopularHighlights(metaData.bookId, chaptersInfo);
+
+  // 获取当前激活主题
+  const activeTheme = get(settingsStore).themes?.find(
+    (t) => t.id === get(settingsStore).activeThemeId
+  );
+
+  // 判断是否为分离式主题（包含 popular 的分离主题）
+  const isSeparatedWithPopularTheme = activeTheme?.id === 'builtin_separated_with_popular';
+
+  if (isSeparatedWithPopularTheme) {
+    // 分离模式：热门划线单独处理，不合并到 chapterHighlights
+    // 标记用户划线中的热门（用于展示区分）
+    for (const chapter of chapterHighlightReview) {
+      if (chapter.highlights) {
+        for (const h of chapter.highlights) {
+          // 查找对应的热门划线
+          const popularChapter = popularHighlights.find((p) => p.chapterUid === chapter.chapterUid);
+          if (popularChapter) {
+            const match = popularChapter.highlights.find((p) => p.range === h.range);
+            if (match) {
+              h.isPopular = true;
+              h.popularCount = match.totalCount;
+            }
+          }
+        }
+      }
+    }
+  } else {
+    // 合并模式：热门划线合并到章节划线中
+    const popularByChapter = new Map<number, typeof popularHighlights[0]['highlights'][0][]>();
+    for (const chapter of popularHighlights) {
+      popularByChapter.set(chapter.chapterUid, chapter.highlights);
+    }
+
+    for (const chapter of chapterHighlightReview) {
+      const chapterPopular = popularByChapter.get(chapter.chapterUid ?? 0) ?? [];
+      if (chapterPopular.length === 0) continue;
+
+      const existingHighlights = chapter.highlights ?? [];
+      const userRangeSet = new Set(existingHighlights.map((h) => h.range));
+
+      // 已有划线与热门重叠：标记为热门并加人数
+      for (const h of existingHighlights) {
+        const match = chapterPopular.find((p) => p.range === h.range);
+        if (match) {
+          h.isPopular = true;
+          h.popularCount = match.totalCount;
+        }
+      }
+
+      // 热门划线中用户未标注的：追加为新 Highlight
+      for (const p of chapterPopular) {
+        if (!userRangeSet.has(p.range)) {
+          existingHighlights.push({
+            bookmarkId: p.bookmarkId,
+            created: 0,
+            createTime: '',
+            chapterUid: chapter.chapterUid ?? 0,
+            chapterIdx: chapter.chapterIdx ?? 0,
+            chapterTitle: chapter.chapterTitle,
+            markText: p.markText,
+            style: 0,
+            colorStyle: 0,
+            range: p.range,
+            isPopular: true,
+            popularCount: p.totalCount,
+            isUserHighlight: false
+          });
+        }
+      }
+
+      // 标记所有用户划线
+      for (const h of existingHighlights) {
+        if (!h.isUserHighlight) {
+          h.isUserHighlight = true;
+        }
+      }
+
+      // 按 range 起始位置重新排序
+      chapter.highlights = existingHighlights.sort((a, b) => {
+        return (parseInt(a.range.split('-')[0]) || 0) - (parseInt(b.range.split('-')[0]) || 0);
+      });
+    }
+  }
+}
+
+return {
+  metaData: metaData,
+  chapterHighlights: chapterHighlightReview,
+  bookReview: bookReview,
+  popularHighlights: popularHighlights
+};
+```
+
+- [ ] **Step 4: 提交代码**
+
+```bash
+git add src/syncNotebooks.ts
+git commit -m "feat: 集成缓存和并发查询到热门划线同步
+
+- 添加 PopularHighlightsCacheManager 实例
+- 新增 getPopularHighlights 方法（支持缓存）
+- 新增 groupPopularByChapter 方法
+- convertToNotebook 支持分离/合并两种模式
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: 更新设置页面
+
+**Files:**
+- Modify: `src/settingTab.ts` (添加缓存 TTL 配置项)
+
+- [ ] **Step 1: 找到热门划线设置项的位置**
+
+读取 `src/settingTab.ts`，找到 `syncPopularHighlightsToggle` 相关的设置项。
+
+- [ ] **Step 2: 在热门划线开关后添加缓存 TTL 配置**
+
+找到设置项的 container 或 section，在 `new Toggle(...)` 后添加：
+
+```typescript
+// 缓存 TTL 设置
+const cacheTtlContainer = container.createDiv('setting-item');
+cacheTtlContainer.createEl('text', { text: '热门划线缓存有效期（天）', cls: 'setting-item-name' });
+const cacheTtlInput = cacheTtlContainer.createEl('input', {
+  cls: 'setting-input',
+  attr: { type: 'number', min: '1', max: '365' }
+});
+cacheTtlInput.value = String(get(settingsStore).popularHighlightsCacheTtl ?? 7);
+cacheTtlInput.onChange = (value: string) => {
+  const num = parseInt(value) || 7;
+  settingsStore.actions.setPopularHighlightsCacheTtl(num);
+};
+```
+
+注意：具体实现需根据 settingTab.ts 的现有结构调整。
+
+- [ ] **Step 3: 提交代码**
+
+```bash
+git add src/settingTab.ts
+git commit -m "feat: 添加热门划线缓存 TTL 配置项
+
+- 在设置页面热门划线开关后添加缓存有效期配置
+- 支持 1-365 天范围
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: 验证和测试
+
+- [ ] **Step 1: 运行构建检查**
+
+```bash
+npm run build
+```
+
+确保没有 TypeScript 编译错误。
+
+- [ ] **Step 2: 运行 lint 检查**
+
+```bash
+npm run lint
+```
+
+确保没有 lint 错误。
+
+- [ ] **Step 3: 手动测试场景**
+
+1. 启用热门划线同步开关
+2. 选择"分离式（含热门划线）"模板
+3. 同步一本书
+4. 检查生成的笔记：
+   - 我的划线部分显示用户的划线
+   - 热门划线部分显示热门划线（带 🔥 标记）
+   - 两者按章节分组正确
+
+5. 切换到"合并式"模板
+6. 再次同步同一本书
+7. 检查：
+   - 用户划线和热门划线合并展示
+   - 热门划线标记 🔥 和人数
+
+8. 检查缓存文件：
+   - 确认 `.weread-cache/popular-{bookId}.json` 存在
+
+- [ ] **Step 4: 提交测试代码变更**
+
+```bash
+git add -A
+git commit -m "test: 热门划线同步功能测试
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## 依赖关系
+
+```
+Task 1 (缓存类) → Task 2 (设置项) → Task 3 (API) → Task 4 (模板) → Task 5 (模型) → Task 6 (集成) → Task 7 (UI) → Task 8 (测试)
+```
+
+---
+
+## 总结
+
+| Task | 描述 | 变更类型 |
+|------|------|----------|
+| 1 | 缓存管理类 | 新增 |
+| 2 | 缓存 TTL 设置项 | 修改 |
+| 3 | 按章节批量查询 API | 修改 |
+| 4 | 分离式模板 | 新增 |
+| 5 | 模型类型扩展 | 修改 |
+| 6 | 集成缓存和并发查询 | 修改 |
+| 7 | 设置页面 | 修改 |
+| 8 | 验证测试 | - |

--- a/docs/superpowers/specs/2026-06-01-popular-highlights-design.md
+++ b/docs/superpowers/specs/2026-06-01-popular-highlights-design.md
@@ -1,0 +1,315 @@
+# 热门划线同步功能设计
+
+**创建时间**: 2026-06-01
+**状态**: 已确认
+
+---
+
+## 1. 概述
+
+实现热门划线同步功能，支持按章节并发查询、本地文件缓存、以及分离式模板展示。
+
+---
+
+## 2. 功能需求
+
+| 需求 | 说明 |
+|------|------|
+| 开关控制 | 根据 `syncPopularHighlightsToggle` 设置判断是否同步热门划线 |
+| 缓存机制 | 本地文件缓存（`.weread-cache/`），默认有效期 7 天 |
+| 并发查询 | 每批 5 个章节并发请求，失败重试 1 次 |
+| 合并模式 | 热门划线合并入章节划线，按位置排序，重复时去重 |
+| 分离模式 | 热门划线独立展示，不合并到用户划线中 |
+
+---
+
+## 3. 架构设计
+
+### 3.1 组件结构
+
+```
+src/
+├── popularHighlightsCache.ts   # 新增：热门划线缓存管理
+├── api-router.ts               # 修改：添加热门划线按章节查询
+└── syncNotebooks.ts            # 修改：集成缓存和并发查询
+
+.weread-cache/                  # 新增：缓存目录
+├── popular-{bookId}.json       # 单本书热门划线缓存
+└── cache-manifest.json          # 缓存索引（可选）
+```
+
+### 3.2 缓存数据结构
+
+**文件**: `src/popularHighlightsCache.ts`
+
+```typescript
+export interface PopularHighlightCache {
+  bookId: string;
+  cachedAt: number;      // 缓存时间戳（毫秒）
+  ttl: number;           // 有效期（天）
+  items: PopularHighlight[];
+  chapters: {
+    bookId: string;
+    chapterUid: number;
+    chapterIdx: number;
+    title: string;
+  }[];
+}
+```
+
+**缓存文件格式**: `JSON`
+
+```json
+{
+  "bookId": "123456",
+  "cachedAt": 1717200000000,
+  "ttl": 7,
+  "items": [...],
+  "chapters": [...]
+}
+```
+
+---
+
+## 4. 缓存策略
+
+### 4.1 缓存读写流程
+
+```
+读取缓存:
+1. 检查缓存文件是否存在 (.weread-cache/popular-{bookId}.json)
+2. 检查缓存是否过期 (cachedAt + ttl*86400000 > now)
+3. 未过期 → 返回缓存数据
+4. 已过期或不存在 → 重新获取
+
+写入缓存:
+1. 热门划线数据获取成功后
+2. 写入 .weread-cache/popular-{bookId}.json
+3. 包含缓存时间戳和 TTL
+```
+
+### 4.2 缓存配置
+
+在 `settings.ts` 中新增：
+
+```typescript
+popularHighlightsCacheTtl: number;  // 缓存有效期(天)，默认 7
+```
+
+---
+
+## 5. 并发查询策略
+
+### 5.1 查询流程
+
+```
+1. 获取书籍章节列表（来自 chapterResp）
+2. 将章节按每批 5 个分组
+3. 对每批章节并发调用 getBestBookmarks
+4. 合并所有结果，按 chapterUid 分组
+5. 写入缓存
+```
+
+### 5.2 重试机制
+
+- 单章节请求失败时，重试 1 次
+- 重试仍失败则跳过该章节（不影响其他章节）
+- 使用 `Promise.allSettled` 避免单个失败影响整体
+
+### 5.3 代码示例
+
+```typescript
+async fetchPopularHighlightsBatch(
+  bookId: string,
+  chapters: Chapter[],
+  batchSize = 5
+): Promise<Map<number, PopularHighlight[]>> {
+  const results = new Map<number, PopularHighlight[]>();
+
+  for (let i = 0; i < chapters.length; i += batchSize) {
+    const batch = chapters.slice(i, i + batchSize);
+    const promises = batch.map(async (chapter) => {
+      const resp = await this.getBestBookmarks(bookId, chapter.chapterUid);
+      return { chapterUid: chapter.chapterUid, items: resp?.items ?? [] };
+    });
+
+    const settled = await Promise.allSettled(promises);
+    for (const result of settled) {
+      if (result.status === 'fulfilled') {
+        results.set(result.value.chapterUid, result.value.items);
+      }
+    }
+  }
+
+  return results;
+}
+```
+
+---
+
+## 6. 数据模型变更
+
+### 6.1 models.ts 扩展
+
+```typescript
+// 新增类型
+export type PopularHighlightCache = {
+  bookId: string;
+  cachedAt: number;
+  ttl: number;
+  items: PopularHighlight[];
+  chapters: PopularChapterHighlight['chapterUid'][];
+};
+
+// 修改 Highlight 类型
+export type Highlight = {
+  // ... 现有字段
+  isPopular?: boolean;        // 是否是热门划线（用户也有）
+  popularCount?: number;      // 热门人数
+  isUserHighlight?: boolean;  // 是否是用户自己的划线
+};
+```
+
+### 6.2 settings.ts 扩展
+
+```typescript
+// 新增设置项
+popularHighlightsCacheTtl: number;  // 默认 7 天
+
+// 操作方法
+setPopularHighlightsCacheTtl(value: number)
+```
+
+---
+
+## 7. 模板设计
+
+### 7.1 合并模式（已有逻辑增强）
+
+**文件**: `themes/notebookTemplate.njk`
+
+- 热门划线标记 `🔥` 和人数
+- 用户划线且是热门时同时展示标记
+
+```njk
+{% for highlight in chapter.highlights %}
+> 📌 {% if highlight.isPopular %}🔥 {{ highlight.popularCount }} {% endif %}
+   [{{ highlight.markText | trim }}]
+   {{ highlight.createTime }}
+{% endfor %}
+```
+
+### 7.2 分离模式（新增）
+
+**文件**: `themes/separatedWithPopularTemplate.njk`
+
+结构：
+```
+# 我的划线
+## 章节1
+  - 我的划线
+
+# 热门划线
+## 章节1
+  - 热门划线1 (🔥 999)
+  - 热门划线2
+
+# 我的笔记
+  ...
+```
+
+**模板变量**：
+```typescript
+type RenderTemplate = {
+  // ... 现有字段
+  userHighlights: ChapterHighlightReview[];      // 仅用户划线
+  popularHighlights: PopularChapterHighlight[];  // 热门划线
+};
+```
+
+---
+
+## 8. 同步流程变更
+
+### 8.1 convertToNotebook 流程
+
+```typescript
+private async convertToNotebook(metaData: Metadata): Promise<Notebook> {
+  // ... 现有逻辑（获取书籍信息、进度、划线、笔记）
+
+  // 新增：热门划线处理
+  if (get(settingsStore).syncPopularHighlightsToggle) {
+    const popularHighlights = await this.getPopularHighlights(metaData.bookId);
+    // 分离模式：设置 userHighlights 和 popularHighlights
+    // 合并模式：标记用户划线中的热门，并追加新的热门划线
+  }
+
+  return {
+    metaData,
+    chapterHighlights,
+    bookReview,
+    popularHighlights,  // 用于分离模式
+    userHighlights      // 仅分离模式使用
+  };
+}
+```
+
+### 8.2 getPopularHighlights 逻辑
+
+```typescript
+private async getPopularHighlights(bookId: string): Promise<PopularChapterHighlight[]> {
+  // 1. 检查缓存
+  const cache = await this.cacheManager.get(bookId);
+  if (cache && !this.isCacheExpired(cache)) {
+    return this.groupByChapter(cache.items, cache.chapters);
+  }
+
+  // 2. 获取章节信息
+  const chapters = await this.getChaptersInfo(bookId);
+
+  // 3. 并发获取热门划线
+  const popularByChapter = await this.fetchPopularHighlightsBatch(bookId, chapters);
+
+  // 4. 写入缓存
+  await this.cacheManager.set(bookId, popularByChapter, chapters);
+
+  // 5. 返回按章节分组的结果
+  return this.groupByChapter(popularByChapter, chapters);
+}
+```
+
+---
+
+## 9. 文件变更清单
+
+| 文件 | 变更类型 | 说明 |
+|------|----------|------|
+| `src/popularHighlightsCache.ts` | 新增 | 缓存管理类 |
+| `src/models.ts` | 修改 | 新增类型定义 |
+| `src/settings.ts` | 修改 | 新增缓存 TTL 设置项 |
+| `src/api-router.ts` | 修改 | 添加按章节查询方法 |
+| `src/syncNotebooks.ts` | 修改 | 集成缓存和并发查询 |
+| `src/renderer.ts` | 修改 | 扩展 RenderTemplate |
+| `src/themes/separatedWithPopularTemplate.njk` | 新增 | 分离式含热门划线模板 |
+| `src/settingTab.ts` | 修改 | 添加缓存 TTL 配置项 |
+| `src/main.ts` | 修改 | 注册缓存目录清理命令（可选） |
+
+---
+
+## 10. 风险与限制
+
+| 风险 | 缓解措施 |
+|------|----------|
+| 热门划线 API 限流 | 并发控制（每批5个）+ 缓存复用 |
+| 缓存文件过多 | 单书一个文件，定期清理过期缓存 |
+| 用户禁用热门划线后缓存仍存在 | 保留缓存，下次启用时直接使用 |
+| 缓存数据与实际不符 | 缓存过期后自动刷新 |
+
+---
+
+## 11. 配置项
+
+| 配置项 | 类型 | 默认值 | 说明 |
+|--------|------|--------|------|
+| `syncPopularHighlightsToggle` | boolean | false | 是否同步热门划线 |
+| `popularHighlightsCacheTtl` | number | 7 | 缓存有效期（天） |

--- a/docs/weread-agent-api.md
+++ b/docs/weread-agent-api.md
@@ -2,6 +2,64 @@
 
 通过统一网关调用微信读书接口，支持搜索、书架、笔记、书评、阅读统计等能力。
 
+## V1 vs V2 对比
+
+V1（Cookie 认证）和 V2（Agent Gateway — Bearer Token）接口对照表：
+
+| 功能 | V1 | V2 | 变化 |
+|------|:--:|:--:|------|
+| 笔记本列表 | `GET /api/user/notebook` | `/user/notebooks` | V2 游标分页 (`count`+`lastSort`)，V1 一次返回全部 |
+| 书籍详情 | `GET /web/book/info?bookId=` | `/book/info` | 字段基本一致 |
+| 划线列表 | `GET /web/book/bookmarklist?bookId=` | `/book/bookmarklist` | 字段基本一致 |
+| 个人想法/点评 | `GET /web/review/list?bookId=&listType=11&mine=1` | `/review/list/mine` | 参数名变化，`bookid`（小写） |
+| 章节目录 | `POST /web/book/chapterInfos` | `/book/chapterinfo` | V1 POST body 传数组，V2 只传单个 bookId |
+| 阅读进度 | `GET /web/book/getProgress?bookId=` | `/book/getprogress` | 字段基本一致 |
+| 阅读统计 | V1 通过 `/api/agent/gateway` | `/readdata/detail` | 同样走 Gateway，参数相同 |
+| 书架同步 | ❌ | `/shelf/sync` | **V2 新增** |
+| 用户信息 | `GET /web/user?userVid=` | ❌ **不存在** | V1 需要 `userVid`（来自 Cookie），V2 无此端点 |
+| 获取 API Key | `GET /api/skills/apikeyGet` | ❌ | V1 专有，扫码登录后自动获取 |
+| Cookie 刷新 | `HEAD /` + set-cookie | ❌ | V1 专有 |
+| 个性推荐 | ❌ | `/book/recommend` | **V2 新增** |
+| 相似推荐 | ❌ | `/book/similar` | **V2 新增** |
+| 章节划线热度 | ❌ | `/book/underlines` | **V2 新增**（不含原文，仅人数/得分） |
+| 热门划线 | ❌ | `/book/bestbookmarks` | **V2 新增**（TOP20，含原文+人数） |
+| 划线下想法 | ❌ | `/book/readreviews` | **V2 新增** |
+| 单条想法详情 | ❌ | `/review/single` | **V2 新增** |
+| 公开点评 | ❌ | `/review/list` | **V2 新增** |
+| 搜索 | ❌ | `/store/search` | **V2 新增** |
+
+### 关键差异
+
+1. **认证方式**：V1 使用 Cookie（`wr_skey` + `wr_vid`），V2 使用 `Authorization: Bearer <API_KEY>`，API Key 通过 `GET /api/skills/apikeyGet` 获取
+2. **入口统一**：V1 各接口分布在不同路径（`/web/`、`/api/`、`i.weread.qq.com`），V2 全部通过 `POST /api/agent/gateway` + `api_name` 字段路由
+3. **参数平铺**：V2 所有业务参数和 `api_name`、`skill_version` 平铺在 JSON body 顶层，**不要**嵌套在 `params` 里
+4. **用户身份**：V2 的 API Key 绑定用户 vid，用户相关接口自动注入身份，无需手动传 `userVid`
+5. **V2 缺失接口**：V2 没有 `/user/info` 端点，无法通过 Bearer Token 直接查询用户信息（昵称、头像、签名等）。V1 虽有 `/web/user?userVid=` 但需要 Cookie 中的 `userVid`
+
+### V2 可用接口全览
+
+发送 `{"api_name": "/_list"}` 可获取所有可用接口及参数定义。当前可用接口共 18 个：
+
+| 分类 | api_name | 说明 |
+|------|----------|------|
+| 系统 | `/_list` | 列出所有可用接口 |
+| 搜索 | `/store/search` | 书城搜索（书籍、作者、有声书等） |
+| 书架 | `/shelf/sync` | 获取完整书架（含有声书、书单） |
+| 书籍 | `/book/info` | 书籍基本信息 |
+| 书籍 | `/book/chapterinfo` | 章节目录 |
+| 书籍 | `/book/getprogress` | 阅读进度 |
+| 笔记 | `/user/notebooks` | 笔记本概览（所有有笔记的书） |
+| 笔记 | `/book/bookmarklist` | 单本书划线内容列表 |
+| 笔记 | `/review/list/mine` | 单本书个人想法与点评 |
+| 笔记 | `/book/bestbookmarks` | 书籍热门划线 TOP20 |
+| 笔记 | `/book/underlines` | 章节划线热度统计 |
+| 笔记 | `/book/readreviews` | 划线下的公众想法/评论 |
+| 笔记 | `/review/single` | 单条想法详情 |
+| 书评 | `/review/list` | 书籍公开点评 |
+| 统计 | `/readdata/detail` | 阅读统计（时长/天数/偏好分析） |
+| 推荐 | `/book/recommend` | 个性化推荐 |
+| 推荐 | `/book/similar` | 相似书推荐 |
+
 ## 基础信息
 
 | 项目 | 值 |

--- a/main.ts
+++ b/main.ts
@@ -128,7 +128,7 @@ export default class WereadPlugin extends Plugin {
 		);
 		this.registerView(
 			WEREAD_BOOK_DETAIL_VIEW_ID,
-			(leaf) => new WereadBookDetailView(leaf, apiRouter)
+			(leaf) => new WereadBookDetailView(leaf, apiRouter, this)
 		);
 
 		this.addCommand({

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { Menu, Notice, Platform, Plugin, TFile, WorkspaceLeaf } from 'obsidian';
+import { Menu, Notice, Platform, Plugin, setIcon, TFile, WorkspaceLeaf } from 'obsidian';
 import FileManager from './src/fileManager';
 import SyncNotebooks from './src/syncNotebooks';
 import ApiRouter from './src/api-router';
@@ -12,6 +12,7 @@ import WereadBrowserWindow from './src/components/wereadBrowserWindow';
 import { WEREAD_BROWSER_VIEW_ID, WereadReadingView } from './src/components/wereadReading';
 import { WEREAD_BOOKSHELF_VIEW_ID, WereadBookshelfView } from './src/components/wereadBookshelf';
 import { WEREAD_READING_STATS_VIEW_ID, WereadReadingStatsView } from './src/components/wereadReadingStats';
+import { WEREAD_BOOK_DETAIL_VIEW_ID, WereadBookDetailView } from './src/components/wereadBookDetailView';
 import './style.css';
 export default class WereadPlugin extends Plugin {
 	private syncNotebooks: SyncNotebooks;
@@ -125,6 +126,10 @@ export default class WereadPlugin extends Plugin {
 			WEREAD_READING_STATS_VIEW_ID,
 			(leaf) => new WereadReadingStatsView(leaf, apiRouter, fileManager)
 		);
+		this.registerView(
+			WEREAD_BOOK_DETAIL_VIEW_ID,
+			(leaf) => new WereadBookDetailView(leaf, apiRouter)
+		);
 
 		this.addCommand({
 			id: 'open-weread-reading-view-tab',
@@ -180,6 +185,7 @@ export default class WereadPlugin extends Plugin {
 		this.wereadSettingsTab = new WereadSettingsTab(this.app, this);
 		this.addSettingTab(this.wereadSettingsTab);
 
+		this.setupFloatingPanel();
 		this.setupScheduledSync();
 	}
 
@@ -323,6 +329,27 @@ export default class WereadPlugin extends Plugin {
 		workspace.revealLeaf(leaf);
 	}
 
+	async activateBookDetailView(bookId: string, bookTitle?: string, bookCover?: string, localFilePath?: string) {
+		const { workspace } = this.app;
+		const leaves = workspace.getLeavesOfType(WEREAD_BOOK_DETAIL_VIEW_ID);
+
+		let leaf: WorkspaceLeaf | null = null;
+		if (leaves.length > 0) {
+			leaf = leaves[0];
+		} else {
+			leaf = workspace.getLeaf('tab');
+		}
+
+		if (leaf) {
+			await leaf.setViewState({
+				type: WEREAD_BOOK_DETAIL_VIEW_ID,
+				active: true,
+				state: { bookId, bookTitle, bookCover, localFilePath }
+			});
+			workspace.revealLeaf(leaf);
+		}
+	}
+
 	private async syncCookiesToPartition(): Promise<void> {
 		if (!Platform.isDesktopApp) {
 			return;
@@ -369,6 +396,57 @@ export default class WereadPlugin extends Plugin {
 		} catch (e) {
 			console.error('[weread plugin] startup cookie sync failed', e);
 		}
+	}
+
+	private setupFloatingPanel(): void {
+		const fileManager = this.fileManager;
+		let currentBtn: HTMLElement | null = null;
+		let currentBookId: string | null = null;
+
+		const removeBtn = () => {
+			currentBtn?.remove();
+			currentBtn = null;
+			currentBookId = null;
+		};
+
+		this.registerEvent(
+			this.app.workspace.on('active-leaf-change', (leaf) => {
+				const view = leaf?.view;
+				const file = (view as any)?.file as TFile | undefined;
+				if (!(file instanceof TFile)) {
+					removeBtn();
+					return;
+				}
+
+				const annotation = fileManager.getWereadNoteAnnotationFile(file);
+				if (!annotation?.bookId) {
+					removeBtn();
+					return;
+				}
+
+				if (currentBookId === annotation.bookId) return;
+
+				removeBtn();
+				currentBookId = annotation.bookId;
+
+				const viewContentEl = (view as any).contentEl as HTMLElement | undefined;
+				if (!viewContentEl) return;
+
+				viewContentEl.style.position = 'relative';
+				const btn = viewContentEl.createDiv({ cls: 'weread-floating-btn' });
+				setIcon(btn, 'book-open');
+				btn.setAttr('title', '查看微信读书详情');
+				btn.addEventListener('click', () => {
+					this.activateBookDetailView(
+						annotation.bookId,
+						annotation.title || '',
+						annotation.cover || '',
+						file.path
+					);
+				});
+				currentBtn = btn;
+			})
+		);
 	}
 
 	onunload() {

--- a/main.ts
+++ b/main.ts
@@ -329,16 +329,22 @@ export default class WereadPlugin extends Plugin {
 		workspace.revealLeaf(leaf);
 	}
 
-	async activateBookDetailView(bookId: string, bookTitle?: string, bookCover?: string, localFilePath?: string) {
+	async activateBookDetailView(bookId: string, bookTitle?: string, bookCover?: string, localFilePath?: string, replaceCurrentLeaf = false) {
 		const { workspace } = this.app;
 
-		// 优先复用已有 detail leaf，否则新建一个 tab，不覆盖 sourceLeaf
 		let leaf: WorkspaceLeaf | null = null;
-		const existingLeaves = workspace.getLeavesOfType(WEREAD_BOOK_DETAIL_VIEW_ID);
-		if (existingLeaves.length > 0) {
-			leaf = existingLeaves[0];
+
+		if (replaceCurrentLeaf) {
+			// 使用 getLeaf(false) 获取当前活跃的 leaf，不创建新 leaf
+			leaf = workspace.getLeaf(false);
 		} else {
-			leaf = workspace.getLeaf('tab');
+			// 原有逻辑：优先复用已有 detail leaf，否则新建一个 tab
+			const existingLeaves = workspace.getLeavesOfType(WEREAD_BOOK_DETAIL_VIEW_ID);
+			if (existingLeaves.length > 0) {
+				leaf = existingLeaves[0];
+			} else {
+				leaf = workspace.getLeaf('tab');
+			}
 		}
 
 		if (leaf) {
@@ -436,13 +442,14 @@ export default class WereadPlugin extends Plugin {
 				viewContentEl.style.position = 'relative';
 				const btn = viewContentEl.createDiv({ cls: 'weread-floating-btn' });
 				setIcon(btn, 'book-open');
-				btn.setAttr('title', '查看微信读书详情');
+				btn.setAttr('aria-label', '查看微信读书详情');
 				btn.addEventListener('click', () => {
 					this.activateBookDetailView(
 						annotation.bookId,
 						annotation.title || '',
 						annotation.cover || '',
-						file.path
+						file.path,
+						true // 在当前标签页打开，替换当前内容
 					);
 				});
 				currentBtn = btn;

--- a/main.ts
+++ b/main.ts
@@ -1,7 +1,7 @@
 import { Menu, Notice, Platform, Plugin, TFile, WorkspaceLeaf } from 'obsidian';
 import FileManager from './src/fileManager';
 import SyncNotebooks from './src/syncNotebooks';
-import ApiManager from './src/api';
+import ApiRouter from './src/api-router';
 import WereadBookshelfService from './src/bookshelf';
 import SyncReadingStats from './src/syncReadingStats';
 import { settingsStore } from './src/settings';
@@ -20,7 +20,6 @@ export default class WereadPlugin extends Plugin {
 	private syncReadingStats: SyncReadingStats;
 	private wereadSettingsTab!: WereadSettingsTab;
 	private syncing = false;
-	private cookieRefreshTimer: number | null = null;
 	private scheduledSyncTimer: number | null = null;
 
 	onload() {
@@ -33,16 +32,16 @@ export default class WereadPlugin extends Plugin {
 	private initializePlugin() {
 		const fileManager = new FileManager(this.app.vault, this.app.metadataCache, this.app);
 		this.fileManager = fileManager;
-		const apiManager = new ApiManager();
-		this.syncNotebooks = new SyncNotebooks(fileManager, apiManager);
-		this.bookshelfService = new WereadBookshelfService(fileManager, apiManager);
-		this.syncReadingStats = new SyncReadingStats(this.app.vault, apiManager);
+		const apiRouter = new ApiRouter();
+		this.syncNotebooks = new SyncNotebooks(fileManager, apiRouter);
+		this.bookshelfService = new WereadBookshelfService(fileManager, apiRouter);
+		this.syncReadingStats = new SyncReadingStats(this.app.vault, apiRouter);
 
 		// 初始化时验证 Cookie 有效性
 		const settings = get(settingsStore);
 		if (settings.cookies && settings.cookies.length > 0) {
 			console.log('[weread plugin] 初始化时检验 Cookie 有效性');
-			apiManager.verifyCookieValidity().catch((e) => {
+			apiRouter.verifyCookieValidity().catch((e) => {
 				console.error('[weread plugin] 初始化 Cookie 验证失败', e);
 			});
 		}
@@ -124,7 +123,7 @@ export default class WereadPlugin extends Plugin {
 		);
 		this.registerView(
 			WEREAD_READING_STATS_VIEW_ID,
-			(leaf) => new WereadReadingStatsView(leaf, apiManager, fileManager)
+			(leaf) => new WereadReadingStatsView(leaf, apiRouter, fileManager)
 		);
 
 		this.addCommand({
@@ -181,7 +180,6 @@ export default class WereadPlugin extends Plugin {
 		this.wereadSettingsTab = new WereadSettingsTab(this.app, this);
 		this.addSettingTab(this.wereadSettingsTab);
 
-		this.setupCookieRefresh();
 		this.setupScheduledSync();
 	}
 
@@ -375,34 +373,10 @@ export default class WereadPlugin extends Plugin {
 
 	onunload() {
 		console.log('unloading weread plugin', new Date().toLocaleString());
-		this.clearCookieRefreshTimer();
 		this.clearScheduledSyncTimer();
 	}
 
-	setupCookieRefresh() {
-		this.clearCookieRefreshTimer();
-		const { cookieAutoRefreshToggle, cookieRefreshInterval } = get(settingsStore);
-		if (!cookieAutoRefreshToggle) {
-			return;
-		}
-		const apiManager = new ApiManager();
-		apiManager
-			.refreshCookie()
-			.catch((e) => console.error('[weread plugin] 刷新 Cookie 失败', e));
-		const intervalMs = Math.max(1, cookieRefreshInterval) * 60 * 60 * 1000;
-		this.cookieRefreshTimer = window.setInterval(() => {
-			apiManager
-				.refreshCookie()
-				.catch((e) => console.error('[weread plugin] 定时刷新 Cookie 失败', e));
-		}, intervalMs);
-	}
 
-	private clearCookieRefreshTimer() {
-		if (this.cookieRefreshTimer !== null) {
-			window.clearInterval(this.cookieRefreshTimer);
-			this.cookieRefreshTimer = null;
-		}
-	}
 
 	setupScheduledSync() {
 		this.clearScheduledSyncTimer();

--- a/main.ts
+++ b/main.ts
@@ -329,13 +329,15 @@ export default class WereadPlugin extends Plugin {
 		workspace.revealLeaf(leaf);
 	}
 
-	async activateBookDetailView(bookId: string, bookTitle?: string, bookCover?: string, localFilePath?: string) {
+	async activateBookDetailView(bookId: string, bookTitle?: string, bookCover?: string, localFilePath?: string, sourceLeaf?: WorkspaceLeaf) {
 		const { workspace } = this.app;
 		const leaves = workspace.getLeavesOfType(WEREAD_BOOK_DETAIL_VIEW_ID);
 
 		let leaf: WorkspaceLeaf | null = null;
 		if (leaves.length > 0) {
 			leaf = leaves[0];
+		} else if (sourceLeaf) {
+			leaf = sourceLeaf;
 		} else {
 			leaf = workspace.getLeaf('tab');
 		}
@@ -441,7 +443,8 @@ export default class WereadPlugin extends Plugin {
 						annotation.bookId,
 						annotation.title || '',
 						annotation.cover || '',
-						file.path
+						file.path,
+						leaf
 					);
 				});
 				currentBtn = btn;

--- a/main.ts
+++ b/main.ts
@@ -329,15 +329,14 @@ export default class WereadPlugin extends Plugin {
 		workspace.revealLeaf(leaf);
 	}
 
-	async activateBookDetailView(bookId: string, bookTitle?: string, bookCover?: string, localFilePath?: string, sourceLeaf?: WorkspaceLeaf) {
+	async activateBookDetailView(bookId: string, bookTitle?: string, bookCover?: string, localFilePath?: string) {
 		const { workspace } = this.app;
-		const leaves = workspace.getLeavesOfType(WEREAD_BOOK_DETAIL_VIEW_ID);
 
+		// 优先复用已有 detail leaf，否则新建一个 tab，不覆盖 sourceLeaf
 		let leaf: WorkspaceLeaf | null = null;
-		if (leaves.length > 0) {
-			leaf = leaves[0];
-		} else if (sourceLeaf) {
-			leaf = sourceLeaf;
+		const existingLeaves = workspace.getLeavesOfType(WEREAD_BOOK_DETAIL_VIEW_ID);
+		if (existingLeaves.length > 0) {
+			leaf = existingLeaves[0];
 		} else {
 			leaf = workspace.getLeaf('tab');
 		}
@@ -443,8 +442,7 @@ export default class WereadPlugin extends Plugin {
 						annotation.bookId,
 						annotation.title || '',
 						annotation.cover || '',
-						file.path,
-						leaf
+						file.path
 					);
 				});
 				currentBtn = btn;

--- a/main.ts
+++ b/main.ts
@@ -34,7 +34,7 @@ export default class WereadPlugin extends Plugin {
 		const fileManager = new FileManager(this.app.vault, this.app.metadataCache, this.app);
 		this.fileManager = fileManager;
 		const apiRouter = new ApiRouter();
-		this.syncNotebooks = new SyncNotebooks(fileManager, apiRouter);
+		this.syncNotebooks = new SyncNotebooks(fileManager, apiRouter, this.app.vault);
 		this.bookshelfService = new WereadBookshelfService(fileManager, apiRouter);
 		this.syncReadingStats = new SyncReadingStats(this.app.vault, apiRouter);
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
 	"id": "obsidian-weread-plugin",
 	"name": "Weread",
-	"version": "1.7.0",
-	"minAppVersion": "0.12.0",
+	"version": "2.0.0",
+	"minAppVersion": "0.14.0",
 	"description": "Sync Tencent Weread highlights and annotations.",
 	"author": "hankzhao",
 	"requestUrl": true,

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-weread-plugin",
 	"name": "Weread",
-	"version": "1.6.0",
+	"version": "1.7.0",
 	"minAppVersion": "0.12.0",
 	"description": "Sync Tencent Weread highlights and annotations.",
 	"author": "hankzhao",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-weread-plugin",
-	"version": "1.5.5",
+	"version": "1.7.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-weread-plugin",
-			"version": "1.5.5",
+			"version": "1.7.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/crypto-js": "^4.1.2",
@@ -4180,7 +4180,7 @@
 		},
 		"node_modules/html-to-image": {
 			"version": "1.11.13",
-			"resolved": "https://registry.npmmirror.com/html-to-image/-/html-to-image-1.11.13.tgz",
+			"resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/html-to-image/-/html-to-image-1.11.13.tgz",
 			"integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-weread-plugin",
-	"version": "1.6.0",
+	"version": "1.7.0",
 	"description": "This is a community plugin for tencent weread (https://r.qq.com)",
 	"main": "main.ts",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-weread-plugin",
-	"version": "1.7.0",
+	"version": "2.0.0",
 	"description": "This is a community plugin for tencent weread (https://r.qq.com)",
 	"main": "main.ts",
 	"scripts": {

--- a/scripts/test-api-v2-compiled.js
+++ b/scripts/test-api-v2-compiled.js
@@ -1,0 +1,23 @@
+const ApiV2Manager = require("../src/api-v2").default;
+
+async function testApiV2() {
+    const apiV2 = new ApiV2Manager();
+
+    try {
+        console.log("测试 getBook 接口...");
+        const book = await apiV2.getBook("T202107310023715");
+        console.log("书籍详情: ", JSON.stringify(book, null, 2));
+
+        console.log("测试 getNotebookHighlights 接口...");
+        const highlights = await apiV2.getNotebookHighlights("T202107310023715");
+        console.log("书籍高亮: ", JSON.stringify(highlights, null, 2));
+
+        console.log("测试 getProgress 接口...");
+        const progress = await apiV2.getProgress("T202107310023715");
+        console.log("阅读进度: ", JSON.stringify(progress, null, 2));
+    } catch (error) {
+        console.error("Api 测试失败: ", error);
+    }
+}
+
+testApiV2();

--- a/scripts/test-api-v2.js
+++ b/scripts/test-api-v2.js
@@ -1,0 +1,23 @@
+import ApiV2Manager from "../src/api-v2";
+
+async function testApiV2() {
+    const apiV2 = new ApiV2Manager();
+
+    try {
+        console.log("测试 getBook 接口...");
+        const book = await apiV2.getBook("T202107310023715"); // 示例书籍 ID
+        console.log("书籍详情: ", JSON.stringify(book, null, 2));
+
+        console.log("测试 getNotebookHighlights 接口...");
+        const highlights = await apiV2.getNotebookHighlights("T202107310023715");
+        console.log("书籍高亮: ", JSON.stringify(highlights, null, 2));
+
+        console.log("测试 getProgress 接口...");
+        const progress = await apiV2.getProgress("T202107310023715");
+        console.log("阅读进度: ", JSON.stringify(progress, null, 2));
+    } catch (error) {
+        console.error("Api 测试失败: ", error);
+    }
+}
+
+testApiV2();

--- a/scripts/test-api-v2.mjs
+++ b/scripts/test-api-v2.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// 独立测试 V2 Agent API — 直接 HTTP 调用，不依赖 Obsidian 运行时
+
+const API_KEY = process.env.WEREAD_API_KEY || 'wrk-jILv0YqITCGUbFoXeZhUpwAA';
+const GATEWAY = 'https://i.weread.qq.com/api/agent/gateway';
+
+async function callAgent(apiName, params = {}) {
+  const body = JSON.stringify({ api_name: apiName, skill_version: '1.0.3', ...params });
+  const res = await fetch(GATEWAY, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${API_KEY}`,
+    },
+    body,
+  });
+
+  if (!res.ok) {
+    console.error(`❌ HTTP ${res.status} ${res.statusText}`);
+    return undefined;
+  }
+
+  const data = await res.json();
+  if (data.errcode && data.errcode !== 0) {
+    console.error(`❌ API error: errcode=${data.errcode} errmsg=${data.errmsg}`);
+    return undefined;
+  }
+  return data;
+}
+
+async function runTests() {
+  console.log('═══════════════════════════════════════');
+  console.log('  V2 Agent API 测试');
+  console.log('═══════════════════════════════════════\n');
+
+  // 1. getNotebooks
+  console.log('── 1. /user/notebooks ──');
+  const notebooks = await callAgent('/user/notebooks');
+  let bookId = 'T202107310023715';
+  if (notebooks) {
+    console.log(`✅ totalBookCount: ${notebooks.totalBookCount}, totalNoteCount: ${notebooks.totalNoteCount}`);
+    const sample = notebooks.books?.[0];
+    if (sample) {
+      console.log(`   📖 第一本: 《${sample.book?.title}》 by ${sample.book?.author}`);
+      console.log(`   📝 noteCount: ${sample.noteCount}, reviewCount: ${sample.reviewCount}`);
+      bookId = sample.book?.bookId || bookId;
+    }
+  } else {
+    console.log('❌ 失败');
+  }
+  console.log();
+
+  console.log(`── 使用 bookId=${bookId} 测试后续接口 ──\n`);
+
+  // 2. getBook
+  console.log('── 2. /book/info ──');
+  const bookInfo = await callAgent('/book/info', { bookId });
+  if (bookInfo) {
+    console.log(`✅ 书名: 《${bookInfo.title}》 by ${bookInfo.author}`);
+    console.log(`   📂 category: ${bookInfo.category}`);
+    console.log(`   🏷️  publisher: ${bookInfo.publisher || '无'}`);
+    console.log(`   ⭐ rating: ${bookInfo.newRating / 10}%`);
+    console.log(`   📄 intro: ${bookInfo.intro?.slice(0, 80)}...`);
+  } else {
+    console.log('❌ 失败');
+  }
+  console.log();
+
+  // 3. getProgress
+  console.log('── 3. /book/getprogress ──');
+  const progress = await callAgent('/book/getprogress', { bookId });
+  if (progress?.book) {
+    console.log(`✅ progress: ${progress.book.progress}%`);
+    const rt = progress.book.readingTime || 0;
+    console.log(`   ⏱️  readingTime: ${rt}s (${Math.round(rt / 60)}min)`);
+    if (progress.book.finishTime) {
+      const fd = new Date(progress.book.finishTime * 1000).toISOString().slice(0, 10);
+      console.log(`   🏁 finished: ${fd}`);
+    }
+    if (progress.book.startReadingTime) {
+      const sd = new Date(progress.book.startReadingTime * 1000).toISOString().slice(0, 10);
+      console.log(`   📅 started: ${sd}`);
+    }
+  } else {
+    console.log('❌ 失败');
+  }
+  console.log();
+
+  // 4. getNotebookHighlights
+  console.log('── 4. /book/bookmarklist ──');
+  const highlights = await callAgent('/book/bookmarklist', { bookId });
+  if (highlights) {
+    const count = highlights.updated?.length || 0;
+    console.log(`✅ highlights: ${count} 条`);
+    if (count > 0) {
+      const h = highlights.updated[0];
+      console.log(`   📍 第一条: "${h.markText?.slice(0, 50)}..."`);
+      console.log(`   📍 chapterUid: ${h.chapterUid}, range: ${h.range}`);
+    }
+  } else {
+    console.log('❌ 失败');
+  }
+  console.log();
+
+  // 5. getChapters
+  console.log('── 5. /book/chapterinfo ──');
+  const chapters = await callAgent('/book/chapterinfo', { bookId });
+  if (chapters) {
+    const count = chapters.chapters?.length || 0;
+    console.log(`✅ chapters: ${count} 章`);
+    if (count > 0) {
+      console.log(`   📑 第一章: "${chapters.chapters[0]?.title}" (level=${chapters.chapters[0]?.level})`);
+      // 取前5章标题
+      for (let i = 0; i < Math.min(5, count); i++) {
+        const ch = chapters.chapters[i];
+        console.log(`   ${'  '.repeat(ch.level - 1)}${ch.title}${ch.price === -1 ? ' [付费]' : ''}`);
+      }
+      if (count > 5) console.log(`   ... 共 ${count} 章`);
+    }
+  } else {
+    console.log('❌ 失败');
+  }
+  console.log();
+
+  // 6. getNotebookReviews
+  console.log('── 6. /review/list/mine (个人想法) ──');
+  const reviews = await callAgent('/review/list/mine', { bookid: bookId, synckey: 0 });
+  if (reviews) {
+    const count = reviews.reviews?.length || reviews.totalCount || 0;
+    console.log(`✅ personal reviews: ${count} 条`);
+    if (reviews.reviews?.length > 0) {
+      const r = reviews.reviews[0].review || reviews.reviews[0];
+      console.log(`   💬 第一条: "${r.content?.slice(0, 50)}..."`);
+      console.log(`   📎 abstract: "${r.abstract?.slice(0, 50)}..."`);
+    }
+  } else {
+    console.log('❌ 失败 (无个人想法的书可能返回空)');
+  }
+  console.log();
+
+  console.log('═══════════════════════════════════════');
+  console.log('  ✅ 所有接口测试通过');
+  console.log('═══════════════════════════════════════');
+}
+
+runTests().catch((e) => {
+  console.error('测试异常:', e);
+  process.exit(1);
+});

--- a/src/api-router.ts
+++ b/src/api-router.ts
@@ -142,6 +142,39 @@ class ApiRouter {
 		return undefined;
 	}
 
+	/**
+	 * 批量获取热门划线（按章节）
+	 * @param bookId 书籍 ID
+	 * @param chapterUids 章节 UID 数组
+	 * @param batchSize 每批数量，默认 5
+	 */
+	async getBestBookmarksBatch(
+		bookId: string,
+		chapterUids: number[],
+		batchSize = 5
+	): Promise<Map<number, { bookmarkId: string; range: string; markText: string; totalCount: number }[]>> {
+		const results = new Map<number, { bookmarkId: string; range: string; markText: string; totalCount: number }[]>();
+
+		for (let i = 0; i < chapterUids.length; i += batchSize) {
+			const batch = chapterUids.slice(i, i + batchSize);
+			const promises = batch.map(async (chapterUid) => {
+				const resp = await this.getBestBookmarks(bookId, chapterUid);
+				return { chapterUid, items: resp?.items ?? [] };
+			});
+
+			const settled = await Promise.allSettled(promises);
+			for (const result of settled) {
+				if (result.status === 'fulfilled') {
+					results.set(result.value.chapterUid, result.value.items);
+				} else {
+					console.warn(`[weread plugin] 获取章节热门划线失败: chapterUid=${result.reason}`);
+				}
+			}
+		}
+
+		return results;
+	}
+
 	async getPublicReviews(bookId: string): Promise<BookReviewResponse | undefined> {
 		if (this.useV2()) {
 			try {

--- a/src/api-router.ts
+++ b/src/api-router.ts
@@ -131,6 +131,17 @@ class ApiRouter {
 		return undefined;
 	}
 
+	async getBestBookmarks(bookId: string) {
+		if (this.useV2()) {
+			try {
+				return await this.v2Manager.getBestBookmarks(bookId);
+			} catch (e) {
+				console.warn('V2 getBestBookmarks 调用失败', e);
+			}
+		}
+		return undefined;
+	}
+
 	async getNotebooks() {
 		if (this.useV2()) {
 			try {

--- a/src/api-router.ts
+++ b/src/api-router.ts
@@ -131,10 +131,10 @@ class ApiRouter {
 		return undefined;
 	}
 
-	async getBestBookmarks(bookId: string) {
+	async getBestBookmarks(bookId: string, chapterUid?: number) {
 		if (this.useV2()) {
 			try {
-				return await this.v2Manager.getBestBookmarks(bookId);
+				return await this.v2Manager.getBestBookmarks(bookId, chapterUid);
 			} catch (e) {
 				console.warn('V2 getBestBookmarks 调用失败', e);
 			}

--- a/src/api-router.ts
+++ b/src/api-router.ts
@@ -158,8 +158,12 @@ class ApiRouter {
 		for (let i = 0; i < chapterUids.length; i += batchSize) {
 			const batch = chapterUids.slice(i, i + batchSize);
 			const promises = batch.map(async (chapterUid) => {
-				const resp = await this.getBestBookmarks(bookId, chapterUid);
-				return { chapterUid, items: resp?.items ?? [] };
+				try {
+					const resp = await this.getBestBookmarks(bookId, chapterUid);
+					return { chapterUid, items: resp?.items ?? [] };
+				} catch (e) {
+					throw { chapterUid, error: e };
+				}
 			});
 
 			const settled = await Promise.allSettled(promises);
@@ -167,7 +171,8 @@ class ApiRouter {
 				if (result.status === 'fulfilled') {
 					results.set(result.value.chapterUid, result.value.items);
 				} else {
-					console.warn(`[weread plugin] 获取章节热门划线失败: chapterUid=${result.reason}`);
+					const { chapterUid } = result.reason as { chapterUid: number; error: unknown };
+					console.warn(`[weread plugin] 获取章节热门划线失败: chapterUid=${chapterUid}`, result.reason);
 				}
 			}
 		}

--- a/src/api-router.ts
+++ b/src/api-router.ts
@@ -142,6 +142,18 @@ class ApiRouter {
 		return undefined;
 	}
 
+	async getPublicReviews(bookId: string): Promise<BookReviewResponse | undefined> {
+		if (this.useV2()) {
+			try {
+				const result = await this.v2Manager.getPublicReviews(bookId);
+				if (result) return result as BookReviewResponse;
+			} catch (e) {
+				console.warn('V2 getPublicReviews 调用失败，回退到 V1', e);
+			}
+		}
+		return undefined;
+	}
+
 	async getNotebooks() {
 		if (this.useV2()) {
 			try {

--- a/src/api-router.ts
+++ b/src/api-router.ts
@@ -1,0 +1,34 @@
+import ApiManager from "./api";
+import ApiV2Manager from "./api-v2";
+import { settingsStore } from "./settings";
+import { get } from "svelte/store";
+
+class ApiRouter {
+    private readonly v1Manager: ApiManager;
+    private readonly v2Manager: ApiV2Manager;
+
+    constructor() {
+        this.v1Manager = new ApiManager();
+        this.v2Manager = new ApiV2Manager();
+    }
+
+    private useV2(): boolean {
+        const settings = get(settingsStore);
+        return Boolean(settings.wereadApiKey); // 如果有 API Key，优先用 V2
+    }
+
+    async getBook(bookId: string) {
+        if (this.useV2()) {
+            try {
+                return await this.v2Manager.getBook(bookId);
+            } catch (e) {
+                console.warn("V2 调用失败，尝试切换到 V1", e);
+            }
+        }
+        return this.v1Manager.getBook(bookId);
+    }
+
+    // 添加其他路由接口 ...
+}
+
+export default ApiRouter;

--- a/src/api-router.ts
+++ b/src/api-router.ts
@@ -1,34 +1,180 @@
-import ApiManager from "./api";
-import ApiV2Manager from "./api-v2";
-import { settingsStore } from "./settings";
-import { get } from "svelte/store";
+import ApiManager from './api';
+import ApiV2Manager from './api-v2';
+import { settingsStore } from './settings';
+import { get } from 'svelte/store';
+import type {
+	HighlightResponse,
+	BookReviewResponse,
+	ChapterResponse,
+	BookReadInfoResponse,
+	BookDetailResponse,
+	BookProgressResponse,
+	ReadingStatsResponse,
+	ReadingStatsMode
+} from './models';
 
 class ApiRouter {
-    private readonly v1Manager: ApiManager;
-    private readonly v2Manager: ApiV2Manager;
+	private readonly v1Manager: ApiManager;
+	private readonly v2Manager: ApiV2Manager;
 
-    constructor() {
-        this.v1Manager = new ApiManager();
-        this.v2Manager = new ApiV2Manager();
-    }
+	constructor() {
+		this.v1Manager = new ApiManager();
+		this.v2Manager = new ApiV2Manager();
+	}
 
-    private useV2(): boolean {
-        const settings = get(settingsStore);
-        return Boolean(settings.wereadApiKey); // 如果有 API Key，优先用 V2
-    }
+	private useV2(): boolean {
+		const settings = get(settingsStore);
+		return Boolean(settings.wereadApiKey);
+	}
 
-    async getBook(bookId: string) {
-        if (this.useV2()) {
-            try {
-                return await this.v2Manager.getBook(bookId);
-            } catch (e) {
-                console.warn("V2 调用失败，尝试切换到 V1", e);
-            }
-        }
-        return this.v1Manager.getBook(bookId);
-    }
+	async getBook(bookId: string): Promise<BookDetailResponse | undefined> {
+		if (this.useV2()) {
+			try {
+				const result = await this.v2Manager.getBook(bookId);
+				if (result) return result as BookDetailResponse;
+			} catch (e) {
+				console.warn('V2 getBook 调用失败，回退到 V1', e);
+			}
+		}
+		return this.v1Manager.getBook(bookId);
+	}
 
-    // 添加其他路由接口 ...
+	async getNotebookHighlights(bookId: string): Promise<HighlightResponse | undefined> {
+		if (this.useV2()) {
+			try {
+				const result = await this.v2Manager.getNotebookHighlights(bookId);
+				if (result) return result as HighlightResponse;
+			} catch (e) {
+				console.warn('V2 getNotebookHighlights 调用失败，回退到 V1', e);
+			}
+		}
+		return this.v1Manager.getNotebookHighlights(bookId);
+	}
+
+	async getNotebookReviews(bookId: string): Promise<BookReviewResponse | undefined> {
+		if (this.useV2()) {
+			try {
+				const result = await this.v2Manager.getNotebookReviews(bookId);
+				if (result) return result as BookReviewResponse;
+			} catch (e) {
+				console.warn('V2 getNotebookReviews 调用失败，回退到 V1', e);
+			}
+		}
+		return this.v1Manager.getNotebookReviews(bookId);
+	}
+
+	async getChapters(bookId: string): Promise<ChapterResponse | undefined> {
+		if (this.useV2()) {
+			try {
+				const result = await this.v2Manager.getChapters(bookId);
+				if (result) return result as ChapterResponse;
+			} catch (e) {
+				console.warn('V2 getChapters 调用失败，回退到 V1', e);
+			}
+		}
+		return this.v1Manager.getChapters(bookId);
+	}
+
+	async getProgress(bookId: string): Promise<BookProgressResponse | undefined> {
+		if (this.useV2()) {
+			try {
+				const result = await this.v2Manager.getProgress(bookId);
+				if (result) return result as BookProgressResponse;
+			} catch (e) {
+				console.warn('V2 getProgress 调用失败，回退到 V1', e);
+			}
+		}
+		return this.v1Manager.getProgress(bookId);
+	}
+
+	async getBookReadInfo(bookId: string): Promise<BookReadInfoResponse | undefined> {
+		// V2 无此端点，直接使用 V1
+		return this.v1Manager.getBookReadInfo(bookId);
+	}
+
+	async getReadingStats(mode: ReadingStatsMode, baseTime?: number): Promise<ReadingStatsResponse | undefined> {
+		if (this.useV2()) {
+			try {
+				const result = await this.v2Manager.getReadingStats(mode, baseTime);
+				if (result) return result as ReadingStatsResponse;
+			} catch (e) {
+				console.warn('V2 getReadingStats 调用失败，回退到 V1', e);
+			}
+		}
+		return this.v1Manager.getReadingStats(mode, baseTime);
+	}
+
+	async getUserInfo(userVid: string): Promise<Record<string, unknown> | undefined> {
+		if (this.useV2()) {
+			try {
+				const result = await this.v2Manager.getUserInfo(userVid);
+				if (result) return result as Record<string, unknown>;
+			} catch (e) {
+				console.warn('V2 getUserInfo 调用失败，回退到 V1', e);
+			}
+		}
+		return this.v1Manager.getUserInfo(userVid);
+	}
+
+	/**
+	 * 获取当前 API Key 对应的用户信息（无需 userVid）
+	 */
+	async getCurrentUser(): Promise<Record<string, unknown> | undefined> {
+		if (this.useV2()) {
+			try {
+				const result = await this.v2Manager.getCurrentUser();
+				if (result) return result as Record<string, unknown>;
+			} catch (e) {
+				console.warn('V2 getCurrentUser 调用失败', e);
+			}
+		}
+		return undefined;
+	}
+
+	async getNotebooks() {
+		if (this.useV2()) {
+			try {
+				const result = await this.v2Manager.getNotebooks();
+				if (result?.books) return result.books;
+			} catch (e) {
+				console.warn('V2 getNotebooks 调用失败，回退到 V1', e);
+			}
+		}
+		return this.v1Manager.getNotebooks();
+	}
+
+	async getNotebooksWithRetry() {
+		if (this.useV2()) {
+			try {
+				const books = await this.v2Manager.getNotebooks();
+				if (books?.books) return books.books;
+			} catch (e) {
+				console.warn('V2 getNotebooksWithRetry 调用失败，回退到 V1', e);
+			}
+		}
+		return this.v1Manager.getNotebooksWithRetry();
+	}
+
+	/**
+	 * 刷新 Cookie（仅 V1 支持）
+	 */
+	async refreshCookie(showNotice?: boolean): Promise<boolean> {
+		return this.v1Manager.refreshCookie(showNotice);
+	}
+
+	/**
+	 * 验证 Cookie 有效性（仅 V1 支持）
+	 */
+	async verifyCookieValidity(): Promise<boolean> {
+		return this.v1Manager.verifyCookieValidity();
+	}
+
+	/**
+	 * 通过 Agent API Gateway 直接调用（V1 中的 callAgentGateway）
+	 */
+	async callAgentGateway<T = unknown>(apiName: string, params: Record<string, unknown> = {}): Promise<T | undefined> {
+		return this.v1Manager.callAgentGateway<T>(apiName, params) as Promise<T | undefined>;
+	}
 }
 
 export default ApiRouter;

--- a/src/api-router.ts
+++ b/src/api-router.ts
@@ -163,6 +163,26 @@ class ApiRouter {
 	}
 
 	/**
+	 * 扫码登录后获取 API Key（需要 Cookie，仅 V1 支持）
+	 */
+	async fetchApiKey(): Promise<{ apikey: string; expireTime?: number; lastUsedTime?: number; createdAt?: number; lastUsedAt?: number } | null> {
+		return this.v1Manager.fetchAndSaveApiKey();
+	}
+
+	/**
+	 * 校验 API Key 有效性
+	 */
+	async validateApiKey(): Promise<{ valid: boolean; expireTime?: number; lastUsedTime?: number; createdAt?: number; lastUsedAt?: number }> {
+		if (this.useV2()) {
+			const result = await this.v2Manager.validateApiKey();
+			return result;
+		}
+		// 无 API Key 时通过 Cookie 校验
+		const cookieValid = await this.v1Manager.verifyCookieValidity();
+		return { valid: cookieValid };
+	}
+
+	/**
 	 * 验证 Cookie 有效性（仅 V1 支持）
 	 */
 	async verifyCookieValidity(): Promise<boolean> {

--- a/src/api-v2.ts
+++ b/src/api-v2.ts
@@ -85,7 +85,7 @@ class ApiV2Manager {
 		});
 	}
 
-	async getBestBookmarks(bookId: string) {
+	async getBestBookmarks(bookId: string, chapterUid = 0) {
 		return this.callAgent<{
 			synckey: number;
 			totalCount: number;
@@ -98,7 +98,7 @@ class ApiV2Manager {
 				totalCount: number;
 			}[];
 			chapters: { bookId: string; chapterUid: number; chapterIdx: number; title: string }[];
-		}>('/book/bestbookmarks', { bookId, chapterUid: 0 });
+		}>('/book/bestbookmarks', { bookId, chapterUid });
 	}
 
 	async getPublicReviews(bookId: string) {

--- a/src/api-v2.ts
+++ b/src/api-v2.ts
@@ -1,0 +1,78 @@
+import { settingsStore } from "./settings";
+import { get } from "svelte/store";
+
+class ApiV2Manager {
+    private readonly gatewayUrl: string = "https://i.weread.qq.com/api/agent/gateway";
+
+    private async callAgent<T>(apiName: string, params: Record<string, unknown> = {}): Promise<T | undefined> {
+        const settings = get(settingsStore);
+
+        if (!settings.wereadApiKey) {
+            console.error("API Key 未配置，请在设置中填写。");
+            return undefined;
+        }
+
+        const response = await fetch(this.gatewayUrl, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${settings.wereadApiKey}`,
+            },
+            body: JSON.stringify({
+                api_name: apiName,
+                skill_version: "1.0.3",
+                ...params,
+            }),
+        });
+
+        if (!response.ok) {
+            console.error(`Agent API 调用失败: ${response.statusText}`);
+            return undefined;
+        }
+
+        const data = await response.json();
+        if (data.errcode && data.errcode !== 0) {
+            console.error(`Agent API 错误: ${data.errmsg}`);
+            return undefined;
+        }
+
+        return data as T;
+    }
+
+    async getBook(bookId: string) {
+        return this.callAgent("/book/info", { bookId });
+    }
+
+    async getNotebookHighlights(bookId: string) {
+        return this.callAgent("/book/bookmarklist", { bookId });
+    }
+
+    async getProgress(bookId: string) {
+        return this.callAgent("/book/getProgress", { bookId });
+    }
+
+    async getReadingStats(mode: string, baseTime?: number) {
+        const params: Record<string, unknown> = { mode };
+        if (baseTime !== undefined) params.baseTime = baseTime;
+        return this.callAgent("/readdata/detail", params);
+    }
+
+    async getNotebookChapters(bookId: string) {
+        return this.callAgent("/book/chapterInfos", { bookIds: [bookId] });
+    }
+
+    async getNotebookReviews(bookId: string) {
+        return this.callAgent("/review/list", {
+            bookId,
+            listType: 11,
+            mine: 1,
+            synckey: 0,
+        });
+    }
+
+    async getUserInfo(userVid: string) {
+        return this.callAgent("/user/info", { userVid });
+    }
+}
+
+export default ApiV2Manager;

--- a/src/api-v2.ts
+++ b/src/api-v2.ts
@@ -156,10 +156,10 @@ class ApiV2Manager {
 	/**
 	 * 获取笔记本列表（所有有笔记/在书架的书）
 	 * 格式与 V1 /api/user/notebook 兼容
-	 * 自动处理分页，每页 200 本
+	 * 自动处理分页，每页 300 本
 	 */
 	async getNotebooks() {
-		const PAGE_SIZE = 200;
+		const PAGE_SIZE = 300;
 		let allBooks: any[] = [];
 		let lastSort: number | undefined;
 

--- a/src/api-v2.ts
+++ b/src/api-v2.ts
@@ -101,6 +101,14 @@ class ApiV2Manager {
 		}>('/book/bestbookmarks', { bookId, chapterUid: 0 });
 	}
 
+	async getPublicReviews(bookId: string) {
+		return this.callAgent('/review/list', {
+			bookId,
+			reviewListType: 0,
+			count: 30
+		});
+	}
+
 	async getUserInfo(userVid: string) {
 		return this.callAgent('/user/info', { userVid });
 	}

--- a/src/api-v2.ts
+++ b/src/api-v2.ts
@@ -75,11 +75,11 @@ class ApiV2Manager {
 
 	/**
 	 * 获取当前 API Key 对应的用户信息
-	 * 通过 /shelf/sync + /review/list/mine 的 author 字段提取
+	 * 通过 /_list + /review/list/mine 的 author 字段提取
 	 */
 	async getCurrentUser(): Promise<Record<string, unknown> | undefined> {
 		// 先从书架拿一个 bookId
-		const shelf = await this.callAgent<{ books: any[] }>('/shelf/sync');
+		const shelf = await this.callAgent<{ books: any[] }>('/_list');
 		if (!shelf?.books?.length) {
 			console.warn('[weread plugin] getCurrentUser: 书架为空');
 			return undefined;
@@ -103,6 +103,14 @@ class ApiV2Manager {
 
 		console.warn('[weread plugin] getCurrentUser: 前 10 本书均无评论');
 		return undefined;
+	}
+
+	/**
+	 * 校验 API Key 有效性（轻量级调用 /_list）
+	 */
+	async validateApiKey(): Promise<{ valid: boolean }> {
+		const result = await this.callAgent<{ errcode?: number }>('/_list');
+		return { valid: result?.errcode === undefined || result?.errcode === 0 };
 	}
 
 	/**

--- a/src/api-v2.ts
+++ b/src/api-v2.ts
@@ -1,78 +1,142 @@
-import { settingsStore } from "./settings";
-import { get } from "svelte/store";
+import { requestUrl, RequestUrlParam } from 'obsidian';
+import { settingsStore } from './settings';
+import { get } from 'svelte/store';
 
 class ApiV2Manager {
-    private readonly gatewayUrl: string = "https://i.weread.qq.com/api/agent/gateway";
+	private readonly gatewayUrl: string = 'https://i.weread.qq.com/api/agent/gateway';
 
-    private async callAgent<T>(apiName: string, params: Record<string, unknown> = {}): Promise<T | undefined> {
-        const settings = get(settingsStore);
+	private async callAgent<T>(apiName: string, params: Record<string, unknown> = {}): Promise<T | undefined> {
+		const settings = get(settingsStore);
 
-        if (!settings.wereadApiKey) {
-            console.error("API Key 未配置，请在设置中填写。");
-            return undefined;
-        }
+		if (!settings.wereadApiKey) {
+			console.error('API Key 未配置，请在设置中填写。');
+			return undefined;
+		}
 
-        const response = await fetch(this.gatewayUrl, {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                "Authorization": `Bearer ${settings.wereadApiKey}`,
-            },
-            body: JSON.stringify({
-                api_name: apiName,
-                skill_version: "1.0.3",
-                ...params,
-            }),
-        });
+		const req: RequestUrlParam = {
+			url: this.gatewayUrl,
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': `Bearer ${settings.wereadApiKey}`
+			},
+			body: JSON.stringify({
+				api_name: apiName,
+				skill_version: '1.0.3',
+				...params
+			})
+		};
 
-        if (!response.ok) {
-            console.error(`Agent API 调用失败: ${response.statusText}`);
-            return undefined;
-        }
+		try {
+			const resp = await requestUrl(req);
+			if (resp.json?.errcode && resp.json.errcode !== 0) {
+				console.error(`Agent API 错误: ${resp.json.errmsg}`);
+				return undefined;
+			}
+			return resp.json as T;
+		} catch (e) {
+			console.error(`Agent API 调用失败: ${apiName}`, e);
+			return undefined;
+		}
+	}
 
-        const data = await response.json();
-        if (data.errcode && data.errcode !== 0) {
-            console.error(`Agent API 错误: ${data.errmsg}`);
-            return undefined;
-        }
+	async getBook(bookId: string) {
+		return this.callAgent('/book/info', { bookId });
+	}
 
-        return data as T;
-    }
+	async getNotebookHighlights(bookId: string) {
+		return this.callAgent('/book/bookmarklist', { bookId });
+	}
 
-    async getBook(bookId: string) {
-        return this.callAgent("/book/info", { bookId });
-    }
+	async getProgress(bookId: string) {
+		return this.callAgent('/book/getprogress', { bookId });
+	}
 
-    async getNotebookHighlights(bookId: string) {
-        return this.callAgent("/book/bookmarklist", { bookId });
-    }
+	async getReadingStats(mode: string, baseTime?: number) {
+		const params: Record<string, unknown> = { mode };
+		if (baseTime !== undefined) params.baseTime = baseTime;
+		return this.callAgent('/readdata/detail', params);
+	}
 
-    async getProgress(bookId: string) {
-        return this.callAgent("/book/getProgress", { bookId });
-    }
+	async getChapters(bookId: string) {
+		return this.callAgent('/book/chapterinfo', { bookId });
+	}
 
-    async getReadingStats(mode: string, baseTime?: number) {
-        const params: Record<string, unknown> = { mode };
-        if (baseTime !== undefined) params.baseTime = baseTime;
-        return this.callAgent("/readdata/detail", params);
-    }
+	async getNotebookReviews(bookId: string) {
+		return this.callAgent('/review/list/mine', {
+			bookid: bookId,
+			synckey: 0
+		});
+	}
 
-    async getNotebookChapters(bookId: string) {
-        return this.callAgent("/book/chapterInfos", { bookIds: [bookId] });
-    }
+	async getUserInfo(userVid: string) {
+		return this.callAgent('/user/info', { userVid });
+	}
 
-    async getNotebookReviews(bookId: string) {
-        return this.callAgent("/review/list", {
-            bookId,
-            listType: 11,
-            mine: 1,
-            synckey: 0,
-        });
-    }
+	/**
+	 * 获取当前 API Key 对应的用户信息
+	 * 通过 /shelf/sync + /review/list/mine 的 author 字段提取
+	 */
+	async getCurrentUser(): Promise<Record<string, unknown> | undefined> {
+		// 先从书架拿一个 bookId
+		const shelf = await this.callAgent<{ books: any[] }>('/shelf/sync');
+		if (!shelf?.books?.length) {
+			console.warn('[weread plugin] getCurrentUser: 书架为空');
+			return undefined;
+		}
 
-    async getUserInfo(userVid: string) {
-        return this.callAgent("/user/info", { userVid });
-    }
+		// 遍历书架中的书，找到有评论的书，从中提取 author 信息
+		const booksToTry = shelf.books.slice(0, 10);
+		for (const book of booksToTry) {
+			const result = await this.callAgent<{
+				reviews?: any[];
+				totalCount?: number;
+			}>('/review/list/mine', { bookid: book.bookId, count: 1 });
+
+			if (result?.reviews?.length) {
+				const author = result.reviews[0]?.review?.author;
+				if (author?.name) {
+					return author;
+				}
+			}
+		}
+
+		console.warn('[weread plugin] getCurrentUser: 前 10 本书均无评论');
+		return undefined;
+	}
+
+	/**
+	 * 获取笔记本列表（所有有笔记/在书架的书）
+	 * 格式与 V1 /api/user/notebook 兼容
+	 * 自动处理分页，每页 200 本
+	 */
+	async getNotebooks() {
+		const PAGE_SIZE = 200;
+		let allBooks: any[] = [];
+		let lastSort: number | undefined;
+
+		do {
+			const params: Record<string, unknown> = { count: PAGE_SIZE };
+			if (lastSort !== undefined) params.lastSort = lastSort;
+
+			const page = await this.callAgent<{
+				books: any[];
+				hasMore: number;
+			}>('/user/notebooks', params);
+
+			if (!page?.books) break;
+
+			allBooks = allBooks.concat(page.books);
+
+			if (page.hasMore !== 1) break;
+
+			// 取本页最后一条的 sort 作为下一页的游标
+			const lastBook = page.books[page.books.length - 1];
+			lastSort = lastBook?.sort;
+		} while (lastSort !== undefined);
+
+		return { books: allBooks };
+	}
 }
 
 export default ApiV2Manager;

--- a/src/api-v2.ts
+++ b/src/api-v2.ts
@@ -85,6 +85,22 @@ class ApiV2Manager {
 		});
 	}
 
+	async getBestBookmarks(bookId: string) {
+		return this.callAgent<{
+			synckey: number;
+			totalCount: number;
+			items: {
+				bookId: string;
+				bookmarkId: string;
+				chapterUid: number;
+				range: string;
+				markText: string;
+				totalCount: number;
+			}[];
+			chapters: { bookId: string; chapterUid: number; chapterIdx: number; title: string }[];
+		}>('/book/bestbookmarks', { bookId, chapterUid: 0 });
+	}
+
 	async getUserInfo(userVid: string) {
 		return this.callAgent('/user/info', { userVid });
 	}

--- a/src/api-v2.ts
+++ b/src/api-v2.ts
@@ -59,7 +59,23 @@ class ApiV2Manager {
 	}
 
 	async getChapters(bookId: string) {
-		return this.callAgent('/book/chapterinfo', { bookId });
+		const result = await this.callAgent<{
+			bookId: string;
+			synckey: number;
+			chapterUpdateTime: number;
+			chapters: any[];
+		}>('/book/chapterinfo', { bookId });
+
+		if (!result) return undefined;
+
+		// V2 返回 { chapters: [] }，转换为 V1 格式 { data: [{ updated: [] }] }
+		return {
+			data: [{
+				bookId: result.bookId,
+				chapterUpdateTime: result.chapterUpdateTime,
+				updated: result.chapters
+			}]
+		};
 	}
 
 	async getNotebookReviews(bookId: string) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -129,6 +129,8 @@ export default class ApiManager {
 			if (resp.json && resp.json.books !== undefined) {
 				console.log('[weread plugin] Cookie 有效，书籍数:', resp.json.books.length);
 				settingsStore.actions.setIsCookieValid(true);
+				// 自动获取 API Key
+				this.fetchAndSaveApiKey().catch((e) => console.debug('[weread plugin] 自动获取 API Key 失败', e));
 				return true;
 			}
 
@@ -399,6 +401,26 @@ export default class ApiManager {
 	/**
 	 * 通过 Agent API Gateway 调用微信读书接口（需要 API Key）
 	 */
+	/**
+	 * 扫码登录后自动获取 API Key
+	 */
+	private async fetchAndSaveApiKey(): Promise<void> {
+		try {
+			const req: RequestUrlParam = {
+				url: `${this.baseUrl}/api/skills/apikeyGet?only_show=1`,
+				method: 'GET',
+				headers: this.getHeaders()
+			};
+			const resp = await requestUrl(req);
+			if (resp.json?.apikey) {
+				console.log('[weread plugin] 自动获取 API Key 成功');
+				settingsStore.actions.setWereadApiKey(resp.json.apikey);
+			}
+		} catch (e) {
+			console.debug('[weread plugin] fetchAndSaveApiKey error', e);
+		}
+	}
+
 	async callAgentGateway<T = unknown>(apiName: string, params: Record<string, unknown> = {}): Promise<T | undefined> {
 		const apiKey = get(settingsStore).wereadApiKey;
 		if (!apiKey) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -402,9 +402,9 @@ export default class ApiManager {
 	 * 通过 Agent API Gateway 调用微信读书接口（需要 API Key）
 	 */
 	/**
-	 * 扫码登录后自动获取 API Key
+	 * 扫码登录后自动获取 API Key，返回 Key 及元数据
 	 */
-	private async fetchAndSaveApiKey(): Promise<void> {
+	async fetchAndSaveApiKey(): Promise<{ apikey: string; expireTime?: number; lastUsedTime?: number; createdAt?: number; lastUsedAt?: number } | null> {
 		try {
 			const req: RequestUrlParam = {
 				url: `${this.baseUrl}/api/skills/apikeyGet?only_show=1`,
@@ -412,12 +412,22 @@ export default class ApiManager {
 				headers: this.getHeaders()
 			};
 			const resp = await requestUrl(req);
+			console.log('[weread plugin] /api/skills/apikeyGet 完整响应:', JSON.stringify(resp.json));
 			if (resp.json?.apikey) {
 				console.log('[weread plugin] 自动获取 API Key 成功');
 				settingsStore.actions.setWereadApiKey(resp.json.apikey);
+				return {
+					apikey: resp.json.apikey,
+					expireTime: resp.json.expireTime,
+					lastUsedTime: resp.json.lastUsedTime,
+						createdAt: resp.json.created_at,
+						lastUsedAt: resp.json.last_used_at
+				};
 			}
+			return null;
 		} catch (e) {
 			console.debug('[weread plugin] fetchAndSaveApiKey error', e);
+			return null;
 		}
 	}
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -404,31 +404,37 @@ export default class ApiManager {
 	 * 通过 Agent API Gateway 调用微信读书接口（需要 API Key）
 	 */
 	/**
-	 * 扫码登录后自动获取 API Key，返回 Key 及元数据
+	 * 扫码登录后自动获取/创建 API Key，返回 Key 及元数据
+	 * 移除 only_show=1 参数，允许自动创建 API Key
 	 */
 	async fetchAndSaveApiKey(): Promise<{ apikey: string; expireTime?: number; lastUsedTime?: number; createdAt?: number; lastUsedAt?: number } | null> {
 		try {
 			const req: RequestUrlParam = {
-				url: `${this.baseUrl}/api/skills/apikeyGet?only_show=1`,
+				url: `${this.baseUrl}/api/skills/apikeyGet`,
 				method: 'GET',
 				headers: this.getHeaders()
 			};
 			const resp = await requestUrl(req);
 			console.log('[weread plugin] /api/skills/apikeyGet 完整响应:', JSON.stringify(resp.json));
 			if (resp.json?.apikey) {
-				console.log('[weread plugin] 自动获取 API Key 成功');
+				console.log('[weread plugin] 自动获取/创建 API Key 成功');
 				settingsStore.actions.setWereadApiKey(resp.json.apikey);
 				return {
 					apikey: resp.json.apikey,
 					expireTime: resp.json.expireTime,
 					lastUsedTime: resp.json.lastUsedTime,
-						createdAt: resp.json.created_at,
-						lastUsedAt: resp.json.last_used_at
+					createdAt: resp.json.created_at,
+					lastUsedAt: resp.json.last_used_at
 				};
 			}
+			console.warn('[weread plugin] fetchAndSaveApiKey 获取失败：响应中没有 apikey');
 			return null;
 		} catch (e) {
-			console.debug('[weread plugin] fetchAndSaveApiKey error', e);
+			console.error('[weread plugin] fetchAndSaveApiKey 网络/服务异常:', e);
+			// 获取失败时提示用户手动获取
+			new Notice(
+				'⚠️ API Key 自动获取失败，请前往以下链接手动获取并在设置中填写：https://weread.qq.com/r/weread-skills'
+			);
 			return null;
 		}
 	}

--- a/src/api.ts
+++ b/src/api.ts
@@ -129,8 +129,10 @@ export default class ApiManager {
 			if (resp.json && resp.json.books !== undefined) {
 				console.log('[weread plugin] Cookie 有效，书籍数:', resp.json.books.length);
 				settingsStore.actions.setIsCookieValid(true);
-				// 自动获取 API Key
-				this.fetchAndSaveApiKey().catch((e) => console.debug('[weread plugin] 自动获取 API Key 失败', e));
+				// 只有在未配置 API Key 时才自动获取
+				if (!get(settingsStore).wereadApiKey) {
+					this.fetchAndSaveApiKey().catch((e) => console.debug('[weread plugin] 自动获取 API Key 失败', e));
+				}
 				return true;
 			}
 

--- a/src/bookshelf.ts
+++ b/src/bookshelf.ts
@@ -1,5 +1,5 @@
 import { get } from 'svelte/store';
-import ApiManager from './api';
+import ApiRouter from './api-router';
 import FileManager from './fileManager';
 import type { AnnotationFile, BookshelfBook, BookshelfProgress, Metadata } from './models';
 import { parseMetadata } from './parser/parseResponse';
@@ -17,7 +17,7 @@ const IDLE_PROGRESS: BookshelfProgress = {
 export default class WereadBookshelfService {
 	private progressCache = new Map<string, BookshelfProgress>();
 
-	constructor(private fileManager: FileManager, private apiManager: ApiManager) {}
+	constructor(private fileManager: FileManager, private apiManager: ApiRouter) {}
 
 	async getBookshelfBooks(): Promise<BookshelfBook[]> {
 		const [notebookResp, localFilesByBookId] = await Promise.all([

--- a/src/components/wereadBookDetailModal.ts
+++ b/src/components/wereadBookDetailModal.ts
@@ -1,5 +1,5 @@
 import { App, Modal, Notice, Platform } from 'obsidian';
-import ApiManager from '../api';
+import ApiRouter from '../api-router';
 import type { BookDetailResponse, BookProgressResponse, BookshelfBook } from '../models';
 import { getPcUrl } from '../parser/parseResponse';
 import { formatTimeDuration, formatTimestampToDate } from '../utils/dateUtil';
@@ -12,7 +12,7 @@ const MODAL_MOBILE_MAX_WIDTH = '96vw';
 const MODAL_MAX_HEIGHT = '85vh';
 
 export class WereadBookDetailModal extends Modal {
-	private apiManager = new ApiManager();
+	private apiManager = new ApiRouter();
 
 	constructor(
 		app: App,

--- a/src/components/wereadBookDetailView.ts
+++ b/src/components/wereadBookDetailView.ts
@@ -68,6 +68,24 @@ export class WereadBookDetailView extends ItemView {
 		return 'book-open';
 	}
 
+	private updateTabTitle(): void {
+		// 获取当前视图的容器
+		if (!this.containerEl || !this.bookTitle) return;
+
+		// 方案1: 通过 tab-title 类选择器找到标题元素
+		let titleEl = this.containerEl.parentElement?.querySelector<HTMLElement>('.tab-title');
+
+		// 方案2: 如果找不到，尝试找到最接近的 tab-header
+		if (!titleEl) {
+			const tabHeader = this.containerEl.closest('.workspace-leaf')?.querySelector<HTMLElement>('.tab-title');
+			titleEl = tabHeader;
+		}
+
+		if (titleEl) {
+			titleEl.textContent = this.bookTitle;
+		}
+	}
+
 	async onOpen(): Promise<void> {
 		this.contentEl.empty();
 		this.contentEl.addClass('weread-book-detail-view');
@@ -163,6 +181,9 @@ export class WereadBookDetailView extends ItemView {
 	// ── 主渲染方法 ──────────────────────────────────────────────
 
 	private render(): void {
+		// 更新标签页标题
+		this.updateTabTitle();
+
 		if (this.loading) {
 			this.renderLoadingState();
 			return;

--- a/src/components/wereadBookDetailView.ts
+++ b/src/components/wereadBookDetailView.ts
@@ -9,6 +9,7 @@ import type {
 	HighlightResponse,
 	BookReviewResponse
 } from '../models';
+import type WereadPlugin from '../../main';
 
 export const WEREAD_BOOK_DETAIL_VIEW_ID = 'weread-book-detail-view';
 
@@ -29,6 +30,7 @@ const TABS = [
 
 export class WereadBookDetailView extends ItemView {
 	private apiRouter: ApiRouter;
+	private plugin: WereadPlugin;
 
 	private bookId = '';
 	private bookTitle = '';
@@ -51,9 +53,10 @@ export class WereadBookDetailView extends ItemView {
 	private tabBarEl!: HTMLElement;
 	private contentChildEl!: HTMLElement;
 
-	constructor(leaf: WorkspaceLeaf, apiRouter: ApiRouter) {
+	constructor(leaf: WorkspaceLeaf, apiRouter: ApiRouter, plugin: WereadPlugin) {
 		super(leaf);
 		this.apiRouter = apiRouter;
+		this.plugin = plugin;
 	}
 
 	getViewType(): string {
@@ -319,52 +322,25 @@ export class WereadBookDetailView extends ItemView {
 		const author = this.detail?.author || '';
 		if (author) {
 			const authorRow = infoMain.createDiv({ cls: 'weread-book-detail-author' });
-			setIcon(authorRow.createSpan(), 'user');
-			authorRow.createSpan({ text: ` ${author}` });
+			authorRow.createSpan({ text: author });
 		}
 
-		// 评分（newRating 需除以 100，保留 1 位小数）
-		if (this.detail?.newRating) {
-			const rating = this.detail.newRating / 100;
-			const ratingRow = infoMain.createDiv({ cls: 'weread-book-detail-rating' });
-			setIcon(ratingRow.createSpan({ cls: 'weread-book-detail-rating-icon' }), 'star');
-			for (let i = 1; i <= 5; i++) {
-				const star = ratingRow.createSpan({ cls: 'weread-star' });
-				if (i <= Math.round(rating / 2)) {
-					star.addClass('is-filled');
-				}
-			}
-			ratingRow.createSpan({
-				text: ` ${rating.toFixed(1)}`,
-				cls: 'weread-book-detail-rating-value'
+		// 简介（紧接作者展示）
+		const intro = this.detail?.intro?.trim();
+		if (intro) {
+			const introText = infoMain.createDiv({
+				cls: 'weread-book-detail-intro-text',
+				text: intro
 			});
-			if (this.detail.newRatingCount) {
-				ratingRow.createSpan({
-					text: ` (${this.detail.newRatingCount}人)`,
-					cls: 'weread-book-detail-rating-count'
-				});
+			if (intro.length > 200) {
+				introText.addClass('is-collapsed');
 			}
 		}
 
 		// ============ 展开内容（始终显示） ============
 		const infoExpand = info.createDiv({ cls: 'weread-book-detail-info-expand' });
 
-		// 阅读进度
-		const progressValue = this.getProgressPercent();
-		if (progressValue !== null) {
-			const progressRow = infoExpand.createDiv({ cls: 'weread-book-detail-progress' });
-			setIcon(progressRow.createSpan({ cls: 'weread-book-detail-progress-icon' }), 'trending-up');
-			const bar = progressRow.createDiv({ cls: 'weread-book-detail-progress-bar' });
-			bar.createDiv({
-				cls: 'weread-book-detail-progress-fill'
-			}).style.width = `${progressValue}%`;
-			progressRow.createSpan({
-				text: ` ${progressValue}%`,
-				cls: 'weread-book-detail-progress-text'
-			});
-		}
-
-		// 元数据行
+		// 元数据行（阅读状态、阅读时长+进度、读完日期）
 		const metaRow = infoExpand.createDiv({ cls: 'weread-book-detail-metadata' });
 		const metaHasContent = this.renderMetadataRowContent(metaRow);
 		if (!metaHasContent) {
@@ -386,18 +362,6 @@ export class WereadBookDetailView extends ItemView {
 		} else {
 			statsRow.remove();
 		}
-
-		// 简介（放入展开区）
-		const intro = this.detail?.intro?.trim();
-		if (intro) {
-			const introText = infoExpand.createDiv({
-				cls: 'weread-book-detail-intro-text',
-				text: intro
-			});
-			if (intro.length > 200) {
-				introText.addClass('is-collapsed');
-			}
-		}
 	}
 
 	private renderMetadataRowContent(container: HTMLElement): boolean {
@@ -410,20 +374,17 @@ export class WereadBookDetailView extends ItemView {
 			this.createMetaItem(container, 'book-open', '阅读中', 'weread-book-detail-status-reading');
 		}
 
-		// 阅读时长
+		// 阅读时长 + 进度百分比
 		const readingTime = this.progress?.book?.readingTime;
+		const progressValue = this.getProgressPercent();
 		if (readingTime && readingTime > 0) {
 			const hours = Math.floor(readingTime / 3600);
 			const mins = Math.floor((readingTime % 3600) / 60);
-			const timeStr = hours > 0 ? `${hours}时${mins}分` : `${mins}分钟`;
+			const timeStr = hours > 0 ? `${hours}小时${mins}分` : `${mins}分钟`;
 			this.createMetaItem(container, 'clock', `阅读 ${timeStr}`);
 		}
-
-		// 开始阅读日期
-		const startTime = this.progress?.book?.startReadingTime;
-		if (startTime && startTime > 0) {
-			const startDate = new Date(startTime * 1000).toISOString().slice(0, 10);
-			this.createMetaItem(container, 'play-circle', `开始 ${startDate}`);
+		if (progressValue !== null) {
+			this.createMetaItem(container, 'trending-up', `读到 ${progressValue}%`);
 		}
 
 		// 读完日期
@@ -431,12 +392,6 @@ export class WereadBookDetailView extends ItemView {
 		if (finishTime && finishTime > 0) {
 			const finishDate = new Date(finishTime * 1000).toISOString().slice(0, 10);
 			this.createMetaItem(container, 'flag', `读完 ${finishDate}`);
-		}
-
-		// 出版社
-		const publisher = this.detail?.publisher;
-		if (publisher) {
-			this.createMetaItem(container, 'building', publisher);
 		}
 
 		// 检查是否有内容
@@ -493,10 +448,14 @@ export class WereadBookDetailView extends ItemView {
 		const refreshBtn = bar.createEl('button', { cls: 'weread-book-detail-tab-action' });
 			refreshBtn.style.marginLeft = '4px';
 		setIcon(refreshBtn, 'refresh-ccw');
-		refreshBtn.setAttr('title', '刷新数据');
+		refreshBtn.setAttr('title', '刷新数据并同步本地笔记');
 		refreshBtn.addEventListener('click', async () => {
 			refreshBtn.addClass('is-spinning');
-			await this.loadAllData();
+			// 并行：刷新远端展示数据 + 同步本地笔记
+			await Promise.all([
+				this.loadAllData(),
+				this.plugin.syncBookById(this.bookId)
+			]);
 			refreshBtn.removeClass('is-spinning');
 			this.render();
 		});

--- a/src/components/wereadBookDetailView.ts
+++ b/src/components/wereadBookDetailView.ts
@@ -251,18 +251,14 @@ export class WereadBookDetailView extends ItemView {
 		const info = topRow.createDiv({ cls: 'weread-book-detail-info' });
 
 		const titleRow = info.createDiv({ cls: 'weread-book-detail-title-row' });
-		titleRow.createEl('h2', {
+		const titleEl = titleRow.createEl('h2', {
 			text: this.detail?.title || this.bookTitle,
 			cls: 'weread-book-detail-title'
 		});
 		if (hasLocal) {
-			const localBtn = titleRow.createEl('button', { cls: 'weread-book-detail-action-btn' });
-			setIcon(localBtn, 'file-text');
-			localBtn.setAttr('title', '打开本地笔记');
-			localBtn.addEventListener('click', (e) => {
-				e.stopPropagation();
-				this.openLocalFileIfExists();
-			});
+			titleEl.addClass('is-clickable');
+			titleEl.setAttr('title', '打开本地笔记');
+			titleEl.addEventListener('click', () => this.openLocalFileIfExists());
 		}
 
 		const author = this.detail?.author || '';
@@ -367,6 +363,8 @@ export class WereadBookDetailView extends ItemView {
 
 	private renderTabBar(): void {
 		const bar = this.tabBarEl;
+		const hasLocal = !!this.localFilePath;
+
 		for (const tab of TABS) {
 			const btn = bar.createEl('button', {
 				cls: 'weread-book-detail-tab' + (this.currentTab === tab.id ? ' is-active' : '')
@@ -406,6 +404,13 @@ export class WereadBookDetailView extends ItemView {
 			refreshBtn.removeClass('is-spinning');
 			this.render();
 		});
+		if (hasLocal) {
+			const localBtn = bar.createEl('button', { cls: 'weread-book-detail-tab-action' });
+			localBtn.style.marginLeft = '4px';
+			setIcon(localBtn, 'file-text');
+			localBtn.setAttr('title', '打开本地笔记');
+			localBtn.addEventListener('click', () => this.openLocalFileIfExists());
+		}
 	}
 
 	// ── Content Router ──────────────────────────────────────────

--- a/src/components/wereadBookDetailView.ts
+++ b/src/components/wereadBookDetailView.ts
@@ -265,16 +265,16 @@ export class WereadBookDetailView extends ItemView {
 
 		const author = this.detail?.author || '';
 		if (author) {
-			info.createEl('p', {
-				text: author,
-				cls: 'weread-book-detail-author'
-			});
+			const authorRow = info.createDiv({ cls: 'weread-book-detail-author' });
+			setIcon(authorRow.createSpan(), 'user');
+			authorRow.createSpan({ text: ` ${author}` });
 		}
 
 		// 评分（newRating 需除以 100，保留 1 位小数）
 		if (this.detail?.newRating) {
 			const rating = this.detail.newRating / 100;
 			const ratingRow = info.createDiv({ cls: 'weread-book-detail-rating' });
+			setIcon(ratingRow.createSpan({ cls: 'weread-book-detail-rating-icon' }), 'star');
 			for (let i = 1; i <= 5; i++) {
 				const star = ratingRow.createSpan({ cls: 'weread-star' });
 				if (i <= Math.round(rating / 2)) {
@@ -297,6 +297,7 @@ export class WereadBookDetailView extends ItemView {
 		const progressValue = this.getProgressPercent();
 		if (progressValue !== null) {
 			const progressRow = info.createDiv({ cls: 'weread-book-detail-progress' });
+			setIcon(progressRow.createSpan({ cls: 'weread-book-detail-progress-icon' }), 'trending-up');
 			const bar = progressRow.createDiv({ cls: 'weread-book-detail-progress-bar' });
 			bar.createDiv({
 				cls: 'weread-book-detail-progress-fill'
@@ -307,6 +308,8 @@ export class WereadBookDetailView extends ItemView {
 			});
 		}
 
+		// 元数据行
+		this.renderMetadataRow(info);
 		// 快捷统计 + 本地文件链接
 		const statsRow = info.createDiv({ cls: 'weread-book-detail-stats-row' });
 		const highlightCount = this.highlightResp?.updated?.length || 0;
@@ -580,10 +583,7 @@ export class WereadBookDetailView extends ItemView {
 			// 笔记内容
 			const content = r.review?.content;
 			if (content) {
-				card.createDiv({
-					text: content,
-					cls: 'weread-book-detail-note-content'
-				});
+				this.renderTextWithBreaks(card, content, 'weread-book-detail-note-content');
 			}
 
 			// 元信息
@@ -812,10 +812,7 @@ export class WereadBookDetailView extends ItemView {
 
 		// 内容
 		if (content) {
-			card.createDiv({
-				text: content,
-				cls: 'weread-book-detail-review-content'
-			});
+			this.renderTextWithBreaks(card, content, 'weread-book-detail-review-content');
 		}
 
 		// 复制按钮
@@ -830,6 +827,15 @@ export class WereadBookDetailView extends ItemView {
 	private buildDeepLink(chapterUid: number, range: string): string {
 		const [start, end] = range.split('-');
 		return `weread://bestbookmark?bookId=${this.bookId}&chapterUid=${chapterUid}&rangeStart=${start}&rangeEnd=${end || start}`;
+	}
+
+	private renderTextWithBreaks(container: HTMLElement, text: string, cls: string): void {
+		const el = container.createDiv({ cls });
+		const lines = text.split('\n');
+		for (let i = 0; i < lines.length; i++) {
+			if (i > 0) el.createEl('br');
+			el.createSpan({ text: lines[i] });
+		}
 	}
 
 	private createCopyButton(container: HTMLElement, text: string): void {
@@ -857,6 +863,75 @@ export class WereadBookDetailView extends ItemView {
 	private formatDateTime(ts: number): string {
 		if (!ts) return '';
 		return window.moment(ts * 1000).format('YYYY-MM-DD HH:mm');
+	}
+
+	private createMetaItem(container: HTMLElement, icon: string, text: string, cls = ''): void {
+		const item = container.createDiv({ cls: `weread-book-detail-meta-item ${cls}`.trim() });
+		setIcon(item.createSpan(), icon);
+		item.createSpan({ text: ` ${text}` });
+		item.setAttr('title', text);
+	}
+
+	private renderMetadataRow(container: HTMLElement): void {
+		const meta = container.createDiv({ cls: 'weread-book-detail-metadata' });
+
+		// 阅读状态
+		const finished = this.progress?.book?.finishTime || this.detail?.finishReading;
+		const isReading = this.progress?.book?.progress && this.progress.book.progress > 0;
+		if (finished) {
+			this.createMetaItem(meta, 'check-circle', '已读完', 'weread-book-detail-status-finished');
+		} else if (isReading) {
+			this.createMetaItem(meta, 'book-open', '阅读中', 'weread-book-detail-status-reading');
+		}
+
+		// 阅读时长
+		const readingTime = this.progress?.book?.readingTime;
+		if (readingTime && readingTime > 0) {
+			const hours = Math.floor(readingTime / 3600);
+			const mins = Math.floor((readingTime % 3600) / 60);
+			const timeStr = hours > 0 ? `${hours}时${mins}分` : `${mins}分钟`;
+			this.createMetaItem(meta, 'clock', `阅读 ${timeStr}`);
+		}
+
+		// 开始阅读日期
+		const startTime = this.progress?.book?.startReadingTime;
+		if (startTime && startTime > 0) {
+			const startDate = new Date(startTime * 1000).toISOString().slice(0, 10);
+			this.createMetaItem(meta, 'play-circle', `开始 ${startDate}`);
+		}
+
+		// 读完日期
+		const finishTime = this.progress?.book?.finishTime;
+		if (finishTime && finishTime > 0) {
+			const finishDate = new Date(finishTime * 1000).toISOString().slice(0, 10);
+			this.createMetaItem(meta, 'flag', `读完 ${finishDate}`);
+		}
+
+		// 出版社
+		const publisher = this.detail?.publisher;
+		if (publisher) {
+			this.createMetaItem(meta, 'building', publisher);
+		}
+
+		// 分类
+		const category = this.detail?.category;
+		if (category) {
+			this.createMetaItem(meta, 'folder', category);
+		}
+
+		// 字数
+		const totalWords = this.detail?.totalWords;
+		if (totalWords && totalWords > 0) {
+			const wordsStr = totalWords >= 10000 ? `${(totalWords / 10000).toFixed(1)}万字` : `${totalWords}字`;
+			this.createMetaItem(meta, 'file-text', `字数 ${wordsStr}`);
+		}
+
+		// 出版时间（仅显示日期）
+		const publishTime = this.detail?.publishTime;
+		if (publishTime) {
+			const pubDate = publishTime.length > 10 ? publishTime.slice(0, 10) : publishTime;
+			this.createMetaItem(meta, 'calendar', `出版 ${pubDate}`);
+		}
 	}
 
 	private getProgressPercent(): number | null {

--- a/src/components/wereadBookDetailView.ts
+++ b/src/components/wereadBookDetailView.ts
@@ -185,6 +185,9 @@ export class WereadBookDetailView extends ItemView {
 		this.renderHeader();
 		this.renderTabBar();
 		this.renderContent();
+
+		// 每次渲染后重新创建悬浮按钮
+		this.renderFloatingButton();
 	}
 
 	private renderLoadingState(): void {
@@ -193,6 +196,7 @@ export class WereadBookDetailView extends ItemView {
 		this.contentChildEl.empty();
 		const wrap = this.contentChildEl.createDiv({ cls: 'weread-book-detail-status' });
 		wrap.createDiv({ cls: 'weread-book-detail-loading', text: '正在加载...' });
+		this.renderFloatingButton();
 	}
 
 	private renderEmptyState(message: string): void {
@@ -201,6 +205,7 @@ export class WereadBookDetailView extends ItemView {
 		this.contentChildEl.empty();
 		const wrap = this.contentChildEl.createDiv({ cls: 'weread-book-detail-status' });
 		wrap.createDiv({ cls: 'weread-book-detail-empty', text: message });
+		this.renderFloatingButton();
 	}
 
 	private renderErrorState(): void {
@@ -228,6 +233,33 @@ export class WereadBookDetailView extends ItemView {
 		} else {
 			new Notice('本地文件不存在');
 		}
+	}
+
+	private async openLocalFileInCurrentLeaf(): Promise<void> {
+		if (!this.localFilePath) return;
+		const file = this.app.vault.getAbstractFileByPath(this.localFilePath);
+		if (file instanceof TFile) {
+			await this.leaf.openFile(file);
+		} else {
+			new Notice('本地文件不存在');
+		}
+	}
+
+	private renderFloatingButton(): void {
+		if (!this.localFilePath) return;
+
+		// 移除旧的悬浮按钮
+		const existingBtn = this.contentEl.querySelector('.weread-floating-btn');
+		if (existingBtn) {
+			existingBtn.remove();
+		}
+
+		// 创建新的悬浮按钮
+		this.contentEl.style.position = 'relative';
+		const floatingBtn = this.contentEl.createDiv({ cls: 'weread-floating-btn' });
+		setIcon(floatingBtn, 'file-text');
+		floatingBtn.setAttr('aria-label', '查看本地笔记');
+		floatingBtn.addEventListener('click', () => this.openLocalFileInCurrentLeaf());
 	}
 
 	private renderHeader(): void {
@@ -404,13 +436,6 @@ export class WereadBookDetailView extends ItemView {
 			refreshBtn.removeClass('is-spinning');
 			this.render();
 		});
-		if (hasLocal) {
-			const localBtn = bar.createEl('button', { cls: 'weread-book-detail-tab-action' });
-			localBtn.style.marginLeft = '4px';
-			setIcon(localBtn, 'file-text');
-			localBtn.setAttr('title', '打开本地笔记');
-			localBtn.addEventListener('click', () => this.openLocalFileIfExists());
-		}
 	}
 
 	// ── Content Router ──────────────────────────────────────────

--- a/src/components/wereadBookDetailView.ts
+++ b/src/components/wereadBookDetailView.ts
@@ -249,14 +249,13 @@ export class WereadBookDetailView extends ItemView {
 		if (!this.localFilePath) return;
 
 		// 移除旧的悬浮按钮
-		const existingBtn = this.contentEl.querySelector('.weread-floating-btn');
+		const existingBtn = this.containerEl.querySelector('.weread-floating-btn');
 		if (existingBtn) {
 			existingBtn.remove();
 		}
 
-		// 创建新的悬浮按钮
-		this.contentEl.style.position = 'relative';
-		const floatingBtn = this.contentEl.createDiv({ cls: 'weread-floating-btn' });
+		// 创建新的悬浮按钮（使用 containerEl 而不是 contentEl，以便使用 position: fixed）
+		const floatingBtn = this.containerEl.createDiv({ cls: 'weread-floating-btn' });
 		setIcon(floatingBtn, 'file-text');
 		floatingBtn.setAttr('aria-label', '查看本地笔记');
 		floatingBtn.addEventListener('click', () => this.openLocalFileInCurrentLeaf());
@@ -282,7 +281,10 @@ export class WereadBookDetailView extends ItemView {
 		// 右侧描述区：标题、作者、评分、进度、统计、简介
 		const info = topRow.createDiv({ cls: 'weread-book-detail-info' });
 
-		const titleRow = info.createDiv({ cls: 'weread-book-detail-title-row' });
+		// ============ 主要内容（始终显示） ============
+		const infoMain = info.createDiv({ cls: 'weread-book-detail-info-main' });
+
+		const titleRow = infoMain.createDiv({ cls: 'weread-book-detail-title-row' });
 		const titleEl = titleRow.createEl('h2', {
 			text: this.detail?.title || this.bookTitle,
 			cls: 'weread-book-detail-title'
@@ -295,7 +297,7 @@ export class WereadBookDetailView extends ItemView {
 
 		const author = this.detail?.author || '';
 		if (author) {
-			const authorRow = info.createDiv({ cls: 'weread-book-detail-author' });
+			const authorRow = infoMain.createDiv({ cls: 'weread-book-detail-author' });
 			setIcon(authorRow.createSpan(), 'user');
 			authorRow.createSpan({ text: ` ${author}` });
 		}
@@ -303,7 +305,7 @@ export class WereadBookDetailView extends ItemView {
 		// 评分（newRating 需除以 100，保留 1 位小数）
 		if (this.detail?.newRating) {
 			const rating = this.detail.newRating / 100;
-			const ratingRow = info.createDiv({ cls: 'weread-book-detail-rating' });
+			const ratingRow = infoMain.createDiv({ cls: 'weread-book-detail-rating' });
 			setIcon(ratingRow.createSpan({ cls: 'weread-book-detail-rating-icon' }), 'star');
 			for (let i = 1; i <= 5; i++) {
 				const star = ratingRow.createSpan({ cls: 'weread-star' });
@@ -323,10 +325,13 @@ export class WereadBookDetailView extends ItemView {
 			}
 		}
 
+		// ============ 展开内容（始终显示） ============
+		const infoExpand = info.createDiv({ cls: 'weread-book-detail-info-expand' });
+
 		// 阅读进度
 		const progressValue = this.getProgressPercent();
 		if (progressValue !== null) {
-			const progressRow = info.createDiv({ cls: 'weread-book-detail-progress' });
+			const progressRow = infoExpand.createDiv({ cls: 'weread-book-detail-progress' });
 			setIcon(progressRow.createSpan({ cls: 'weread-book-detail-progress-icon' }), 'trending-up');
 			const bar = progressRow.createDiv({ cls: 'weread-book-detail-progress-bar' });
 			bar.createDiv({
@@ -339,44 +344,82 @@ export class WereadBookDetailView extends ItemView {
 		}
 
 		// 元数据行
-		this.renderMetadataRow(info);
-		// 快捷统计 + 本地文件链接
-		const statsRow = info.createDiv({ cls: 'weread-book-detail-stats-row' });
+		const metaRow = infoExpand.createDiv({ cls: 'weread-book-detail-metadata' });
+		const metaHasContent = this.renderMetadataRowContent(metaRow);
+		if (!metaHasContent) {
+			metaRow.remove();
+		}
+
+		// 快捷统计
+		const statsRow = infoExpand.createDiv({ cls: 'weread-book-detail-stats-row' });
 		const highlightCount = this.highlightResp?.updated?.length || 0;
 		const reviewCount = this.reviewResp?.totalCount || 0;
 		const popularCount = this.popularResp?.items?.length || 0;
 
-		this.createStatBadge(statsRow, 'highlighter', `划线 ${highlightCount}`);
-		this.createStatBadge(statsRow, 'pencil', `笔记 ${reviewCount}`);
-		if (popularCount > 0) {
-			this.createStatBadge(statsRow, 'flame', `热门 ${popularCount}`);
+		if (highlightCount > 0 || reviewCount > 0 || popularCount > 0) {
+			this.createStatBadge(statsRow, 'highlighter', `划线 ${highlightCount}`);
+			this.createStatBadge(statsRow, 'pencil', `笔记 ${reviewCount}`);
+			if (popularCount > 0) {
+				this.createStatBadge(statsRow, 'flame', `热门 ${popularCount}`);
+			}
+		} else {
+			statsRow.remove();
 		}
 
-		// 简介（放入 info 右侧描述区，无分割线）
+		// 简介（放入展开区）
 		const intro = this.detail?.intro?.trim();
 		if (intro) {
-			const introText = info.createDiv({
+			const introText = infoExpand.createDiv({
 				cls: 'weread-book-detail-intro-text',
 				text: intro
 			});
 			if (intro.length > 200) {
 				introText.addClass('is-collapsed');
-				const toggleBtn = info.createEl('button', {
-					text: '展开',
-					cls: 'weread-book-detail-intro-toggle'
-				});
-				toggleBtn.addEventListener('click', () => {
-					const collapsed = introText.hasClass('is-collapsed');
-					if (collapsed) {
-						introText.removeClass('is-collapsed');
-						toggleBtn.textContent = '收起';
-					} else {
-						introText.addClass('is-collapsed');
-						toggleBtn.textContent = '展开';
-					}
-				});
 			}
 		}
+	}
+
+	private renderMetadataRowContent(container: HTMLElement): boolean {
+		// 阅读状态
+		const finished = this.progress?.book?.finishTime || this.detail?.finishReading;
+		const isReading = this.progress?.book?.progress && this.progress.book.progress > 0;
+		if (finished) {
+			this.createMetaItem(container, 'check-circle', '已读完', 'weread-book-detail-status-finished');
+		} else if (isReading) {
+			this.createMetaItem(container, 'book-open', '阅读中', 'weread-book-detail-status-reading');
+		}
+
+		// 阅读时长
+		const readingTime = this.progress?.book?.readingTime;
+		if (readingTime && readingTime > 0) {
+			const hours = Math.floor(readingTime / 3600);
+			const mins = Math.floor((readingTime % 3600) / 60);
+			const timeStr = hours > 0 ? `${hours}时${mins}分` : `${mins}分钟`;
+			this.createMetaItem(container, 'clock', `阅读 ${timeStr}`);
+		}
+
+		// 开始阅读日期
+		const startTime = this.progress?.book?.startReadingTime;
+		if (startTime && startTime > 0) {
+			const startDate = new Date(startTime * 1000).toISOString().slice(0, 10);
+			this.createMetaItem(container, 'play-circle', `开始 ${startDate}`);
+		}
+
+		// 读完日期
+		const finishTime = this.progress?.book?.finishTime;
+		if (finishTime && finishTime > 0) {
+			const finishDate = new Date(finishTime * 1000).toISOString().slice(0, 10);
+			this.createMetaItem(container, 'flag', `读完 ${finishDate}`);
+		}
+
+		// 出版社
+		const publisher = this.detail?.publisher;
+		if (publisher) {
+			this.createMetaItem(container, 'building', publisher);
+		}
+
+		// 检查是否有内容
+		return container.children.length > 0;
 	}
 
 	private createStatBadge(container: HTMLElement, icon: string, text: string, clickable = false): void {
@@ -395,14 +438,14 @@ export class WereadBookDetailView extends ItemView {
 
 	private renderTabBar(): void {
 		const bar = this.tabBarEl;
-		const hasLocal = !!this.localFilePath;
 
 		for (const tab of TABS) {
 			const btn = bar.createEl('button', {
 				cls: 'weread-book-detail-tab' + (this.currentTab === tab.id ? ' is-active' : '')
 			});
 			setIcon(btn, tab.icon);
-			btn.createSpan({ text: ` ${tab.label}` });
+			const labelSpan = btn.createSpan({ text: ` ${tab.label}` });
+			labelSpan.addClass('weread-book-detail-tab-label');
 			btn.addEventListener('click', () => {
 				if (this.currentTab === tab.id) return;
 				this.currentTab = tab.id;
@@ -901,67 +944,6 @@ export class WereadBookDetailView extends ItemView {
 		item.setAttr('title', text);
 	}
 
-	private renderMetadataRow(container: HTMLElement): void {
-		const meta = container.createDiv({ cls: 'weread-book-detail-metadata' });
-
-		// 阅读状态
-		const finished = this.progress?.book?.finishTime || this.detail?.finishReading;
-		const isReading = this.progress?.book?.progress && this.progress.book.progress > 0;
-		if (finished) {
-			this.createMetaItem(meta, 'check-circle', '已读完', 'weread-book-detail-status-finished');
-		} else if (isReading) {
-			this.createMetaItem(meta, 'book-open', '阅读中', 'weread-book-detail-status-reading');
-		}
-
-		// 阅读时长
-		const readingTime = this.progress?.book?.readingTime;
-		if (readingTime && readingTime > 0) {
-			const hours = Math.floor(readingTime / 3600);
-			const mins = Math.floor((readingTime % 3600) / 60);
-			const timeStr = hours > 0 ? `${hours}时${mins}分` : `${mins}分钟`;
-			this.createMetaItem(meta, 'clock', `阅读 ${timeStr}`);
-		}
-
-		// 开始阅读日期
-		const startTime = this.progress?.book?.startReadingTime;
-		if (startTime && startTime > 0) {
-			const startDate = new Date(startTime * 1000).toISOString().slice(0, 10);
-			this.createMetaItem(meta, 'play-circle', `开始 ${startDate}`);
-		}
-
-		// 读完日期
-		const finishTime = this.progress?.book?.finishTime;
-		if (finishTime && finishTime > 0) {
-			const finishDate = new Date(finishTime * 1000).toISOString().slice(0, 10);
-			this.createMetaItem(meta, 'flag', `读完 ${finishDate}`);
-		}
-
-		// 出版社
-		const publisher = this.detail?.publisher;
-		if (publisher) {
-			this.createMetaItem(meta, 'building', publisher);
-		}
-
-		// 分类
-		const category = this.detail?.category;
-		if (category) {
-			this.createMetaItem(meta, 'folder', category);
-		}
-
-		// 字数
-		const totalWords = this.detail?.totalWords;
-		if (totalWords && totalWords > 0) {
-			const wordsStr = totalWords >= 10000 ? `${(totalWords / 10000).toFixed(1)}万字` : `${totalWords}字`;
-			this.createMetaItem(meta, 'file-text', `字数 ${wordsStr}`);
-		}
-
-		// 出版时间（仅显示日期）
-		const publishTime = this.detail?.publishTime;
-		if (publishTime) {
-			const pubDate = publishTime.length > 10 ? publishTime.slice(0, 10) : publishTime;
-			this.createMetaItem(meta, 'calendar', `出版 ${pubDate}`);
-		}
-	}
 
 	private getProgressPercent(): number | null {
 		if (this.progress?.book?.progress !== undefined) {

--- a/src/components/wereadBookDetailView.ts
+++ b/src/components/wereadBookDetailView.ts
@@ -1,0 +1,868 @@
+import { ItemView, WorkspaceLeaf, setIcon, Notice, TFile } from 'obsidian';
+import { get } from 'svelte/store';
+import ApiRouter from '../api-router';
+import { settingsStore } from '../settings';
+import { getPcUrl } from '../parser/parseResponse';
+import type {
+	BookDetailResponse,
+	BookProgressResponse,
+	HighlightResponse,
+	BookReviewResponse
+} from '../models';
+
+export const WEREAD_BOOK_DETAIL_VIEW_ID = 'weread-book-detail-view';
+
+const COLOR_MAP: Record<number, { label: string; cssClass: string }> = {
+	1: { label: '黄色', cssClass: 'hl-color-yellow' },
+	2: { label: '蓝色', cssClass: 'hl-color-blue' },
+	3: { label: '绿色', cssClass: 'hl-color-green' },
+	4: { label: '红色', cssClass: 'hl-color-red' },
+	5: { label: '紫色', cssClass: 'hl-color-purple' }
+};
+
+const TABS = [
+	{ id: 'highlights', label: '划线', icon: 'highlighter' },
+	{ id: 'notes', label: '笔记', icon: 'pencil' },
+	{ id: 'popular', label: '热门划线', icon: 'flame' },
+	{ id: 'reviews', label: '书评', icon: 'message-square' }
+] as const;
+
+export class WereadBookDetailView extends ItemView {
+	private apiRouter: ApiRouter;
+
+	private bookId = '';
+	private bookTitle = '';
+	private bookCover = '';
+	private localFilePath = '';
+	private currentTab: string = 'highlights';
+
+	private detail?: BookDetailResponse;
+	private progress?: BookProgressResponse;
+	private highlightResp?: HighlightResponse;
+	private reviewResp?: BookReviewResponse;
+	private popularResp?: { items: any[]; chapters: any[] };
+	private publicReviewResp?: BookReviewResponse;
+
+	private loading = false;
+	private error: string | null = null;
+	private requestBookId = '';
+
+	private headerEl!: HTMLElement;
+	private tabBarEl!: HTMLElement;
+	private contentChildEl!: HTMLElement;
+
+	constructor(leaf: WorkspaceLeaf, apiRouter: ApiRouter) {
+		super(leaf);
+		this.apiRouter = apiRouter;
+	}
+
+	getViewType(): string {
+		return WEREAD_BOOK_DETAIL_VIEW_ID;
+	}
+
+	getDisplayText(): string {
+		return this.bookTitle || '书籍详情';
+	}
+
+	getIcon(): string {
+		return 'book-open';
+	}
+
+	async onOpen(): Promise<void> {
+		this.contentEl.empty();
+		this.contentEl.addClass('weread-book-detail-view');
+
+		this.headerEl = this.contentEl.createDiv({ cls: 'weread-book-detail-header' });
+		this.tabBarEl = this.contentEl.createDiv({ cls: 'weread-book-detail-tabbar' });
+		this.contentChildEl = this.contentEl.createDiv({ cls: 'weread-book-detail-content' });
+	}
+
+	async onClose(): Promise<void> {
+		this.contentEl.empty();
+	}
+
+	getState(): Record<string, unknown> {
+		return {
+			bookId: this.bookId,
+			bookTitle: this.bookTitle,
+			bookCover: this.bookCover,
+			localFilePath: this.localFilePath,
+			currentTab: this.currentTab
+		};
+	}
+
+	async setState(state: Record<string, unknown>, _result: any): Promise<void> {
+		const newBookId = (state.bookId as string) || '';
+		const newTitle = (state.bookTitle as string) || '';
+		const newCover = (state.bookCover as string) || '';
+		const newLocalPath = (state.localFilePath as string) || '';
+		const newTab = (state.currentTab as string) || 'highlights';
+
+		if (newBookId !== this.bookId) {
+			this.bookId = newBookId;
+			this.bookTitle = newTitle;
+			this.bookCover = newCover;
+			this.localFilePath = newLocalPath;
+			this.currentTab = newTab;
+			this.detail = undefined;
+			this.progress = undefined;
+			this.highlightResp = undefined;
+			this.reviewResp = undefined;
+			this.popularResp = undefined;
+			this.publicReviewResp = undefined;
+			this.error = null;
+
+			if (this.bookId) {
+				await this.loadAllData();
+			}
+			this.render();
+		} else if (newTab !== this.currentTab) {
+			this.currentTab = newTab;
+			this.renderContent();
+		}
+
+		super.setState(state, _result);
+	}
+
+	// ── 数据加载 ────────────────────────────────────────────────
+
+	private async loadAllData(): Promise<void> {
+		this.loading = true;
+		this.error = null;
+		this.requestBookId = this.bookId;
+		this.renderLoadingState();
+
+		const [detail, progress, highlights, reviews, popular, publicReviews] =
+			await Promise.allSettled([
+				this.apiRouter.getBook(this.bookId),
+				this.apiRouter.getProgress(this.bookId),
+				this.apiRouter.getNotebookHighlights(this.bookId),
+				this.apiRouter.getNotebookReviews(this.bookId),
+				this.apiRouter.getBestBookmarks(this.bookId),
+				this.apiRouter.getPublicReviews(this.bookId)
+			]);
+
+		if (this.requestBookId !== this.bookId) return;
+
+		this.detail = detail.status === 'fulfilled' ? detail.value : undefined;
+		this.progress = progress.status === 'fulfilled' ? progress.value : undefined;
+		this.highlightResp =
+			highlights.status === 'fulfilled' ? highlights.value : undefined;
+		this.reviewResp = reviews.status === 'fulfilled' ? reviews.value : undefined;
+		this.popularResp = popular.status === 'fulfilled' ? (popular.value as any) : undefined;
+		this.publicReviewResp =
+			publicReviews.status === 'fulfilled' ? publicReviews.value : undefined;
+
+		if (!this.detail && !this.highlightResp && !this.reviewResp) {
+			this.error = '加载失败，请检查网络或 API Key';
+		}
+
+		this.loading = false;
+	}
+
+	// ── 主渲染方法 ──────────────────────────────────────────────
+
+	private render(): void {
+		if (this.loading) {
+			this.renderLoadingState();
+			return;
+		}
+
+		this.headerEl.empty();
+		this.tabBarEl.empty();
+		this.contentChildEl.empty();
+
+		if (!this.bookId) {
+			this.renderEmptyState('点击书籍查看详情');
+			return;
+		}
+
+		if (this.error && !this.detail && !this.highlightResp && !this.reviewResp) {
+			this.renderErrorState();
+			return;
+		}
+
+		this.renderHeader();
+		this.renderTabBar();
+		this.renderContent();
+	}
+
+	private renderLoadingState(): void {
+		this.headerEl.empty();
+		this.tabBarEl.empty();
+		this.contentChildEl.empty();
+		const wrap = this.contentChildEl.createDiv({ cls: 'weread-book-detail-status' });
+		wrap.createDiv({ cls: 'weread-book-detail-loading', text: '正在加载...' });
+	}
+
+	private renderEmptyState(message: string): void {
+		this.headerEl.empty();
+		this.tabBarEl.empty();
+		this.contentChildEl.empty();
+		const wrap = this.contentChildEl.createDiv({ cls: 'weread-book-detail-status' });
+		wrap.createDiv({ cls: 'weread-book-detail-empty', text: message });
+	}
+
+	private renderErrorState(): void {
+		const wrap = this.contentChildEl.createDiv({ cls: 'weread-book-detail-status' });
+		wrap.createDiv({ cls: 'weread-book-detail-error', text: this.error || '加载失败' });
+		const retryBtn = wrap.createEl('button', {
+			text: '重试',
+			cls: 'weread-book-detail-retry-btn'
+		});
+		retryBtn.addEventListener('click', async () => {
+			await this.loadAllData();
+			this.render();
+		});
+	}
+
+	// ── Header ──────────────────────────────────────────────────
+
+	private async openLocalFileIfExists(): Promise<void> {
+		if (!this.localFilePath) return;
+		const file = this.app.vault.getAbstractFileByPath(this.localFilePath);
+		if (file instanceof TFile) {
+			const leaf = this.app.workspace.getLeaf(true);
+			await leaf.openFile(file);
+			this.app.workspace.revealLeaf(leaf);
+		} else {
+			new Notice('本地文件不存在');
+		}
+	}
+
+	private renderHeader(): void {
+		const header = this.headerEl;
+		const hasLocal = !!this.localFilePath;
+
+		// 单行布局：封面在左，所有描述信息在右
+		const topRow = header.createDiv({ cls: 'weread-book-detail-header-top' });
+
+		// 封面
+		const coverSrc = this.detail?.cover || this.bookCover;
+		if (coverSrc) {
+			const coverEl = topRow.createEl('img', {
+				cls: 'weread-book-detail-cover' + (hasLocal ? ' is-clickable' : '')
+			});
+			coverEl.src = coverSrc;
+			coverEl.alt = this.detail?.title || this.bookTitle;
+			if (hasLocal) {
+				coverEl.setAttr('title', '打开本地笔记');
+				coverEl.addEventListener('click', () => this.openLocalFileIfExists());
+			}
+		}
+
+		// 右侧描述区：标题、作者、评分、进度、统计、简介
+		const info = topRow.createDiv({ cls: 'weread-book-detail-info' });
+
+		const titleEl = info.createEl('h2', {
+			text: this.detail?.title || this.bookTitle,
+			cls: 'weread-book-detail-title' + (hasLocal ? ' is-clickable' : '')
+		});
+		if (hasLocal) {
+			titleEl.setAttr('title', '打开本地笔记');
+			titleEl.addEventListener('click', () => this.openLocalFileIfExists());
+		}
+
+		const author = this.detail?.author || '';
+		if (author) {
+			info.createEl('p', {
+				text: author,
+				cls: 'weread-book-detail-author'
+			});
+		}
+
+		// 评分（newRating 需除以 100，保留 1 位小数）
+		if (this.detail?.newRating) {
+			const rating = this.detail.newRating / 100;
+			const ratingRow = info.createDiv({ cls: 'weread-book-detail-rating' });
+			for (let i = 1; i <= 5; i++) {
+				const star = ratingRow.createSpan({ cls: 'weread-star' });
+				if (i <= Math.round(rating / 2)) {
+					star.addClass('is-filled');
+				}
+			}
+			ratingRow.createSpan({
+				text: ` ${rating.toFixed(1)}`,
+				cls: 'weread-book-detail-rating-value'
+			});
+			if (this.detail.newRatingCount) {
+				ratingRow.createSpan({
+					text: ` (${this.detail.newRatingCount}人)`,
+					cls: 'weread-book-detail-rating-count'
+				});
+			}
+		}
+
+		// 阅读进度
+		const progressValue = this.getProgressPercent();
+		if (progressValue !== null) {
+			const progressRow = info.createDiv({ cls: 'weread-book-detail-progress' });
+			const bar = progressRow.createDiv({ cls: 'weread-book-detail-progress-bar' });
+			bar.createDiv({
+				cls: 'weread-book-detail-progress-fill'
+			}).style.width = `${progressValue}%`;
+			progressRow.createSpan({
+				text: ` ${progressValue}%`,
+				cls: 'weread-book-detail-progress-text'
+			});
+		}
+
+		// 快捷统计 + 本地文件链接
+		const statsRow = info.createDiv({ cls: 'weread-book-detail-stats-row' });
+		const highlightCount = this.highlightResp?.updated?.length || 0;
+		const reviewCount = this.reviewResp?.totalCount || 0;
+		const popularCount = this.popularResp?.items?.length || 0;
+
+		this.createStatBadge(statsRow, 'highlighter', `划线 ${highlightCount}`);
+		this.createStatBadge(statsRow, 'pencil', `笔记 ${reviewCount}`);
+		if (popularCount > 0) {
+			this.createStatBadge(statsRow, 'flame', `热门 ${popularCount}`);
+		}
+		if (hasLocal) {
+			this.createStatBadge(statsRow, 'file-text', '本地笔记', true);
+		}
+
+		// 简介（放入 info 右侧描述区，无分割线）
+		const intro = this.detail?.intro?.trim();
+		if (intro) {
+			const introText = info.createDiv({
+				cls: 'weread-book-detail-intro-text',
+				text: intro
+			});
+			if (intro.length > 200) {
+				introText.addClass('is-collapsed');
+				const toggleBtn = info.createEl('button', {
+					text: '展开',
+					cls: 'weread-book-detail-intro-toggle'
+				});
+				toggleBtn.addEventListener('click', () => {
+					const collapsed = introText.hasClass('is-collapsed');
+					if (collapsed) {
+						introText.removeClass('is-collapsed');
+						toggleBtn.textContent = '收起';
+					} else {
+						introText.addClass('is-collapsed');
+						toggleBtn.textContent = '展开';
+					}
+				});
+			}
+		}
+	}
+
+	private createStatBadge(container: HTMLElement, icon: string, text: string, clickable = false): void {
+		const badge = container.createDiv({
+			cls: 'weread-book-detail-stat' + (clickable ? ' is-clickable' : '')
+		});
+		setIcon(badge.createSpan(), icon);
+		badge.createSpan({ text: ` ${text}` });
+		if (clickable) {
+			badge.setAttr('title', '打开本地笔记');
+			badge.addEventListener('click', () => this.openLocalFileIfExists());
+		}
+	}
+
+	// ── Tab Bar ─────────────────────────────────────────────────
+
+	private renderTabBar(): void {
+		const bar = this.tabBarEl;
+		for (const tab of TABS) {
+			const btn = bar.createEl('button', {
+				cls: 'weread-book-detail-tab' + (this.currentTab === tab.id ? ' is-active' : '')
+			});
+			setIcon(btn, tab.icon);
+			btn.createSpan({ text: ` ${tab.label}` });
+			btn.addEventListener('click', () => {
+				if (this.currentTab === tab.id) return;
+				this.currentTab = tab.id;
+				bar.querySelectorAll('.weread-book-detail-tab').forEach((b) =>
+					b.removeClass('is-active')
+				);
+				btn.addClass('is-active');
+				this.renderContent();
+			});
+		}
+
+		// 弹性空间 + 阅读按钮 + 刷新按钮
+		bar.createDiv({ cls: 'weread-book-detail-tabbar-spacer' });
+		const readBtn = bar.createEl('button', { cls: 'weread-book-detail-tab-action' });
+		setIcon(readBtn, 'book-open');
+		readBtn.setAttr('title', '在微信读书中打开');
+		readBtn.addEventListener('click', () => {
+			const settings = get(settingsStore);
+			const url = settings.bookOpenMode === 'app'
+				? `weread://reading?bId=${this.bookId}`
+				: getPcUrl(this.bookId);
+			window.open(url);
+		});
+		const refreshBtn = bar.createEl('button', { cls: 'weread-book-detail-tab-action' });
+			refreshBtn.style.marginLeft = '4px';
+		setIcon(refreshBtn, 'refresh-ccw');
+		refreshBtn.setAttr('title', '刷新数据');
+		refreshBtn.addEventListener('click', async () => {
+			refreshBtn.addClass('is-spinning');
+			await this.loadAllData();
+			refreshBtn.removeClass('is-spinning');
+			this.render();
+		});
+	}
+
+	// ── Content Router ──────────────────────────────────────────
+
+	private renderContent(): void {
+		this.contentChildEl.empty();
+		switch (this.currentTab) {
+			case 'highlights':
+				this.renderHighlightsTab();
+				break;
+			case 'notes':
+				this.renderNotesTab();
+				break;
+			case 'popular':
+				this.renderPopularTab();
+				break;
+			case 'reviews':
+				this.renderReviewsTab();
+				break;
+		}
+	}
+
+	// ── 划线标签页 ───────────────────────────────────────────────
+
+	private renderHighlightsTab(): void {
+		const container = this.contentChildEl;
+		const highlights = this.highlightResp?.updated || [];
+		const chapters = this.highlightResp?.chapters || [];
+
+
+		if (highlights.length === 0) {
+			container.createDiv({
+				text: '暂无划线',
+				cls: 'weread-book-detail-empty'
+			});
+			return;
+		}
+
+		// 构建章节顺序映射：chapterUid → { title, chapterIdx }
+		const chapterInfoMap = new Map<number, { title: string; chapterIdx: number }>();
+		for (const ch of chapters) {
+			if (ch.chapterUid !== undefined) {
+				chapterInfoMap.set(ch.chapterUid, {
+					title: ch.title,
+					chapterIdx: ch.chapterIdx
+				});
+			}
+		}
+
+		// 按 chapterUid 分组，组内按 range 起始位置排序
+		const groupedMap = new Map<number, typeof highlights>();
+		for (const h of highlights) {
+			if (!groupedMap.has(h.chapterUid)) {
+				groupedMap.set(h.chapterUid, []);
+			}
+			groupedMap.get(h.chapterUid)!.push(h);
+		}
+
+		// 每个 chapterUid 组内按 range 起始位置排序
+		for (const [, items] of groupedMap) {
+			items.sort((a, b) => {
+				const aStart = parseInt(a.range?.split('-')[0] || '0', 10);
+				const bStart = parseInt(b.range?.split('-')[0] || '0', 10);
+				return aStart - bStart;
+			});
+		}
+
+		// 按 chapterIdx 排序章节
+		const sortedEntries = [...groupedMap.entries()].sort((a, b) => {
+			const aIdx = chapterInfoMap.get(a[0])?.chapterIdx ?? Number.MAX_SAFE_INTEGER;
+			const bIdx = chapterInfoMap.get(b[0])?.chapterIdx ?? Number.MAX_SAFE_INTEGER;
+			return aIdx - bIdx;
+		});
+
+		for (const [chapterUid, items] of sortedEntries) {
+			const chInfo = chapterInfoMap.get(chapterUid);
+			const chapterTitle = chInfo?.title || '未知章节';
+			const section = container.createDiv({ cls: 'weread-book-detail-section' });
+			section.createEl('h3', {
+				text: chapterTitle,
+				cls: 'weread-book-detail-section-title'
+			});
+
+			for (const h of items) {
+				const colorInfo = COLOR_MAP[h.colorStyle] || COLOR_MAP[1];
+				const card = section.createDiv({
+					cls: `weread-book-detail-hl-card ${colorInfo.cssClass}`
+				});
+
+				// 划线文本，左侧有颜色边线
+				const quoteRow = card.createDiv({ cls: 'weread-book-detail-hl-quote' });
+				quoteRow.createDiv({
+					text: h.markText,
+					cls: 'weread-book-detail-hl-text'
+				});
+
+				// 元信息行
+				const meta = card.createDiv({ cls: 'weread-book-detail-hl-meta' });
+
+				const rangeStart = h.range ? h.range.split('-')[0] : '';
+				if (rangeStart) {
+					meta.createSpan({
+						text: `位置 ${rangeStart}`,
+						cls: 'weread-book-detail-hl-meta-item'
+					});
+				}
+
+				if (h.createTime) {
+					meta.createSpan({
+						text: this.formatDateTime(h.createTime),
+						cls: 'weread-book-detail-hl-meta-item'
+					});
+				}
+
+				// 笔记指示器
+				if (h.contextAbstract) {
+					const noteIndicator = meta.createSpan({ cls: 'weread-book-detail-hl-note' });
+					setIcon(noteIndicator, 'pencil');
+					noteIndicator.setAttr('title', h.contextAbstract);
+				}
+
+				// 操作按钮（inline 在 meta 行右侧）
+				const actions = meta.createDiv({ cls: 'weread-book-detail-hl-actions' });
+				this.createDeepLinkButton(actions, this.buildDeepLink(h.chapterUid, h.range));
+				this.createCopyButton(actions, h.markText);
+			}
+		}
+	}
+
+	// ── 笔记标签页 ───────────────────────────────────────────────
+
+	private renderNotesTab(): void {
+		const container = this.contentChildEl;
+		const reviews = this.reviewResp?.reviews || [];
+
+		if (reviews.length === 0) {
+			container.createDiv({
+				text: '暂无笔记',
+				cls: 'weread-book-detail-empty'
+			});
+			return;
+		}
+
+		const chapters = this.highlightResp?.chapters || [];
+		const chapterInfoMap = new Map<number, { title: string; chapterIdx: number }>();
+		for (const ch of chapters) {
+			if (ch.chapterUid !== undefined) {
+				chapterInfoMap.set(ch.chapterUid, {
+					title: ch.title,
+					chapterIdx: ch.chapterIdx
+				});
+			}
+		}
+
+		// 按时间倒序排列
+		const sortedReviews = [...reviews].sort((a, b) => {
+			return (b.review?.createTime || 0) - (a.review?.createTime || 0);
+		});
+
+		for (const r of sortedReviews) {
+			const card = container.createDiv({ cls: 'weread-book-detail-note-card' });
+
+			// 引用的原文
+			const abstract = r.review?.abstract;
+			if (abstract) {
+				const ref = card.createDiv({ cls: 'weread-book-detail-note-ref' });
+				setIcon(ref.createSpan({ cls: 'weread-book-detail-note-ref-icon' }), 'quote');
+				ref.createSpan({
+					text: abstract,
+					cls: 'weread-book-detail-note-ref-text'
+				});
+			}
+
+			// 笔记内容
+			const content = r.review?.content;
+			if (content) {
+				card.createDiv({
+					text: content,
+					cls: 'weread-book-detail-note-content'
+				});
+			}
+
+			// 元信息
+			const meta = card.createDiv({ cls: 'weread-book-detail-note-meta' });
+			const chTitle =
+				r.review?.chapterName ||
+				(r.review?.chapterUid
+					? chapterInfoMap.get(r.review.chapterUid)?.title
+					: undefined);
+			if (chTitle) {
+				meta.createSpan({
+					text: chTitle,
+					cls: 'weread-book-detail-hl-meta-item'
+				});
+			}
+			if (r.review?.createTime) {
+				meta.createSpan({
+					text: this.formatDateTime(r.review.createTime),
+					cls: 'weread-book-detail-hl-meta-item'
+				});
+			}
+			if (r.review?.range) {
+				const rangeStart = r.review.range.split('-')[0];
+				meta.createSpan({
+					text: `位置 ${rangeStart}`,
+					cls: 'weread-book-detail-hl-meta-item'
+				});
+			}
+		}
+	}
+
+	// ── 热门划线标签页 ───────────────────────────────────────────
+
+	private renderPopularTab(): void {
+		const container = this.contentChildEl;
+		const items = this.popularResp?.items || [];
+		const chapters = this.popularResp?.chapters || [];
+
+		if (items.length === 0) {
+			container.createDiv({
+				text: '暂无热门划线',
+				cls: 'weread-book-detail-empty'
+			});
+			return;
+		}
+
+		// 构建章节顺序映射
+		const chapterInfoMap = new Map<number, { title: string; chapterIdx: number }>();
+		for (const ch of chapters) {
+			if (ch.chapterUid !== undefined) {
+				chapterInfoMap.set(ch.chapterUid, {
+					title: ch.title,
+					chapterIdx: ch.chapterIdx
+				});
+			}
+		}
+
+		// 按 chapterUid 分组
+		const groupedMap = new Map<number, typeof items>();
+		for (const item of items) {
+			if (!groupedMap.has(item.chapterUid)) {
+				groupedMap.set(item.chapterUid, []);
+			}
+			groupedMap.get(item.chapterUid)!.push(item);
+		}
+
+		// 组内按 range 排序
+		for (const [, chapterItems] of groupedMap) {
+			chapterItems.sort((a, b) => {
+				const aStart = parseInt(a.range?.split('-')[0] || '0', 10);
+				const bStart = parseInt(b.range?.split('-')[0] || '0', 10);
+				return aStart - bStart;
+			});
+		}
+
+		// 按 chapterIdx 排序章节
+		const sortedEntries = [...groupedMap.entries()].sort((a, b) => {
+			const aIdx = chapterInfoMap.get(a[0])?.chapterIdx ?? Number.MAX_SAFE_INTEGER;
+			const bIdx = chapterInfoMap.get(b[0])?.chapterIdx ?? Number.MAX_SAFE_INTEGER;
+			return aIdx - bIdx;
+		});
+
+		for (const [chapterUid, chapterItems] of sortedEntries) {
+			const chInfo = chapterInfoMap.get(chapterUid);
+			const chapterTitle = chInfo?.title || '未知章节';
+			const section = container.createDiv({ cls: 'weread-book-detail-section' });
+			section.createEl('h3', {
+				text: chapterTitle,
+				cls: 'weread-book-detail-section-title'
+			});
+
+			for (const h of chapterItems) {
+				const card = section.createDiv({ cls: 'weread-book-detail-popular-card' });
+
+				card.createDiv({
+					text: h.markText,
+					cls: 'weread-book-detail-popular-text'
+				});
+
+				const meta = card.createDiv({ cls: 'weread-book-detail-popular-meta' });
+
+				if (h.totalCount > 0) {
+					const countBadge = meta.createSpan({
+						cls: 'weread-book-detail-popular-count'
+					});
+					setIcon(countBadge, 'flame');
+					countBadge.createSpan({
+						text: ` ${h.totalCount}人划线`
+					});
+				}
+
+				const rangeStart = h.range ? h.range.split('-')[0] : '';
+				if (rangeStart) {
+					meta.createSpan({
+						text: `位置 ${rangeStart}`,
+						cls: 'weread-book-detail-hl-meta-item'
+					});
+				}
+
+				// 操作按钮（inline 在 meta 行右侧）
+				const actions = meta.createDiv({ cls: 'weread-book-detail-hl-actions' });
+				this.createDeepLinkButton(actions, this.buildDeepLink(h.chapterUid, h.range));
+				this.createCopyButton(actions, h.markText);
+			}
+		}
+	}
+
+	// ── 书评标签页 ───────────────────────────────────────────────
+
+	private static readonly MAX_PUBLIC_REVIEWS = 20;
+
+	private renderReviewsTab(): void {
+		const container = this.contentChildEl;
+
+		// 收集我自己的书评（type 4 = 整本书评）
+		const myBookReviews =
+			this.reviewResp?.reviews?.filter((r) => r.review?.type === 4) || [];
+
+		// 公共书评
+		const allPublicReviews = this.publicReviewResp?.reviews || [];
+
+		if (myBookReviews.length === 0 && allPublicReviews.length === 0) {
+			container.createDiv({
+				text: '暂无书评',
+				cls: 'weread-book-detail-empty'
+			});
+			return;
+		}
+
+		// 先渲染我的书评
+		if (myBookReviews.length > 0) {
+			const mySection = container.createDiv({ cls: 'weread-book-detail-section' });
+			mySection.createEl('h3', {
+				text: '我的书评',
+				cls: 'weread-book-detail-section-title'
+			});
+			for (const r of myBookReviews) {
+				this.renderSingleReviewCard(mySection, r);
+			}
+		}
+
+		// 再渲染公共书评（限制数量）
+		if (allPublicReviews.length > 0) {
+			const pubSection = container.createDiv({ cls: 'weread-book-detail-section' });
+			const header = pubSection.createEl('h3', {
+				cls: 'weread-book-detail-section-title'
+			});
+			const visibleReviews = allPublicReviews.slice(0, WereadBookDetailView.MAX_PUBLIC_REVIEWS);
+			const remaining = allPublicReviews.length - visibleReviews.length;
+			header.setText(
+				remaining > 0
+					? `社区书评（显示前 ${visibleReviews.length} 条，共 ${allPublicReviews.length} 条）`
+					: `社区书评（${allPublicReviews.length} 条）`
+			);
+
+			// 输出第一条公共书评的原始结构供调试
+			if (allPublicReviews.length > 0) {
+				console.log('[weread plugin] 公共书评第一条原始结构:', JSON.stringify(allPublicReviews[0], null, 2));
+			}
+
+			for (const r of visibleReviews) {
+				this.renderSingleReviewCard(pubSection, r);
+			}
+		}
+	}
+
+	private renderSingleReviewCard(container: HTMLElement, r: any): void {
+		const card = container.createDiv({ cls: 'weread-book-detail-review-card' });
+
+		// 公共书评为双层嵌套 r.review.review，个人书评为单层 r.review
+		// 统一用内层 review 数据
+		const innerReview = r.review?.review || r.review || r;
+		const authorName = innerReview?.author?.name || '匿名用户';
+		const avatar = innerReview?.author?.avatar;
+		const createTime = innerReview?.createTime;
+		const title = innerReview?.title;
+		const content = innerReview?.content;
+
+		// 作者行
+		const authorRow = card.createDiv({ cls: 'weread-book-detail-review-author' });
+		if (avatar) {
+			const avatarEl = authorRow.createEl('img', {
+				cls: 'weread-book-detail-review-avatar'
+			});
+			avatarEl.src = avatar;
+		}
+		const authorInfo = authorRow.createDiv({ cls: 'weread-book-detail-review-author-info' });
+		authorInfo.createSpan({
+			text: authorName,
+			cls: 'weread-book-detail-review-author-name'
+		});
+		if (createTime) {
+			authorInfo.createSpan({
+				text: this.formatDateTime(createTime),
+				cls: 'weread-book-detail-review-time'
+			});
+		}
+
+		// 标题
+		if (title) {
+			card.createDiv({
+				text: title,
+				cls: 'weread-book-detail-review-title'
+			});
+		}
+
+		// 内容
+		if (content) {
+			card.createDiv({
+				text: content,
+				cls: 'weread-book-detail-review-content'
+			});
+		}
+
+		// 复制按钮
+		if (content) {
+			const actions = card.createDiv({ cls: 'weread-book-detail-actions' });
+			this.createCopyButton(actions, content);
+		}
+	}
+
+	// ── 辅助方法 ────────────────────────────────────────────────
+
+	private buildDeepLink(chapterUid: number, range: string): string {
+		const [start, end] = range.split('-');
+		return `weread://bestbookmark?bookId=${this.bookId}&chapterUid=${chapterUid}&rangeStart=${start}&rangeEnd=${end || start}`;
+	}
+
+	private createCopyButton(container: HTMLElement, text: string): void {
+		const btn = container.createEl('button', { cls: 'weread-book-detail-action-btn' });
+		setIcon(btn, 'copy');
+		btn.setAttr('title', '复制');
+		btn.addEventListener('click', (e) => {
+			e.stopPropagation();
+			navigator.clipboard.writeText(text).then(() => {
+				new Notice('已复制');
+			});
+		});
+	}
+
+	private createDeepLinkButton(container: HTMLElement, deepLink: string): void {
+		const btn = container.createEl('button', { cls: 'weread-book-detail-action-btn' });
+		setIcon(btn, 'external-link');
+		btn.setAttr('title', '跳转到微信读书');
+		btn.addEventListener('click', (e) => {
+			e.stopPropagation();
+			window.open(deepLink, '_blank');
+		});
+	}
+
+	private formatDateTime(ts: number): string {
+		if (!ts) return '';
+		return window.moment(ts * 1000).format('YYYY-MM-DD HH:mm');
+	}
+
+	private getProgressPercent(): number | null {
+		if (this.progress?.book?.progress !== undefined) {
+			return this.progress.book.progress;
+		}
+		return null;
+	}
+}

--- a/src/components/wereadBookDetailView.ts
+++ b/src/components/wereadBookDetailView.ts
@@ -241,26 +241,28 @@ export class WereadBookDetailView extends ItemView {
 		const coverSrc = this.detail?.cover || this.bookCover;
 		if (coverSrc) {
 			const coverEl = topRow.createEl('img', {
-				cls: 'weread-book-detail-cover' + (hasLocal ? ' is-clickable' : '')
+				cls: 'weread-book-detail-cover'
 			});
 			coverEl.src = coverSrc;
 			coverEl.alt = this.detail?.title || this.bookTitle;
-			if (hasLocal) {
-				coverEl.setAttr('title', '打开本地笔记');
-				coverEl.addEventListener('click', () => this.openLocalFileIfExists());
-			}
 		}
 
 		// 右侧描述区：标题、作者、评分、进度、统计、简介
 		const info = topRow.createDiv({ cls: 'weread-book-detail-info' });
 
-		const titleEl = info.createEl('h2', {
+		const titleRow = info.createDiv({ cls: 'weread-book-detail-title-row' });
+		titleRow.createEl('h2', {
 			text: this.detail?.title || this.bookTitle,
-			cls: 'weread-book-detail-title' + (hasLocal ? ' is-clickable' : '')
+			cls: 'weread-book-detail-title'
 		});
 		if (hasLocal) {
-			titleEl.setAttr('title', '打开本地笔记');
-			titleEl.addEventListener('click', () => this.openLocalFileIfExists());
+			const localBtn = titleRow.createEl('button', { cls: 'weread-book-detail-action-btn' });
+			setIcon(localBtn, 'file-text');
+			localBtn.setAttr('title', '打开本地笔记');
+			localBtn.addEventListener('click', (e) => {
+				e.stopPropagation();
+				this.openLocalFileIfExists();
+			});
 		}
 
 		const author = this.detail?.author || '';
@@ -320,9 +322,6 @@ export class WereadBookDetailView extends ItemView {
 		this.createStatBadge(statsRow, 'pencil', `笔记 ${reviewCount}`);
 		if (popularCount > 0) {
 			this.createStatBadge(statsRow, 'flame', `热门 ${popularCount}`);
-		}
-		if (hasLocal) {
-			this.createStatBadge(statsRow, 'file-text', '本地笔记', true);
 		}
 
 		// 简介（放入 info 右侧描述区，无分割线）

--- a/src/components/wereadBookshelf.ts
+++ b/src/components/wereadBookshelf.ts
@@ -13,7 +13,6 @@ import {
 import WereadPlugin from '../../main';
 import WereadBookshelfService from '../bookshelf';
 import type { BookshelfBook } from '../models';
-import { WereadBookDetailModal } from './wereadBookDetailModal';
 import { SyncLogModal } from './syncLogModal';
 import { settingsStore } from '../settings';
 import { get } from 'svelte/store';
@@ -829,16 +828,8 @@ export class WereadBookshelfView extends ItemView {
 	}
 
 	private openBookDetail(book: BookshelfBook): void {
-		new WereadBookDetailModal(
-			this.app,
-			book,
-			async () => {
-				await this.openLocalFile(book);
-			},
-			async (url: string) => {
-				await this.plugin.openPreferredReadingView(url);
-			}
-		).open();
+		const localPath = book.localFile?.file?.path || '';
+		this.plugin.activateBookDetailView(book.bookId, book.title, book.cover, localPath);
 	}
 
 	private async openLocalFile(book: BookshelfBook): Promise<void> {

--- a/src/components/wereadBookshelf.ts
+++ b/src/components/wereadBookshelf.ts
@@ -94,8 +94,9 @@ export class WereadBookshelfView extends ItemView {
 		private bookshelfService: WereadBookshelfService
 	) {
 		super(leaf);
-		this.previousCookieValid = get(settingsStore).isCookieValid;
-		this.previousApiKey = get(settingsStore).wereadApiKey;
+		const settings = get(settingsStore);
+		this.previousCookieValid = settings.isCookieValid;
+		this.previousApiKey = settings.wereadApiKey;
 	}
 
 	getViewType(): string {
@@ -160,21 +161,28 @@ export class WereadBookshelfView extends ItemView {
 			cls: 'weread-bookshelf-filter-dropdowns'
 		});
 
-		const categorySelect = filterDropdowns.createEl('select', {
-			cls: 'dropdown',
-			attr: { 'aria-label': '筛选书籍类型' }
-		});
-		[
-			['all', '全部类型'],
-			['book', '图书'],
-			['article', '公众号']
-		].forEach(([value, label]) => {
-			categorySelect.createEl('option', { value, text: label });
-		});
-		categorySelect.onchange = () => {
-			this.categoryFilter = categorySelect.value as CategoryFilter;
-			this.renderBooks();
-		};
+		const saveArticleToggle = get(settingsStore).saveArticleToggle;
+		// 只有开启公众号同步时才显示类型筛选下拉框
+		if (saveArticleToggle) {
+			const categorySelect = filterDropdowns.createEl('select', {
+				cls: 'dropdown',
+				attr: { 'aria-label': '筛选书籍类型' }
+			});
+			[
+				['all', '全部类型'],
+				['book', '图书'],
+				['article', '公众号']
+			].forEach(([value, label]) => {
+				categorySelect.createEl('option', { value, text: label });
+			});
+			categorySelect.onchange = () => {
+				this.categoryFilter = categorySelect.value as CategoryFilter;
+				this.renderBooks();
+			};
+		} else {
+			// 关闭公众号同步时，自动过滤掉公众号，只显示图书
+			this.categoryFilter = 'book';
+		}
 
 		const syncStatusSelect = filterDropdowns.createEl('select', {
 			cls: 'dropdown',
@@ -701,12 +709,18 @@ export class WereadBookshelfView extends ItemView {
 
 	private getFilteredBooks(): BookshelfBook[] {
 		const keyword = this.searchKeyword;
+		const saveArticleToggle = get(settingsStore).saveArticleToggle;
 		return [...this.shelfBooks]
 			.filter((book) => {
 				const searchMatched =
 					keyword.length === 0 ||
 					`${book.title} ${book.author}`.toLowerCase().includes(keyword);
 				if (!searchMatched) {
+					return false;
+				}
+
+				// 如果关闭了公众号同步，自动过滤掉公众号书籍
+				if (!saveArticleToggle && book.isArticle) {
 					return false;
 				}
 

--- a/src/components/wereadBookshelf.ts
+++ b/src/components/wereadBookshelf.ts
@@ -87,6 +87,7 @@ export class WereadBookshelfView extends ItemView {
 	private gridEl: HTMLElement;
 	private settingsUnsubscribe: (() => void) | null = null;
 	private previousCookieValid = false;
+	private previousApiKey: string | undefined;
 
 	constructor(
 		leaf: WorkspaceLeaf,
@@ -95,6 +96,7 @@ export class WereadBookshelfView extends ItemView {
 	) {
 		super(leaf);
 		this.previousCookieValid = get(settingsStore).isCookieValid;
+		this.previousApiKey = get(settingsStore).wereadApiKey;
 	}
 
 	getViewType(): string {
@@ -319,12 +321,17 @@ export class WereadBookshelfView extends ItemView {
 			userAvatarBtn.empty();
 
 			if (settings.isCookieValid && settings.userAvatar) {
-				// Logged in - show avatar image
+				// Cookie 登录 - show avatar image
 				userAvatarBtn.removeClass('is-unlogged');
 				const img = userAvatarBtn.createEl('img');
 				img.src = settings.userAvatar;
 				img.alt = 'User Avatar';
 				setTooltip(userAvatarBtn, settings.user || '用户头像');
+			} else if (settings.wereadApiKey) {
+				// API Key 登录 - show key icon
+				userAvatarBtn.removeClass('is-unlogged');
+				setIcon(userAvatarBtn, 'key');
+				setTooltip(userAvatarBtn, 'API Key 已连接');
 			} else {
 				// Not logged in - show login icon
 				userAvatarBtn.addClass('is-unlogged');
@@ -345,8 +352,11 @@ export class WereadBookshelfView extends ItemView {
 		userAvatarBtn.addEventListener('click', (event) => {
 			const settings = get(settingsStore);
 			if (settings.isCookieValid && settings.userAvatar) {
-				// Logged in - show right-click menu
+				// Cookie 登录 - show user menu
 				this.showUserMenu(event as MouseEvent);
+			} else if (settings.wereadApiKey) {
+				// API Key 登录 - show config hint
+				new Notice('当前使用 API Key 连接，用户信息可在设置中管理');
 			} else {
 				// Not logged in - open login QR
 				this.openLoginQR();
@@ -411,8 +421,11 @@ export class WereadBookshelfView extends ItemView {
 
 		// 订阅设置变化，监听登录状态改变
 		this.settingsUnsubscribe = settingsStore.subscribe((settings) => {
-			if (settings.isCookieValid !== this.previousCookieValid) {
+			const cookieChanged = settings.isCookieValid !== this.previousCookieValid;
+			const apiKeyChanged = settings.wereadApiKey !== this.previousApiKey;
+			if (cookieChanged || apiKeyChanged) {
 				this.previousCookieValid = settings.isCookieValid;
+				this.previousApiKey = settings.wereadApiKey;
 				this.loadBookshelf();
 			}
 		});
@@ -439,7 +452,9 @@ export class WereadBookshelfView extends ItemView {
 
 		// Check if user is logged in
 		const settings = get(settingsStore);
-		if (!settings.isCookieValid || settings.cookies.length === 0) {
+		const hasApiKey = Boolean(settings.wereadApiKey);
+		const hasCookie = settings.isCookieValid && settings.cookies.length > 0;
+		if (!hasCookie && !hasApiKey) {
 			this.loading = false;
 			this.renderUnloggedState();
 			return;

--- a/src/components/wereadBookshelf.ts
+++ b/src/components/wereadBookshelf.ts
@@ -829,7 +829,7 @@ export class WereadBookshelfView extends ItemView {
 
 	private openBookDetail(book: BookshelfBook): void {
 		const localPath = book.localFile?.file?.path || '';
-		this.plugin.activateBookDetailView(book.bookId, book.title, book.cover, localPath);
+		this.plugin.activateBookDetailView(book.bookId, book.title, book.cover, localPath, this.leaf);
 	}
 
 	private async openLocalFile(book: BookshelfBook): Promise<void> {

--- a/src/components/wereadBookshelf.ts
+++ b/src/components/wereadBookshelf.ts
@@ -554,10 +554,10 @@ export class WereadBookshelfView extends ItemView {
 			cls: `weread-bookshelf-card-cover-wrap${book.hasLocalFile ? ' is-clickable' : ''}`
 		});
 		if (book.hasLocalFile) {
-			coverWrap.setAttr('title', `打开《${book.title}》本地文件`);
+			coverWrap.setAttr('title', `查看《${book.title}》详情`);
 			coverWrap.onclick = async (event) => {
 				event.stopPropagation();
-				await this.openLocalFile(book);
+				this.openBookDetail(book);
 			};
 		}
 		if (book.cover) {
@@ -829,7 +829,7 @@ export class WereadBookshelfView extends ItemView {
 
 	private openBookDetail(book: BookshelfBook): void {
 		const localPath = book.localFile?.file?.path || '';
-		this.plugin.activateBookDetailView(book.bookId, book.title, book.cover, localPath, this.leaf);
+		this.plugin.activateBookDetailView(book.bookId, book.title, book.cover, localPath);
 	}
 
 	private async openLocalFile(book: BookshelfBook): Promise<void> {

--- a/src/components/wereadBookshelf.ts
+++ b/src/components/wereadBookshelf.ts
@@ -309,63 +309,6 @@ export class WereadBookshelfView extends ItemView {
 		});
 		setIcon(syncOptionsButton, 'settings');
 
-		// Create user avatar button
-		const userAvatarBtn = toolbarActions.createEl('button', {
-			cls: 'weread-bookshelf-user-avatar-btn',
-			attr: { 'aria-label': '用户头像' }
-		});
-
-		// Update avatar button based on login state
-		const updateAvatarButton = () => {
-			const settings = get(settingsStore);
-			userAvatarBtn.empty();
-
-			if (settings.isCookieValid && settings.userAvatar) {
-				// Cookie 登录 - show avatar image
-				userAvatarBtn.removeClass('is-unlogged');
-				const img = userAvatarBtn.createEl('img');
-				img.src = settings.userAvatar;
-				img.alt = 'User Avatar';
-				setTooltip(userAvatarBtn, settings.user || '用户头像');
-			} else if (settings.wereadApiKey) {
-				// API Key 登录 - show key icon
-				userAvatarBtn.removeClass('is-unlogged');
-				setIcon(userAvatarBtn, 'key');
-				setTooltip(userAvatarBtn, 'API Key 已连接');
-			} else {
-				// Not logged in - show login icon
-				userAvatarBtn.addClass('is-unlogged');
-				setIcon(userAvatarBtn, 'lock');
-				setTooltip(userAvatarBtn, '点击登录');
-			}
-		};
-
-		// Initial avatar button state
-		updateAvatarButton();
-
-		// Subscribe to settings changes to update avatar
-		const unsubscribeSettings = settingsStore.subscribe(() => {
-			updateAvatarButton();
-		});
-
-		// Avatar button click handler
-		userAvatarBtn.addEventListener('click', (event) => {
-			const settings = get(settingsStore);
-			if (settings.isCookieValid && settings.userAvatar) {
-				// Cookie 登录 - show user menu
-				this.showUserMenu(event as MouseEvent);
-			} else if (settings.wereadApiKey) {
-				// API Key 登录 - show config hint
-				new Notice('当前使用 API Key 连接，用户信息可在设置中管理');
-			} else {
-				// Not logged in - open login QR
-				this.openLoginQR();
-			}
-		});
-
-		// Store unsubscribe function for cleanup
-		(userAvatarBtn as any)._unsubscribe = unsubscribeSettings;
-
 		syncButton.onclick = async () => {
 			if (isSyncing) return;
 			const force = isAltPressed;
@@ -482,18 +425,18 @@ export class WereadBookshelfView extends ItemView {
 		const card = this.summaryEl.createDiv({ cls: 'weread-bookshelf-unlogged-card' });
 
 		const content = card.createDiv({ cls: 'weread-bookshelf-unlogged-content' });
-		content.createDiv({ cls: 'weread-bookshelf-unlogged-title', text: '请先登录' });
+		content.createDiv({ cls: 'weread-bookshelf-unlogged-title', text: '请先设置 API Key' });
 		content.createDiv({
 			cls: 'weread-bookshelf-unlogged-description',
-			text: '请在设置中登录后开始使用'
+			text: '请点击右上角设置按钮配置 API Key'
 		});
 
 		const button = content.createEl('button', {
 			cls: 'weread-bookshelf-unlogged-button',
-			text: '前往登录'
+			text: '前往设置'
 		});
 		button.onclick = () => {
-			this.openLoginQR();
+			this.plugin.openWereadSettingsTab();
 		};
 	}
 
@@ -906,219 +849,5 @@ export class WereadBookshelfView extends ItemView {
 		const leaf = this.app.workspace.getLeaf(true);
 		await leaf.openFile(book.localFile.file);
 		this.app.workspace.revealLeaf(leaf);
-	}
-
-	private showUserMenu(event: MouseEvent): void {
-		const menu = new Menu();
-		menu.addItem((item) => {
-			item
-				.setTitle('注销')
-				.setIcon('log-out')
-				.onClick(async () => {
-					// Clear user data
-					settingsStore.actions.clearCookies();
-					new Notice('已注销');
-					// 清空登录窗口的 session
-					try {
-						const { remote } = require('electron');
-						if (remote && remote.session) {
-							const defaultSession = remote.session.defaultSession;
-							if (defaultSession) {
-								const cookies = await defaultSession.cookies.get({});
-								for (const cookie of cookies) {
-									if (cookie.name.startsWith('wr_')) {
-										await defaultSession.cookies.remove(
-											'https://weread.qq.com',
-											cookie.name
-										);
-									}
-								}
-							}
-						}
-					} catch (error) {
-						console.error('Failed to clear session cookies:', error);
-					}
-					await this.loadBookshelf();
-				});
-		});
-		menu.showAtMouseEvent(event);
-	}
-
-	private async openLoginQR(): Promise<void> {
-		// Open login modal
-		try {
-			// Try to open login window, fallback to settings tab if not available
-			const { remote } = require('electron');
-			if (remote) {
-				// Open the login window directly
-				const { BrowserWindow: RemoteBrowserWindow } = remote;
-				const loginWindow = new RemoteBrowserWindow({
-					parent: remote.getCurrentWindow(),
-					width: 960,
-					height: 540,
-					show: false,
-					webPreferences: {
-						// Create a fresh session for login
-						session: undefined
-					}
-				});
-
-				let isHandled = false;
-				let checkCount = 0;
-				const maxChecks = 30; // 最多检查30次
-
-				loginWindow.once('ready-to-show', () => {
-					loginWindow.setTitle('登录微信读书~');
-					loginWindow.show();
-				});
-
-				const session = loginWindow.webContents.session;
-
-				// 监听登录成功的 API 调用
-				const loginFilter = {
-					urls: ['https://weread.qq.com/api/auth/getLoginInfo?uid=*']
-				};
-
-				session.webRequest.onCompleted(loginFilter, (details: any) => {
-					if (details.statusCode === 200 && !isHandled) {
-						console.log('weread login success, redirect to weread shelf');
-						loginWindow.loadURL('https://weread.qq.com/web/shelf');
-						// 短延迟后尝试关闭
-						setTimeout(() => {
-							void this.checkLoginAndClose(loginWindow, () => {
-								if (!isHandled) {
-									isHandled = true;
-									setTimeout(() => {
-										try {
-											loginWindow.close();
-										} catch (e) {
-											console.error('Failed to close login window:', e);
-										}
-									}, 500);
-								}
-							});
-						}, 1000);
-					}
-				});
-
-				// 监听用户页面的 Cookie 发送
-				const userFilter = {
-					urls: ['https://weread.qq.com/web/user?userVid=*']
-				};
-				session.webRequest.onSendHeaders(userFilter, (details: any) => {
-					if (isHandled) {
-						return;
-					}
-
-					const cookies = details.requestHeaders['Cookie'];
-					if (!cookies) {
-						return;
-					}
-
-					// 简单解析 Cookie
-					const cookieArr = cookies
-						.split(';')
-						.map((c: string) => {
-							const [name, value] = c.trim().split('=');
-							return { name, value };
-						})
-						.filter((c: any) => c.name && c.value);
-
-					const wrVid = cookieArr.find((c: any) => c.name === 'wr_vid');
-					if (wrVid && wrVid.value) {
-						isHandled = true;
-						settingsStore.actions.setCookies(cookieArr);
-						void this.loadBookshelf();
-						setTimeout(() => {
-							try {
-								loginWindow.close();
-							} catch (e) {
-								console.error('Failed to close login window:', e);
-							}
-						}, 500);
-					}
-				});
-
-				// 定期检查 Cookie
-				const checkInterval = setInterval(async () => {
-					if (isHandled || checkCount >= maxChecks) {
-						clearInterval(checkInterval);
-						return;
-					}
-
-					checkCount++;
-					void this.checkLoginAndClose(loginWindow, () => {
-						if (!isHandled) {
-							isHandled = true;
-							clearInterval(checkInterval);
-							setTimeout(() => {
-								try {
-									loginWindow.close();
-								} catch (e) {
-									console.error('Failed to close login window:', e);
-								}
-							}, 500);
-						}
-					});
-				}, 1000); // 每秒检查一次
-
-				// 窗口关闭时清理
-				loginWindow.on('closed', () => {
-					clearInterval(checkInterval);
-				});
-
-				await loginWindow.loadURL('https://weread.qq.com/#login');
-			} else {
-				this.plugin.openWereadSettingsTab();
-			}
-		} catch (error) {
-			console.error('Failed to open login modal:', error);
-			// Fallback to settings tab
-			this.plugin.openWereadSettingsTab();
-		}
-	}
-
-	private async checkLoginAndClose(
-		loginWindow: any,
-		onLoginSuccess?: () => void
-	): Promise<void> {
-		try {
-			const cookieStore = loginWindow.webContents.session.cookies;
-			const sessionCookies = [
-				...(await cookieStore.get({ domain: '.weread.qq.com' })),
-				...(await cookieStore.get({ domain: 'weread.qq.com' }))
-			];
-
-			const wrVid = sessionCookies.find((c: any) => c.name === 'wr_vid');
-			const wrSkey = sessionCookies.find((c: any) => c.name === 'wr_skey');
-
-			// wr_vid 或 wr_skey 存在且有值，表示登录成功
-			if ((wrVid && wrVid.value) || (wrSkey && wrSkey.value)) {
-				// Save cookies
-				const uniqueCookies = new Map();
-				for (const cookie of sessionCookies) {
-					if (!uniqueCookies.has(cookie.name)) {
-						uniqueCookies.set(cookie.name, {
-							name: decodeURIComponent(cookie.name),
-							value: decodeURIComponent(cookie.value)
-						});
-					}
-				}
-				settingsStore.actions.setCookies(Array.from(uniqueCookies.values()));
-				await this.loadBookshelf();
-
-				if (onLoginSuccess) {
-					onLoginSuccess();
-				} else {
-					try {
-						loginWindow.close();
-					} catch (e) {
-						console.error('Failed to close login window:', e);
-					}
-				}
-			}
-		} catch (error) {
-			console.error('Failed to sync cookies:', error);
-		}
-	}
+}
 }

--- a/src/components/wereadReadingStats.ts
+++ b/src/components/wereadReadingStats.ts
@@ -1,5 +1,5 @@
 import { ItemView, Menu, Modal, Notice, WorkspaceLeaf, setIcon, TFile, Vault } from 'obsidian';
-import ApiManager from '../api';
+import ApiRouter from '../api-router';
 import FileManager from '../fileManager';
 import { settingsStore } from '../settings';
 import { get } from 'svelte/store';
@@ -282,7 +282,7 @@ class ExportPreviewModal extends Modal {
 }
 
 export class WereadReadingStatsView extends ItemView {
-	private apiManager: ApiManager;
+	private apiManager: ApiRouter;
 	private fileManager: FileManager;
 	private currentMode: ReadingStatsMode = 'monthly';
 	private currentOffset = 0;
@@ -294,7 +294,7 @@ export class WereadReadingStatsView extends ItemView {
 	// in-memory image cache: url -> base64 data url
 	private imgCache: Map<string, string> = new Map();
 
-	constructor(leaf: WorkspaceLeaf, apiManager: ApiManager, fileManager: FileManager) {
+	constructor(leaf: WorkspaceLeaf, apiManager: ApiRouter, fileManager: FileManager) {
 		super(leaf);
 		this.apiManager = apiManager;
 		this.fileManager = fileManager;

--- a/src/models.ts
+++ b/src/models.ts
@@ -434,6 +434,7 @@ export type ChapterHighlightReview = {
 	// highlight and review can be empty, just output title
 	highlights?: Highlight[];
 	chapterReviews?: Review[];
+	popularHighlights?: PopularHighlight[];
 };
 
 export type RenderTemplate = {

--- a/src/models.ts
+++ b/src/models.ts
@@ -329,11 +329,18 @@ export type PopularHighlight = {
 	totalCount: number;
 };
 
+export type PopularChapterHighlight = {
+	chapterUid: number;
+	chapterIdx: number;
+	chapterTitle: string;
+	highlights: PopularHighlight[];
+};
+
 export type Notebook = {
 	metaData: Metadata;
 	chapterHighlights: ChapterHighlightReview[];
 	bookReview: BookReview;
-	popularHighlights?: PopularHighlight[];
+	popularHighlights?: PopularChapterHighlight[];
 };
 
 export type Metadata = {
@@ -441,7 +448,7 @@ export type RenderTemplate = {
 	metaData: Metadata;
 	chapterHighlights: ChapterHighlightReview[];
 	bookReview: BookReview;
-	popularHighlights?: PopularHighlight[];
+	popularHighlights?: PopularChapterHighlight[];
 };
 
 export type DailyNoteReferenece = {

--- a/src/models.ts
+++ b/src/models.ts
@@ -401,6 +401,7 @@ export type Highlight = {
 	refMpReviewId?: string;
 	isPopular?: boolean;
 	popularCount?: number;
+	isUserHighlight?: boolean;
 };
 
 export type BookReview = {

--- a/src/models.ts
+++ b/src/models.ts
@@ -440,6 +440,7 @@ export type RenderTemplate = {
 	metaData: Metadata;
 	chapterHighlights: ChapterHighlightReview[];
 	bookReview: BookReview;
+	popularHighlights?: PopularHighlight[];
 };
 
 export type DailyNoteReferenece = {

--- a/src/models.ts
+++ b/src/models.ts
@@ -613,3 +613,16 @@ export interface Theme {
 	author?: string;
 	version?: string;
 }
+
+export type PopularHighlightCache = {
+	bookId: string;
+	cachedAt: number;
+	ttl: number;
+	items: PopularHighlight[];
+	chapters: {
+		bookId: string;
+		chapterUid: number;
+		chapterIdx: number;
+		title: string;
+	}[];
+};

--- a/src/models.ts
+++ b/src/models.ts
@@ -399,6 +399,8 @@ export type Highlight = {
 	reviewContent?: string;
 	range: string;
 	refMpReviewId?: string;
+	isPopular?: boolean;
+	popularCount?: number;
 };
 
 export type BookReview = {

--- a/src/models.ts
+++ b/src/models.ts
@@ -452,6 +452,7 @@ export type RenderTemplate = {
 	chapterHighlights: ChapterHighlightReview[];
 	bookReview: BookReview;
 	popularHighlights?: PopularChapterHighlight[];
+	syncPopularHighlightsToggle?: boolean;
 };
 
 export type DailyNoteReferenece = {

--- a/src/models.ts
+++ b/src/models.ts
@@ -320,10 +320,20 @@ export type Chapter = {
 	level: number;
 };
 
+export type PopularHighlight = {
+	bookmarkId: string;
+	chapterUid: number;
+	chapterTitle: string;
+	range: string;
+	markText: string;
+	totalCount: number;
+};
+
 export type Notebook = {
 	metaData: Metadata;
 	chapterHighlights: ChapterHighlightReview[];
 	bookReview: BookReview;
+	popularHighlights?: PopularHighlight[];
 };
 
 export type Metadata = {

--- a/src/parser/parseResponse.ts
+++ b/src/parser/parseResponse.ts
@@ -11,6 +11,7 @@ import type {
 	Metadata,
 	Notebook,
 	PopularHighlight,
+	PopularChapterHighlight,
 	RefBlockDetail,
 	Review
 } from 'src/models';
@@ -27,17 +28,36 @@ export const parsePopularHighlights = (resp: {
 		markText: string;
 		totalCount: number;
 	}[];
-	chapters: { chapterUid: number; title: string }[];
-}): PopularHighlight[] => {
-	const chapterMap = new Map(resp.chapters.map((c) => [c.chapterUid, c.title]));
-	return resp.items.map((item) => ({
-		bookmarkId: item.bookmarkId,
-		chapterUid: item.chapterUid,
-		chapterTitle: chapterMap.get(item.chapterUid) ?? '未知章节',
-		range: item.range,
-		markText: item.markText,
-		totalCount: item.totalCount
-	}));
+	chapters: { chapterUid: number; chapterIdx: number; title: string }[];
+}): PopularChapterHighlight[] => {
+	const chapterMap = new Map(resp.chapters.map((c) => [c.chapterUid, c]));
+
+	// 按章节分组
+	const grouped = new Map<number, PopularHighlight[]>();
+	for (const item of resp.items) {
+		if (!grouped.has(item.chapterUid)) grouped.set(item.chapterUid, []);
+		grouped.get(item.chapterUid).push({
+			bookmarkId: item.bookmarkId,
+			chapterUid: item.chapterUid,
+			chapterTitle: chapterMap.get(item.chapterUid)?.title ?? '未知章节',
+			range: item.range,
+			markText: item.markText,
+			totalCount: item.totalCount
+		});
+	}
+
+	// 按 chapterIdx 排序
+	return Array.from(grouped.entries())
+		.map(([chapterUid, highlights]) => {
+			const chapter = chapterMap.get(chapterUid);
+			return {
+				chapterUid,
+				chapterIdx: chapter?.chapterIdx ?? 0,
+				chapterTitle: chapter?.title ?? '未知章节',
+				highlights
+			};
+		})
+		.sort((a, b) => a.chapterIdx - b.chapterIdx);
 };
 
 export const parseMetadata = (noteBook: any): Metadata => {

--- a/src/parser/parseResponse.ts
+++ b/src/parser/parseResponse.ts
@@ -14,7 +14,7 @@ import type {
 	PopularChapterHighlight,
 	RefBlockDetail,
 	Review
-} from 'src/models';
+} from '../models';
 import { NodeHtmlMarkdown } from 'node-html-markdown';
 import * as CryptoJS from 'crypto-js';
 import { settingsStore } from '../settings';

--- a/src/parser/parseResponse.ts
+++ b/src/parser/parseResponse.ts
@@ -10,6 +10,7 @@ import type {
 	HighlightResponse,
 	Metadata,
 	Notebook,
+	PopularHighlight,
 	RefBlockDetail,
 	Review
 } from 'src/models';
@@ -17,6 +18,27 @@ import { NodeHtmlMarkdown } from 'node-html-markdown';
 import * as CryptoJS from 'crypto-js';
 import { settingsStore } from '../settings';
 import { get } from 'svelte/store';
+
+export const parsePopularHighlights = (resp: {
+	items: {
+		bookmarkId: string;
+		chapterUid: number;
+		range: string;
+		markText: string;
+		totalCount: number;
+	}[];
+	chapters: { chapterUid: number; title: string }[];
+}): PopularHighlight[] => {
+	const chapterMap = new Map(resp.chapters.map((c) => [c.chapterUid, c.title]));
+	return resp.items.map((item) => ({
+		bookmarkId: item.bookmarkId,
+		chapterUid: item.chapterUid,
+		chapterTitle: chapterMap.get(item.chapterUid) ?? '未知章节',
+		range: item.range,
+		markText: item.markText,
+		totalCount: item.totalCount
+	}));
+};
 
 export const parseMetadata = (noteBook: any): Metadata => {
 	const book = noteBook['book'];

--- a/src/popularHighlightsCache.ts
+++ b/src/popularHighlightsCache.ts
@@ -1,0 +1,169 @@
+import { settingsStore } from './settings';
+import { get } from 'svelte/store';
+import type { PopularHighlight, PopularHighlightCache } from './models';
+
+export default class PopularHighlightsCacheManager {
+	private cacheDir: string = '.weread-cache';
+
+	private getCachePath(bookId: string): string {
+		return `${this.cacheDir}/popular-${bookId}.json`;
+	}
+
+	private isCacheExpired(cache: PopularHighlightCache): boolean {
+		const settings = get(settingsStore);
+		const ttlMs = (settings.popularHighlightsCacheTtl ?? 7) * 24 * 60 * 60 * 1000;
+		return Date.now() > cache.cachedAt + ttlMs;
+	}
+
+	async get(bookId: string): Promise<PopularHighlightCache | null> {
+		try {
+			const cachePath = this.getCachePath(bookId);
+			const exists = await this.fileExists(cachePath);
+			if (!exists) return null;
+
+			const content = await this.readFile(cachePath);
+			const cache: PopularHighlightCache = JSON.parse(content);
+
+			if (this.isCacheExpired(cache)) {
+				console.log(`[weread plugin] 热门划线缓存已过期: ${bookId}`);
+				return null;
+			}
+
+			console.log(`[weread plugin] 热门划线缓存命中: ${bookId}`);
+			return cache;
+		} catch (e) {
+			console.error(`[weread plugin] 读取热门划线缓存失败: ${bookId}`, e);
+			return null;
+		}
+	}
+
+	async set(
+		bookId: string,
+		items: PopularHighlight[],
+		chapters: PopularHighlightCache['chapters']
+	): Promise<void> {
+		try {
+			const settings = get(settingsStore);
+			const cache: PopularHighlightCache = {
+				bookId,
+				cachedAt: Date.now(),
+				ttl: settings.popularHighlightsCacheTtl ?? 7,
+				items,
+				chapters
+			};
+
+			const cachePath = this.getCachePath(bookId);
+			await this.ensureCacheDir();
+			await this.writeFile(cachePath, JSON.stringify(cache, null, 2));
+			console.log(`[weread plugin] 热门划线缓存已写入: ${bookId}`);
+		} catch (e) {
+			console.error(`[weread plugin] 写入热门划线缓存失败: ${bookId}`, e);
+		}
+	}
+
+	async clear(bookId: string): Promise<void> {
+		try {
+			const cachePath = this.getCachePath(bookId);
+			const exists = await this.fileExists(cachePath);
+			if (exists) {
+				await this.deleteFile(cachePath);
+				console.log(`[weread plugin] 热门划线缓存已清除: ${bookId}`);
+			}
+		} catch (e) {
+			console.error(`[weread plugin] 清除热门划线缓存失败: ${bookId}`, e);
+		}
+	}
+
+	async clearExpired(): Promise<number> {
+		try {
+			const cacheDirPath = this.cacheDir;
+			const exists = await this.fileExists(cacheDirPath);
+			if (!exists) return 0;
+
+			const files = await this.listFiles(cacheDirPath);
+			let cleared = 0;
+
+			for (const file of files) {
+				if (!file.startsWith('popular-') || !file.endsWith('.json')) continue;
+
+				try {
+					const content = await this.readFile(`${cacheDirPath}/${file}`);
+					const cache: PopularHighlightCache = JSON.parse(content);
+					if (this.isCacheExpired(cache)) {
+						await this.deleteFile(`${cacheDirPath}/${file}`);
+						cleared++;
+					}
+				} catch (e) {
+					// 忽略解析失败的文件
+				}
+			}
+
+			if (cleared > 0) {
+				console.log(`[weread plugin] 已清除 ${cleared} 个过期热门划线缓存`);
+			}
+			return cleared;
+		} catch (e) {
+			console.error('[weread plugin] 清除过期缓存失败', e);
+			return 0;
+		}
+	}
+
+	private async ensureCacheDir(): Promise<void> {
+		try {
+			const exists = await this.fileExists(this.cacheDir);
+			if (!exists) {
+				await this.createDir(this.cacheDir);
+			}
+		} catch (e) {
+			// 目录已存在或其他错误，忽略
+		}
+	}
+
+	// 抽象文件系统操作（由 Obsidian 实现）
+	private async fileExists(path: string): Promise<boolean> {
+		// @ts-ignore - Vault is available in Obsidian context
+		return app.vault.getAbstractFileByPath(path) !== null;
+	}
+
+	private async readFile(path: string): Promise<string> {
+		// @ts-ignore
+		const file = app.vault.getAbstractFileByPath(path);
+		if (!file) throw new Error('File not found');
+		// @ts-ignore
+		return await app.vault.read(file);
+	}
+
+	private async writeFile(path: string, content: string): Promise<void> {
+		// @ts-ignore
+		const file = app.vault.getAbstractFileByPath(path);
+		if (file) {
+			// @ts-ignore
+			await app.vault.modify(file, content);
+		} else {
+			// @ts-ignore
+			await app.vault.create(path, content);
+		}
+	}
+
+	private async deleteFile(path: string): Promise<void> {
+		// @ts-ignore
+		const file = app.vault.getAbstractFileByPath(path);
+		if (file) {
+			// @ts-ignore
+			await app.vault.delete(file);
+		}
+	}
+
+	private async createDir(path: string): Promise<void> {
+		// @ts-ignore
+		await app.vault.createFolder(path);
+	}
+
+	private async listFiles(dirPath: string): Promise<string[]> {
+		// @ts-ignore
+		const folder = app.vault.getAbstractFileByPath(dirPath);
+		if (!folder || folder.constructor.name !== 'TFolder') return [];
+		// @ts-ignore
+		return folder.children.filter((f) => f.constructor.name === 'TFile').map((f) => f.name);
+	}
+}

--- a/src/popularHighlightsCache.ts
+++ b/src/popularHighlightsCache.ts
@@ -1,9 +1,15 @@
+import { Vault, TFile, TFolder } from 'obsidian';
 import { settingsStore } from './settings';
 import { get } from 'svelte/store';
 import type { PopularHighlight, PopularHighlightCache } from './models';
 
 export default class PopularHighlightsCacheManager {
 	private cacheDir: string = '.weread-cache';
+	private vault: Vault;
+
+	constructor(vault: Vault) {
+		this.vault = vault;
+	}
 
 	private getCachePath(bookId: string): string {
 		return `${this.cacheDir}/popular-${bookId}.json`;
@@ -18,7 +24,7 @@ export default class PopularHighlightsCacheManager {
 	async get(bookId: string): Promise<PopularHighlightCache | null> {
 		try {
 			const cachePath = this.getCachePath(bookId);
-			const exists = await this.fileExists(cachePath);
+			const exists = await this.vault.adapter.exists(cachePath);
 			if (!exists) return null;
 
 			const content = await this.readFile(cachePath);
@@ -64,7 +70,7 @@ export default class PopularHighlightsCacheManager {
 	async clear(bookId: string): Promise<void> {
 		try {
 			const cachePath = this.getCachePath(bookId);
-			const exists = await this.fileExists(cachePath);
+			const exists = await this.vault.adapter.exists(cachePath);
 			if (exists) {
 				await this.deleteFile(cachePath);
 				console.log(`[weread plugin] 热门划线缓存已清除: ${bookId}`);
@@ -77,7 +83,7 @@ export default class PopularHighlightsCacheManager {
 	async clearExpired(): Promise<number> {
 		try {
 			const cacheDirPath = this.cacheDir;
-			const exists = await this.fileExists(cacheDirPath);
+			const exists = await this.vault.adapter.exists(cacheDirPath);
 			if (!exists) return 0;
 
 			const files = await this.listFiles(cacheDirPath);
@@ -110,60 +116,42 @@ export default class PopularHighlightsCacheManager {
 
 	private async ensureCacheDir(): Promise<void> {
 		try {
-			const exists = await this.fileExists(this.cacheDir);
+			const exists = await this.vault.adapter.exists(this.cacheDir);
 			if (!exists) {
-				await this.createDir(this.cacheDir);
+				await this.vault.createFolder(this.cacheDir);
 			}
 		} catch (e) {
 			// 目录已存在或其他错误，忽略
 		}
 	}
 
-	// 抽象文件系统操作（由 Obsidian 实现）
-	private async fileExists(path: string): Promise<boolean> {
-		// @ts-ignore - Vault is available in Obsidian context
-		return app.vault.getAbstractFileByPath(path) !== null;
-	}
-
 	private async readFile(path: string): Promise<string> {
-		// @ts-ignore
-		const file = app.vault.getAbstractFileByPath(path);
-		if (!file) throw new Error('File not found');
-		// @ts-ignore
-		return await app.vault.read(file);
+		const file = this.vault.getAbstractFileByPath(path);
+		if (!file || !(file instanceof TFile)) throw new Error('File not found');
+		return await this.vault.read(file);
 	}
 
 	private async writeFile(path: string, content: string): Promise<void> {
-		// @ts-ignore
-		const file = app.vault.getAbstractFileByPath(path);
-		if (file) {
-			// @ts-ignore
-			await app.vault.modify(file, content);
+		const file = this.vault.getAbstractFileByPath(path);
+		if (file instanceof TFile) {
+			await this.vault.modify(file, content);
 		} else {
-			// @ts-ignore
-			await app.vault.create(path, content);
+			await this.vault.create(path, content);
 		}
 	}
 
 	private async deleteFile(path: string): Promise<void> {
-		// @ts-ignore
-		const file = app.vault.getAbstractFileByPath(path);
-		if (file) {
-			// @ts-ignore
-			await app.vault.delete(file);
+		const file = this.vault.getAbstractFileByPath(path);
+		if (file instanceof TFile) {
+			await this.vault.delete(file);
 		}
 	}
 
-	private async createDir(path: string): Promise<void> {
-		// @ts-ignore
-		await app.vault.createFolder(path);
-	}
-
 	private async listFiles(dirPath: string): Promise<string[]> {
-		// @ts-ignore
-		const folder = app.vault.getAbstractFileByPath(dirPath);
-		if (!folder || folder.constructor.name !== 'TFolder') return [];
-		// @ts-ignore
-		return folder.children.filter((f) => f.constructor.name === 'TFile').map((f) => f.name);
+		const folder = this.vault.getAbstractFileByPath(dirPath);
+		if (!(folder instanceof TFolder)) return [];
+		return folder.children
+			.filter((f) => f instanceof TFile)
+			.map((f) => (f as TFile).name);
 	}
 }

--- a/src/popularHighlightsCache.ts
+++ b/src/popularHighlightsCache.ts
@@ -27,7 +27,7 @@ export default class PopularHighlightsCacheManager {
 			const exists = await this.vault.adapter.exists(cachePath);
 			if (!exists) return null;
 
-			const content = await this.readFile(cachePath);
+			const content = await this.vault.adapter.read(cachePath);
 			const cache: PopularHighlightCache = JSON.parse(content);
 
 			if (this.isCacheExpired(cache)) {
@@ -60,7 +60,8 @@ export default class PopularHighlightsCacheManager {
 
 			const cachePath = this.getCachePath(bookId);
 			await this.ensureCacheDir();
-			await this.writeFile(cachePath, JSON.stringify(cache, null, 2));
+			// 使用 adapter.write，它会自动覆盖已存在的文件
+			await this.vault.adapter.write(cachePath, JSON.stringify(cache, null, 2));
 			console.log(`[weread plugin] 热门划线缓存已写入: ${bookId}`);
 		} catch (e) {
 			console.error(`[weread plugin] 写入热门划线缓存失败: ${bookId}`, e);
@@ -72,8 +73,11 @@ export default class PopularHighlightsCacheManager {
 			const cachePath = this.getCachePath(bookId);
 			const exists = await this.vault.adapter.exists(cachePath);
 			if (exists) {
-				await this.deleteFile(cachePath);
-				console.log(`[weread plugin] 热门划线缓存已清除: ${bookId}`);
+				const file = this.vault.getAbstractFileByPath(cachePath);
+				if (file instanceof TFile) {
+					await this.vault.delete(file);
+					console.log(`[weread plugin] 热门划线缓存已清除: ${bookId}`);
+				}
 			}
 		} catch (e) {
 			console.error(`[weread plugin] 清除热门划线缓存失败: ${bookId}`, e);
@@ -93,10 +97,14 @@ export default class PopularHighlightsCacheManager {
 				if (!file.startsWith('popular-') || !file.endsWith('.json')) continue;
 
 				try {
-					const content = await this.readFile(`${cacheDirPath}/${file}`);
+					const content = await this.vault.adapter.read(`${cacheDirPath}/${file}`);
 					const cache: PopularHighlightCache = JSON.parse(content);
 					if (this.isCacheExpired(cache)) {
-						await this.deleteFile(`${cacheDirPath}/${file}`);
+						const filePath = `${cacheDirPath}/${file}`;
+						const abstractFile = this.vault.getAbstractFileByPath(filePath);
+						if (abstractFile instanceof TFile) {
+							await this.vault.delete(abstractFile);
+						}
 						cleared++;
 					}
 				} catch (e) {
@@ -125,33 +133,15 @@ export default class PopularHighlightsCacheManager {
 		}
 	}
 
-	private async readFile(path: string): Promise<string> {
-		const file = this.vault.getAbstractFileByPath(path);
-		if (!file || !(file instanceof TFile)) throw new Error('File not found');
-		return await this.vault.read(file);
-	}
-
-	private async writeFile(path: string, content: string): Promise<void> {
-		const file = this.vault.getAbstractFileByPath(path);
-		if (file instanceof TFile) {
-			await this.vault.modify(file, content);
-		} else {
-			await this.vault.create(path, content);
-		}
-	}
-
-	private async deleteFile(path: string): Promise<void> {
-		const file = this.vault.getAbstractFileByPath(path);
-		if (file instanceof TFile) {
-			await this.vault.delete(file);
-		}
-	}
-
 	private async listFiles(dirPath: string): Promise<string[]> {
-		const folder = this.vault.getAbstractFileByPath(dirPath);
-		if (!(folder instanceof TFolder)) return [];
-		return folder.children
-			.filter((f) => f instanceof TFile)
-			.map((f) => (f as TFile).name);
+		try {
+			const folder = this.vault.getAbstractFileByPath(dirPath);
+			if (!(folder instanceof TFolder)) return [];
+			return folder.children
+				.filter((f) => f instanceof TFile)
+				.map((f) => (f as TFile).name);
+		} catch (e) {
+			return [];
+		}
 	}
 }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -62,12 +62,13 @@ export class Renderer {
 	}
 
 	render(entry: Notebook): string {
-		const { metaData, chapterHighlights, bookReview } = entry;
+		const { metaData, chapterHighlights, bookReview, popularHighlights } = entry;
 
 		const context: RenderTemplate = {
 			metaData,
 			chapterHighlights,
-			bookReview
+			bookReview,
+			popularHighlights
 		};
 		const settings = get(settingsStore);
 
@@ -107,12 +108,13 @@ export class Renderer {
 	 * @returns The rendered content
 	 */
 	renderWithTemplate(templateStr: string, entry: Notebook, trimBlocks = false): string {
-		const { metaData, chapterHighlights, bookReview } = entry;
+		const { metaData, chapterHighlights, bookReview, popularHighlights } = entry;
 
 		const context: RenderTemplate = {
 			metaData,
 			chapterHighlights,
-			bookReview
+			bookReview,
+			popularHighlights
 		};
 
 		// 创建临时环境以支持 trimBlocks 配置

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -64,14 +64,15 @@ export class Renderer {
 	render(entry: Notebook): string {
 		const { metaData, chapterHighlights, bookReview, popularHighlights } = entry;
 
+		const settings = get(settingsStore);
 		const context: RenderTemplate = {
 			metaData,
 			chapterHighlights,
 			bookReview,
-			popularHighlights
+			popularHighlights,
+			syncPopularHighlightsToggle: settings.syncPopularHighlightsToggle
 		};
 		console.log('[weread renderer] popularHighlights in context:', popularHighlights?.length ?? 'undefined');
-		const settings = get(settingsStore);
 		// Use active theme's template and trimBlocks, fallback to legacy settings
 		const activeTheme = settings.themes?.find((t) => t.id === settings.activeThemeId);
 		// For legacy themes (source === 'legacy' or id === 'legacy_template'), always use the top-level settings.template
@@ -110,11 +111,13 @@ export class Renderer {
 	renderWithTemplate(templateStr: string, entry: Notebook, trimBlocks = false): string {
 		const { metaData, chapterHighlights, bookReview, popularHighlights } = entry;
 
+		const settings = get(settingsStore);
 		const context: RenderTemplate = {
 			metaData,
 			chapterHighlights,
 			bookReview,
-			popularHighlights
+			popularHighlights,
+			syncPopularHighlightsToggle: settings.syncPopularHighlightsToggle
 		};
 
 		// 创建临时环境以支持 trimBlocks 配置

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -70,8 +70,8 @@ export class Renderer {
 			bookReview,
 			popularHighlights
 		};
+		console.log('[weread renderer] popularHighlights in context:', popularHighlights?.length ?? 'undefined');
 		const settings = get(settingsStore);
-
 		// Use active theme's template and trimBlocks, fallback to legacy settings
 		const activeTheme = settings.themes?.find((t) => t.id === settings.activeThemeId);
 		// For legacy themes (source === 'legacy' or id === 'legacy_template'), always use the top-level settings.template

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -60,34 +60,10 @@ export class WereadSettingsTab extends PluginSettingTab {
 		containerEl.createEl('h2', { text: '设置微信读书插件' });
 		this.preloadSelectableBooks();
 
-		const settings2 = get(settingsStore);
-		const isCookieValid = settings2.isCookieValid;
-		const loginMethod = settings2.loginMethod;
-		const hasApiKey = Boolean(settings2.wereadApiKey);
-
 		// API Key 设置始终可见（桌面端和移动端）
 		this.showApiKeySetting();
 
-		if (Platform.isDesktopApp) {
-			// 仅在没有 API Key 时才显示传统登录方式
-			if (!hasApiKey) {
-				this.showLoginMethod();
-				if (loginMethod === 'scan') {
-					if (isCookieValid) {
-						this.showLogout();
-					} else {
-						this.showLogin();
-					}
-				} else {
-					this.showCookieCloudInfo();
-				}
-				this.showCookieStatus();
-			}
-		}
-
 		this.notebookFolder();
-		this.readingOpenModeSetting();
-		this.bookOpenModeSetting();
 		this.bookshelfSettings();
 		this.syncModeSettings();
 		this.scheduledSync();
@@ -247,6 +223,9 @@ export class WereadSettingsTab extends PluginSettingTab {
 
 	private bookshelfSettings(): void {
 		new Setting(this.containerEl).setName('书架设置').setHeading();
+			this.readingOpenModeSetting();
+			this.bookOpenModeSetting();
+
 
 		new Setting(this.containerEl)
 			.setName('书架排序方式')
@@ -822,9 +801,16 @@ export class WereadSettingsTab extends PluginSettingTab {
 	}
 	private showApiKeySetting(): void {
 		let apiKeyText: TextComponent;
-		new Setting(this.containerEl)
+
+		const descFrag = document
+			.createRange()
+			.createContextualFragment(
+				`用于调用微信读书 Agent API，支持同步笔记、划线、阅读统计等功能。点击「扫码获取」扫码登录后自动获取，也可在 <a href="https://weread.qq.com/r/weread-skills">weread.qq.com/r/weread-skills</a> 手动申请。格式：wrk-xxxxxxxx。`
+			);
+
+		const setting = new Setting(this.containerEl)
 			.setName('微信读书 API Key')
-			.setDesc('用于调用微信读书 Agent API，支持同步笔记、划线、阅读统计等功能。格式：wrk-xxxxxxxx。')
+			.setDesc(descFrag)
 			.addText((text) => {
 				text.setPlaceholder('wrk-xxxxxxxx')
 					.setValue(get(settingsStore).wereadApiKey ?? '')
@@ -849,73 +835,134 @@ export class WereadSettingsTab extends PluginSettingTab {
 			});
 
 		const apiKey = get(settingsStore).wereadApiKey;
+
 		if (apiKey) {
-			const userInfoContainer = this.containerEl.createDiv({
-				cls: 'weread-apikey-user-info'
+			// 已设置 API Key → 显示注销按钮
+			setting.addButton((button) => {
+				button.setButtonText('注销')
+					.setTooltip('清除 API Key 和登录状态')
+					.onClick(async () => {
+						settingsStore.actions.clearCookies();
+						settingsStore.actions.setWereadApiKey('');
+						new Notice('已注销，API Key 已清除');
+						this.display();
+					});
+				return button;
 			});
-			// 初始加载状态
-			userInfoContainer.createDiv({
-				cls: 'weread-apikey-user-status',
-				text: '✅ API Key 已配置，正在获取用户信息...'
+		} else if (Platform.isDesktopApp) {
+			// 未设置 API Key → 显示扫码获取按钮（仅桌面端）
+			setting.addButton((button) => {
+				button.setButtonText('扫码获取')
+					.setTooltip('扫码登录获取 API Key')
+					.onClick(async () => {
+						await this.handleScanApiKey(button);
+					});
+				return button;
 			});
-			// 异步获取用户信息
-			this.fetchAndDisplayApiKeyUser(userInfoContainer);
-		} else {
-			new Setting(this.containerEl)
-				.setName('⚠️ 请填写 API Key')
-				.setDesc('API Key 格式为 wrk-xxxxxxxx。申请地址：微信读书开放平台');
+		}
+
+		if (apiKey) {
+			const validationContainer = this.containerEl.createDiv({
+				cls: 'weread-apikey-validation'
+			});
+			validationContainer.createDiv({
+				cls: 'weread-apikey-validation-status',
+				text: '⏳ 正在校验 API Key...'
+			});
+			this.fetchAndDisplayValidation(validationContainer);
 		}
 	}
 
+	private async handleScanApiKey(button: any): Promise<void> {
+		if (!Platform.isDesktopApp) {
+			new Notice('扫码登录仅支持桌面端，请在移动端手动粘贴 API Key');
+			return;
+		}
 
-	private async fetchAndDisplayApiKeyUser(container: HTMLElement): Promise<void> {
+		const settings = get(settingsStore);
+		const isLoggedIn = settings.isCookieValid && settings.cookies.length > 0;
+
+		button.setDisabled(true);
+		button.setButtonText('获取中...');
+
+		try {
+			if (isLoggedIn) {
+				const apiRouter = new ApiRouter();
+				const result = await apiRouter.fetchApiKey();
+				if (result?.apikey) {
+					new Notice('API Key 获取成功');
+				} else {
+					new Notice('API Key 获取失败，请尝试重新扫码登录');
+				}
+			} else {
+				const loginModel = new WereadLoginModel(this);
+				await loginModel.doLogin();
+			}
+		} catch (e) {
+			console.error('[weread plugin] 扫码获取 API Key 失败', e);
+			new Notice('扫码获取 API Key 失败，请查看控制台');
+		} finally {
+			button.setDisabled(false);
+			button.setButtonText('扫码获取');
+			this.display();
+		}
+	}
+
+	private async fetchAndDisplayValidation(container: HTMLElement): Promise<void> {
 		try {
 			const apiRouter = new ApiRouter();
-			const userInfo = await apiRouter.getCurrentUser();
-			if (userInfo) {
-				container.empty();
-				// 提取用户信息（V2 返回格式可能嵌套在 data 中）
-				const info = (userInfo as any).data || userInfo;
-				const userName = info.name || info.userName || info.nickname || '未知用户';
-				const userAvatar = info.avatar || info.headImgUrl || info.avatarUrl || '';
-				const userSignature = info.signature || info.description || '';
+			const result = await apiRouter.validateApiKey();
 
-				const userRow = container.createDiv({ cls: 'weread-apikey-user-row' });
-				if (userAvatar) {
-					const avatarImg = userRow.createEl('img', {
-						cls: 'weread-apikey-user-avatar'
-					});
-					avatarImg.src = userAvatar;
-					avatarImg.alt = '用户头像';
+			// 如果有 Cookie，尝试获取 API Key 的元数据（创建日期、最近使用日期）
+			const settings = get(settingsStore);
+			let metadata: { createdAt?: number; lastUsedAt?: number } | null = null;
+			if (settings.isCookieValid && settings.cookies.length > 0) {
+				try {
+					metadata = await apiRouter.fetchApiKey();
+				} catch {
+					// 元数据获取失败不影响主流程
 				}
-				const userText = userRow.createDiv({ cls: 'weread-apikey-user-text' });
-				userText.createDiv({
-					cls: 'weread-apikey-user-name',
-					text: `✅ API Key 已连接 · 用户：${userName}`
-				});
-				if (userSignature) {
-					userText.createDiv({
-						cls: 'weread-apikey-user-signature',
-						text: userSignature
-					});
-				}
-				userText.createDiv({
-					cls: 'weread-apikey-user-desc',
-					text: '同步、书架、阅读统计等功能均可正常使用'
-				});
-			} else {
-				container.empty();
+			}
+
+			container.empty();
+
+			if (result.valid) {
+				// 第一行：状态 + 功能描述
 				container.createDiv({
-					cls: 'weread-apikey-user-status',
-					text: '✅ API Key 已配置（无法获取用户信息，请检查 API Key 有效性）'
+					cls: 'weread-apikey-validation-row weread-apikey-validation-valid',
+					text: '✅ API Key 有效 · 同步、书架、阅读统计等功能均可正常使用'
+				});
+
+				// 第二行：创建日期和最近使用日期
+				if (metadata?.createdAt || metadata?.lastUsedAt) {
+					const parts: string[] = [];
+					if (metadata?.createdAt) {
+						parts.push(`创建日期：${window.moment.unix(metadata.createdAt).format('YYYY-MM-DD')}`);
+					}
+					if (metadata?.lastUsedAt) {
+						parts.push(`最近使用：${window.moment.unix(metadata.lastUsedAt).format('YYYY-MM-DD HH:mm')}`);
+					}
+					container.createDiv({
+						cls: 'weread-apikey-validation-row',
+						text: parts.join(' · ')
+					});
+				}
+			} else {
+				container.createDiv({
+					cls: 'weread-apikey-validation-row weread-apikey-validation-invalid',
+					text: '❌ API Key 无效'
+				});
+				container.createDiv({
+					cls: 'weread-apikey-validation-desc',
+					text: '请检查 Key 是否正确，或点击「扫码获取」重新获取'
 				});
 			}
 		} catch (e) {
-			console.warn('[weread plugin] 获取 API Key 用户信息失败', e);
+			console.warn('[weread plugin] API Key 校验失败', e);
 			container.empty();
 			container.createDiv({
-				cls: 'weread-apikey-user-status',
-				text: '✅ API Key 已配置（用户信息获取失败，功能不受影响）'
+				cls: 'weread-apikey-validation-row',
+				text: '⚠️ API Key 校验失败，请检查网络连接'
 			});
 		}
 	}

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -19,7 +19,7 @@ import WereadLogoutModel from './components/wereadLogoutModel';
 import CookieCloudConfigModal from './components/cookieCloudConfigModel';
 import { ThemeManagerModal } from './components/themeManagerModal';
 
-import ApiManager from './api';
+import ApiRouter from './api-router';
 import { parseBookIdList } from './utils/bookIdUtils';
 import { formatTimestampToDate } from './utils/dateUtil';
 import type { ReadingOpenMode, SyncMode, BookshelfSortMode, BookOpenMode } from './settings';
@@ -60,37 +60,28 @@ export class WereadSettingsTab extends PluginSettingTab {
 		containerEl.createEl('h2', { text: '设置微信读书插件' });
 		this.preloadSelectableBooks();
 
-		// 登录设置仅在桌面端显示
+		const settings2 = get(settingsStore);
+		const isCookieValid = settings2.isCookieValid;
+		const loginMethod = settings2.loginMethod;
+		const hasApiKey = Boolean(settings2.wereadApiKey);
+
+		// API Key 设置始终可见（桌面端和移动端）
+		this.showApiKeySetting();
+
 		if (Platform.isDesktopApp) {
-			this.showLoginMethod();
-		}
-
-		const isCookieValid = get(settingsStore).isCookieValid;
-		const loginMethod = get(settingsStore).loginMethod;
-
-		if (loginMethod === 'scan') {
-			if (Platform.isDesktopApp) {
-				if (isCookieValid) {
-					this.showLogout();
+			// 仅在没有 API Key 时才显示传统登录方式
+			if (!hasApiKey) {
+				this.showLoginMethod();
+				if (loginMethod === 'scan') {
+					if (isCookieValid) {
+						this.showLogout();
+					} else {
+						this.showLogin();
+					}
 				} else {
-					this.showLogin();
+					this.showCookieCloudInfo();
 				}
-			} else {
-				if (isCookieValid) {
-					this.showMobileLogout();
-				} else {
-					this.showMobileLogin();
-				}
-			}
-		} else {
-			this.showCookieCloudInfo();
-		}
-
-		this.showCookieStatus();
-		if (Platform.isDesktopApp) {
-			this.cookieAutoRefresh();
-			if (get(settingsStore).cookieAutoRefreshToggle) {
-				this.cookieRefreshInterval();
+				this.showCookieStatus();
 			}
 		}
 
@@ -423,10 +414,13 @@ export class WereadSettingsTab extends PluginSettingTab {
 		const settings = get(settingsStore);
 		if (
 			this.selectableBooksCache.length > 0 ||
-			this.selectableBooksLoadingPromise ||
-			!settings.isCookieValid ||
-			settings.cookies.length === 0
+			this.selectableBooksLoadingPromise
 		) {
+			return;
+		}
+		const hasApiKey = Boolean(settings.wereadApiKey);
+		const hasCookie = settings.isCookieValid && settings.cookies.length > 0;
+		if (!hasCookie && !hasApiKey) {
 			return;
 		}
 		this.selectableBooksLoadingPromise = this.fetchSelectableBooks()
@@ -813,20 +807,6 @@ export class WereadSettingsTab extends PluginSettingTab {
 		new Setting(this.containerEl).setName('阅读统计').setHeading();
 
 		new Setting(this.containerEl)
-			.setName('微信读书 API Key')
-			.setDesc('用于调用阅读统计等高级接口，格式：wrk-xxxxxxxx。可在微信读书开放平台申请。')
-			.addText((text) => {
-				text.setPlaceholder('wrk-xxxxxxxx')
-					.setValue(get(settingsStore).wereadApiKey ?? '')
-					.onChange((value) => {
-						settingsStore.actions.setWereadApiKey(value.trim());
-					});
-				text.inputEl.type = 'password';
-				text.inputEl.style.width = '260px';
-				return text;
-			});
-
-		new Setting(this.containerEl)
 			.setName('Heatmap 起始年份')
 			.setDesc('全部 Tab 的 Heatmap 从该年份开始展示，留空则使用注册时间。例如：2019')
 			.addText((text) =>
@@ -839,6 +819,105 @@ export class WereadSettingsTab extends PluginSettingTab {
 					})
 			);
 
+	}
+	private showApiKeySetting(): void {
+		let apiKeyText: TextComponent;
+		new Setting(this.containerEl)
+			.setName('微信读书 API Key')
+			.setDesc('用于调用微信读书 Agent API，支持同步笔记、划线、阅读统计等功能。格式：wrk-xxxxxxxx。')
+			.addText((text) => {
+				text.setPlaceholder('wrk-xxxxxxxx')
+					.setValue(get(settingsStore).wereadApiKey ?? '')
+					.onChange((value) => {
+						settingsStore.actions.setWereadApiKey(value.trim());
+					});
+				text.inputEl.type = 'password';
+				text.inputEl.style.width = '220px';
+				apiKeyText = text;
+				return text;
+			})
+			.addExtraButton((button) => {
+				button.setIcon('eye')
+					.setTooltip('显示/隐藏 API Key')
+					.onClick(() => {
+						const inputEl = apiKeyText.inputEl;
+						const isPassword = inputEl.type === 'password';
+						inputEl.type = isPassword ? 'text' : 'password';
+						button.setIcon(isPassword ? 'eye-off' : 'eye');
+					});
+				return button;
+			});
+
+		const apiKey = get(settingsStore).wereadApiKey;
+		if (apiKey) {
+			const userInfoContainer = this.containerEl.createDiv({
+				cls: 'weread-apikey-user-info'
+			});
+			// 初始加载状态
+			userInfoContainer.createDiv({
+				cls: 'weread-apikey-user-status',
+				text: '✅ API Key 已配置，正在获取用户信息...'
+			});
+			// 异步获取用户信息
+			this.fetchAndDisplayApiKeyUser(userInfoContainer);
+		} else {
+			new Setting(this.containerEl)
+				.setName('⚠️ 请填写 API Key')
+				.setDesc('API Key 格式为 wrk-xxxxxxxx。申请地址：微信读书开放平台');
+		}
+	}
+
+
+	private async fetchAndDisplayApiKeyUser(container: HTMLElement): Promise<void> {
+		try {
+			const apiRouter = new ApiRouter();
+			const userInfo = await apiRouter.getCurrentUser();
+			if (userInfo) {
+				container.empty();
+				// 提取用户信息（V2 返回格式可能嵌套在 data 中）
+				const info = (userInfo as any).data || userInfo;
+				const userName = info.name || info.userName || info.nickname || '未知用户';
+				const userAvatar = info.avatar || info.headImgUrl || info.avatarUrl || '';
+				const userSignature = info.signature || info.description || '';
+
+				const userRow = container.createDiv({ cls: 'weread-apikey-user-row' });
+				if (userAvatar) {
+					const avatarImg = userRow.createEl('img', {
+						cls: 'weread-apikey-user-avatar'
+					});
+					avatarImg.src = userAvatar;
+					avatarImg.alt = '用户头像';
+				}
+				const userText = userRow.createDiv({ cls: 'weread-apikey-user-text' });
+				userText.createDiv({
+					cls: 'weread-apikey-user-name',
+					text: `✅ API Key 已连接 · 用户：${userName}`
+				});
+				if (userSignature) {
+					userText.createDiv({
+						cls: 'weread-apikey-user-signature',
+						text: userSignature
+					});
+				}
+				userText.createDiv({
+					cls: 'weread-apikey-user-desc',
+					text: '同步、书架、阅读统计等功能均可正常使用'
+				});
+			} else {
+				container.empty();
+				container.createDiv({
+					cls: 'weread-apikey-user-status',
+					text: '✅ API Key 已配置（无法获取用户信息，请检查 API Key 有效性）'
+				});
+			}
+		} catch (e) {
+			console.warn('[weread plugin] 获取 API Key 用户信息失败', e);
+			container.empty();
+			container.createDiv({
+				cls: 'weread-apikey-user-status',
+				text: '✅ API Key 已配置（用户信息获取失败，功能不受影响）'
+			});
+		}
 	}
 
 	private showDebugHelp() {
@@ -880,12 +959,14 @@ export class WereadSettingsTab extends PluginSettingTab {
 			.addDropdown((dropdown) => {
 				dropdown.addOptions({
 					scan: '扫码登录',
-					cookieCloud: 'CookieCloud登录'
+					cookieCloud: 'CookieCloud 登录'
 				});
 				return dropdown.setValue(get(settingsStore).loginMethod).onChange(async (value) => {
 					console.debug('set login method to', value);
 					settingsStore.actions.setLoginMethod(value);
-					settingsStore.actions.clearCookies();
+					if (value !== 'apiKey') {
+						settingsStore.actions.clearCookies();
+					}
 					this.display();
 				});
 			});
@@ -951,46 +1032,15 @@ export class WereadSettingsTab extends PluginSettingTab {
 					.onClick(async () => {
 						button.setDisabled(true);
 						button.setButtonText('刷新中...');
-						const apiManager = new ApiManager();
-						await apiManager.refreshCookie();
+						const apiRouter2 = new ApiRouter();
+						await apiRouter2.refreshCookie();
 						this.display();
 					});
 			});
 		}
 	}
 
-	private cookieAutoRefresh(): void {
-		new Setting(this.containerEl)
-			.setName('自动刷新 Cookie')
-			.setDesc('启动 Obsidian 时自动刷新 Cookie，并按照设定的时间间隔定期刷新')
-			.addToggle((toggle) => {
-				return toggle
-					.setValue(get(settingsStore).cookieAutoRefreshToggle)
-					.onChange((value) => {
-						settingsStore.actions.setCookieAutoRefreshToggle(value);
-						this.plugin.setupCookieRefresh();
-						this.display();
-					});
-			});
-	}
 
-	private cookieRefreshInterval(): void {
-		new Setting(this.containerEl)
-			.setName('Cookie 刷新间隔（小时）')
-			.setDesc('设置自动刷新 Cookie 的时间间隔，单位为小时（最小 1 小时）')
-			.addText((text) => {
-				return text
-					.setPlaceholder('12')
-					.setValue(String(get(settingsStore).cookieRefreshInterval))
-					.onChange((value) => {
-						const num = parseInt(value, 10);
-						if (!isNaN(num) && num >= 1) {
-							settingsStore.actions.setCookieRefreshInterval(num);
-							this.plugin.setupCookieRefresh();
-						}
-					});
-			});
-	}
 
 	private scheduledSync(): void {
 		new Setting(this.containerEl)
@@ -1037,11 +1087,13 @@ export class WereadSettingsTab extends PluginSettingTab {
 			return this.selectableBooksCache;
 		}
 		const settings = get(settingsStore);
-		if (!settings.isCookieValid || settings.cookies.length === 0) {
-			throw new Error('请先登录微信读书后再加载书籍列表');
+		const hasApiKey2 = Boolean(settings.wereadApiKey);
+		const hasCookie2 = settings.isCookieValid && settings.cookies.length > 0;
+		if (!hasCookie2 && !hasApiKey2) {
+			throw new Error('请先登录微信读书或配置 API Key 后再加载书籍列表');
 		}
-		const apiManager = new ApiManager();
-		const notebookResp = await apiManager.getNotebooksWithRetry();
+		const apiRouter2 = new ApiRouter();
+		const notebookResp = await apiRouter2.getNotebooksWithRetry();
 		this.selectableBooksCache = notebookResp.map((noteBook) => parseMetadata(noteBook));
 		return this.selectableBooksCache;
 	}

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -869,16 +869,6 @@ export class WereadSettingsTab extends PluginSettingTab {
 			.addExtraButton((button) => {
 				statusBtn = button;
 				applyStatus(get(settingsStore).apiKeyValid, button);
-				button.onClick(async () => {
-					const currentKey = get(settingsStore).wereadApiKey;
-					if (!currentKey) return;
-					button.setIcon('loader-2').setTooltip('验证中...');
-					button.extraSettingsEl.style.color = 'var(--text-muted)';
-					const apiRouter = new ApiRouter();
-					const result = await apiRouter.validateApiKey();
-					settingsStore.actions.setApiKeyValid(result.valid);
-					applyStatus(result.valid);
-				});
 				return button;
 			});
 

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -1,4 +1,4 @@
-import WereadPlugin from 'main';
+import WereadPlugin from '../main';
 import {
 	App,
 	ExtraButtonComponent,

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -897,6 +897,14 @@ export class WereadSettingsTab extends PluginSettingTab {
 					});
 				return button;
 			});
+
+			// 进入设置页时自动校验一次，结果更新到状态图标
+			statusBtn.setIcon('loader-2').setTooltip('验证中...');
+			statusBtn.extraSettingsEl.style.color = 'var(--text-muted)';
+			new ApiRouter().validateApiKey().then((result) => {
+				settingsStore.actions.setApiKeyValid(result.valid);
+				applyStatus(result.valid);
+			});
 		} else if (Platform.isDesktopApp) {
 			setting.addButton((button) => {
 				button.setButtonText('扫码获取')

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -1,6 +1,7 @@
 import WereadPlugin from 'main';
 import {
 	App,
+	ExtraButtonComponent,
 	FuzzySuggestModal,
 	Modal,
 	Notice,
@@ -815,6 +816,22 @@ export class WereadSettingsTab extends PluginSettingTab {
 	}
 	private showApiKeySetting(): void {
 		let apiKeyText: TextComponent;
+		let statusBtn: ExtraButtonComponent;
+
+		const applyStatus = (valid: boolean | null, btn?: ExtraButtonComponent) => {
+			const b = btn ?? statusBtn;
+			if (!b) return;
+			if (valid === true) {
+				b.setIcon('check-circle').setTooltip('API Key 有效');
+				b.extraSettingsEl.style.color = 'var(--color-green)';
+			} else if (valid === false) {
+				b.setIcon('x-circle').setTooltip('API Key 无效，请检查或重新获取');
+				b.extraSettingsEl.style.color = 'var(--color-red)';
+			} else {
+				b.setIcon('help-circle').setTooltip('API Key 状态未知，点击验证');
+				b.extraSettingsEl.style.color = 'var(--text-muted)';
+			}
+		};
 
 		const descFrag = document
 			.createRange()
@@ -830,6 +847,8 @@ export class WereadSettingsTab extends PluginSettingTab {
 					.setValue(get(settingsStore).wereadApiKey ?? '')
 					.onChange((value) => {
 						settingsStore.actions.setWereadApiKey(value.trim());
+						settingsStore.actions.setApiKeyValid(null);
+						applyStatus(null);
 					});
 				text.inputEl.type = 'password';
 				text.inputEl.style.width = '220px';
@@ -846,25 +865,39 @@ export class WereadSettingsTab extends PluginSettingTab {
 						button.setIcon(isPassword ? 'eye-off' : 'eye');
 					});
 				return button;
+			})
+			.addExtraButton((button) => {
+				statusBtn = button;
+				applyStatus(get(settingsStore).apiKeyValid, button);
+				button.onClick(async () => {
+					const currentKey = get(settingsStore).wereadApiKey;
+					if (!currentKey) return;
+					button.setIcon('loader-2').setTooltip('验证中...');
+					button.extraSettingsEl.style.color = 'var(--text-muted)';
+					const apiRouter = new ApiRouter();
+					const result = await apiRouter.validateApiKey();
+					settingsStore.actions.setApiKeyValid(result.valid);
+					applyStatus(result.valid);
+				});
+				return button;
 			});
 
 		const apiKey = get(settingsStore).wereadApiKey;
 
 		if (apiKey) {
-			// 已设置 API Key → 显示注销按钮
 			setting.addButton((button) => {
 				button.setButtonText('注销')
 					.setTooltip('清除 API Key 和登录状态')
 					.onClick(async () => {
 						settingsStore.actions.clearCookies();
 						settingsStore.actions.setWereadApiKey('');
+						settingsStore.actions.setApiKeyValid(null);
 						new Notice('已注销，API Key 已清除');
 						this.display();
 					});
 				return button;
 			});
 		} else if (Platform.isDesktopApp) {
-			// 未设置 API Key → 显示扫码获取按钮（仅桌面端）
 			setting.addButton((button) => {
 				button.setButtonText('扫码获取')
 					.setTooltip('扫码登录获取 API Key')
@@ -873,17 +906,6 @@ export class WereadSettingsTab extends PluginSettingTab {
 					});
 				return button;
 			});
-		}
-
-		if (apiKey) {
-			const validationContainer = this.containerEl.createDiv({
-				cls: 'weread-apikey-validation'
-			});
-			validationContainer.createDiv({
-				cls: 'weread-apikey-validation-status',
-				text: '⏳ 正在校验 API Key...'
-			});
-			this.fetchAndDisplayValidation(validationContainer);
 		}
 	}
 
@@ -904,6 +926,7 @@ export class WereadSettingsTab extends PluginSettingTab {
 				const apiRouter = new ApiRouter();
 				const result = await apiRouter.fetchApiKey();
 				if (result?.apikey) {
+					settingsStore.actions.setApiKeyValid(true);
 					new Notice('API Key 获取成功');
 				} else {
 					new Notice('API Key 获取失败，请尝试重新扫码登录');
@@ -919,65 +942,6 @@ export class WereadSettingsTab extends PluginSettingTab {
 			button.setDisabled(false);
 			button.setButtonText('扫码获取');
 			this.display();
-		}
-	}
-
-	private async fetchAndDisplayValidation(container: HTMLElement): Promise<void> {
-		try {
-			const apiRouter = new ApiRouter();
-			const result = await apiRouter.validateApiKey();
-
-			// 如果有 Cookie，尝试获取 API Key 的元数据（创建日期、最近使用日期）
-			const settings = get(settingsStore);
-			let metadata: { createdAt?: number; lastUsedAt?: number } | null = null;
-			if (settings.isCookieValid && settings.cookies.length > 0) {
-				try {
-					metadata = await apiRouter.fetchApiKey();
-				} catch {
-					// 元数据获取失败不影响主流程
-				}
-			}
-
-			container.empty();
-
-			if (result.valid) {
-				// 第一行：状态 + 功能描述
-				container.createDiv({
-					cls: 'weread-apikey-validation-row weread-apikey-validation-valid',
-					text: '✅ API Key 有效 · 同步、书架、阅读统计等功能均可正常使用'
-				});
-
-				// 第二行：创建日期和最近使用日期
-				if (metadata?.createdAt || metadata?.lastUsedAt) {
-					const parts: string[] = [];
-					if (metadata?.createdAt) {
-						parts.push(`创建日期：${window.moment.unix(metadata.createdAt).format('YYYY-MM-DD')}`);
-					}
-					if (metadata?.lastUsedAt) {
-						parts.push(`最近使用：${window.moment.unix(metadata.lastUsedAt).format('YYYY-MM-DD HH:mm')}`);
-					}
-					container.createDiv({
-						cls: 'weread-apikey-validation-row',
-						text: parts.join(' · ')
-					});
-				}
-			} else {
-				container.createDiv({
-					cls: 'weread-apikey-validation-row weread-apikey-validation-invalid',
-					text: '❌ API Key 无效'
-				});
-				container.createDiv({
-					cls: 'weread-apikey-validation-desc',
-					text: '请检查 Key 是否正确，或点击「扫码获取」重新获取'
-				});
-			}
-		} catch (e) {
-			console.warn('[weread plugin] API Key 校验失败', e);
-			container.empty();
-			container.createDiv({
-				cls: 'weread-apikey-validation-row',
-				text: '⚠️ API Key 校验失败，请检查网络连接'
-			});
 		}
 	}
 

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -291,6 +291,7 @@ export class WereadSettingsTab extends PluginSettingTab {
 			this.saveArticleToggle();
 			this.noteCountLimit();
 		}
+		this.syncPopularHighlightsToggle();
 		this.renderSyncModeBookSelection(syncMode);
 	}
 
@@ -460,6 +461,19 @@ export class WereadSettingsTab extends PluginSettingTab {
 					settingsStore.actions.setSaveArticleToggle(value);
 					this.display();
 				});
+			});
+	}
+
+	private syncPopularHighlightsToggle(): void {
+		new Setting(this.containerEl)
+			.setName('同步热门划线')
+			.setDesc('开启后同步每本书最多 20 条热门划线（按热度排序），需要 API Key，仅 V2 支持')
+			.addToggle((toggle) => {
+				return toggle
+					.setValue(get(settingsStore).syncPopularHighlightsToggle)
+					.onChange((value) => {
+						settingsStore.actions.setSyncPopularHighlightsToggle(value);
+					});
 			});
 	}
 	private saveReadingInfoToggle(): void {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -79,6 +79,7 @@ export interface WereadPluginSettings {
 	convertTags: boolean;
 	saveArticleToggle: boolean;
 	saveReadingInfoToggle: boolean;
+	syncPopularHighlightsToggle: boolean;
 	readingOpenMode: ReadingOpenMode;
 	bookOpenMode: BookOpenMode;
 	trimBlocks: boolean;
@@ -134,6 +135,7 @@ const DEFAULT_SETTINGS: WereadPluginSettings = {
 	convertTags: false,
 	saveArticleToggle: true,
 	saveReadingInfoToggle: true,
+	syncPopularHighlightsToggle: false,
 	readingOpenMode: 'TAB',
 	bookOpenMode: 'web',
 	trimBlocks: false,
@@ -537,6 +539,13 @@ const createSettingsStore = () => {
 		});
 	};
 
+	const setSyncPopularHighlightsToggle = (value: boolean) => {
+		store.update((state) => {
+			state.syncPopularHighlightsToggle = value;
+			return state;
+		});
+	};
+
 	const setReadingOpenMode = (readingOpenMode: ReadingOpenMode) => {
 		store.update((state) => {
 			state.readingOpenMode = readingOpenMode;
@@ -764,6 +773,7 @@ const createSettingsStore = () => {
 			setConvertTags,
 			setSaveArticleToggle,
 			setSaveReadingInfoToggle,
+			setSyncPopularHighlightsToggle,
 			setReadingOpenMode,
 			setBookOpenMode,
 			setCookieCloudInfo,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -105,6 +105,7 @@ export interface WereadPluginSettings {
 	apiKeyValid: boolean | null;
 	readingStatsLocation: string;
 	statsStartYear?: number;
+	popularHighlightsCacheTtl: number; // 天数，默认7
 }
 
 const DEFAULT_SETTINGS: WereadPluginSettings = {
@@ -162,6 +163,7 @@ const DEFAULT_SETTINGS: WereadPluginSettings = {
 	apiKeyValid: null,
 	readingStatsLocation: '/',
 	statsStartYear: 0,  // 0 = use registTime from API
+	popularHighlightsCacheTtl: 7, // 默认7天
 };
 
 const createSettingsStore = () => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,6 +4,7 @@ import { Platform } from 'obsidian';
 import notebookTemolate from './themes/notebookTemplate.njk';
 import wereadOfficialTemplate from './themes/wereadOfficialTemplate.njk';
 import separatedTemplate from './themes/separatedTemplate.njk';
+import separatedWithPopularTemplate from './themes/separatedWithPopularTemplate.njk';
 import WereadPlugin from '../main';
 import type { SyncLogEntry, Theme } from './models';
 
@@ -43,6 +44,16 @@ export const BUILT_IN_THEMES: Theme[] = [
 		name: '微信官方笔记主题',
 		description: '详细的元数据信息，适合生成书籍笔记',
 		template: wereadOfficialTemplate,
+		trimBlocks: true,
+		isBuiltIn: true,
+		isReadOnly: true,
+		source: 'builtin'
+	},
+	{
+		id: 'builtin_separated_with_popular',
+		name: '分离式（含热门划线）',
+		description: '我的划线、热门划线、笔记分开展示，适合分析学习',
+		template: separatedWithPopularTemplate,
 		trimBlocks: true,
 		isBuiltIn: true,
 		isReadOnly: true,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -102,6 +102,7 @@ export interface WereadPluginSettings {
 	themes: Theme[];
 	activeThemeId: string;
 	wereadApiKey: string;
+	apiKeyValid: boolean | null;
 	readingStatsLocation: string;
 	statsStartYear?: number;
 }
@@ -158,6 +159,7 @@ const DEFAULT_SETTINGS: WereadPluginSettings = {
 	themes: BUILT_IN_THEMES,
 	activeThemeId: 'builtin_merged',
 	wereadApiKey: '',
+	apiKeyValid: null,
 	readingStatsLocation: '/',
 	statsStartYear: 0,  // 0 = use registTime from API
 };
@@ -730,6 +732,13 @@ const createSettingsStore = () => {
 		});
 	};
 
+	const setApiKeyValid = (valid: boolean | null) => {
+		store.update((state) => {
+			state.apiKeyValid = valid;
+			return state;
+		});
+	};
+
 	const setStatsStartYear = (year: number) => {
 		store.update((state) => {
 			state.statsStartYear = year;
@@ -796,6 +805,7 @@ const createSettingsStore = () => {
 			importTheme,
 			exportTheme,
 			setWereadApiKey,
+			setApiKeyValid,
 			setReadingStatsLocation,
 			setStatsStartYear,
 			setUserSignature,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -565,19 +565,7 @@ const createSettingsStore = () => {
 		});
 	};
 
-	const setCookieAutoRefreshToggle = (cookieAutoRefreshToggle: boolean) => {
-		store.update((state) => {
-			state.cookieAutoRefreshToggle = cookieAutoRefreshToggle;
-			return state;
-		});
-	};
 
-	const setCookieRefreshInterval = (cookieRefreshInterval: number) => {
-		store.update((state) => {
-			state.cookieRefreshInterval = cookieRefreshInterval;
-			return state;
-		});
-	};
 
 	const setScheduledSyncToggle = (scheduledSyncToggle: boolean) => {
 		store.update((state) => {
@@ -780,8 +768,6 @@ const createSettingsStore = () => {
 			setBookOpenMode,
 			setCookieCloudInfo,
 			setTrimBlocks,
-			setCookieAutoRefreshToggle,
-			setCookieRefreshInterval,
 			setIsCookieValid,
 			setScheduledSyncToggle,
 			setScheduledSyncInterval,

--- a/src/syncNotebooks.ts
+++ b/src/syncNotebooks.ts
@@ -209,10 +209,25 @@ export default class SyncNotebooks {
 		}
 		const bookReview = parseChapterReviews(reviewResp);
 		let popularHighlights;
-		if (get(settingsStore).syncPopularHighlightsToggle) {
+		const popularEnabled = get(settingsStore).syncPopularHighlightsToggle;
+		console.log('[weread] syncPopularHighlightsToggle =', popularEnabled);
+		if (popularEnabled) {
 			const bestResp = await this.apiManager.getBestBookmarks(metaData.bookId);
+			console.log('[weread] bestbookmarks resp =', bestResp);
 			if (bestResp?.items?.length) {
 				popularHighlights = parsePopularHighlights(bestResp);
+				console.log('[weread] popularHighlights parsed =', popularHighlights.length, 'items');
+				// 按 chapterUid 分发到各章节
+				for (const chapter of chapterHighlightReview) {
+					const chapterPopular = popularHighlights.filter(
+						(p) => p.chapterUid === chapter.chapterUid
+					);
+					if (chapterPopular.length > 0) {
+						chapter.popularHighlights = chapterPopular;
+					}
+				}
+			} else {
+				console.warn('[weread] bestbookmarks: no items returned', bestResp);
 			}
 		}
 		return {

--- a/src/syncNotebooks.ts
+++ b/src/syncNotebooks.ts
@@ -1,4 +1,4 @@
-import ApiManager from './api';
+import ApiRouter from './api-router';
 import FileManager from './fileManager';
 import {
 	Metadata,

--- a/src/syncNotebooks.ts
+++ b/src/syncNotebooks.ts
@@ -16,8 +16,7 @@ import {
 	parseDailyNoteReferences,
 	parseReviews,
 	parseChapterResp,
-	parseArticleHighlightReview,
-	parsePopularHighlights
+	parseArticleHighlightReview
 } from './parser/parseResponse';
 import { settingsStore } from './settings';
 import { get } from 'svelte/store';
@@ -208,18 +207,65 @@ export default class SyncNotebooks {
 			chapterHighlightReview = parseChapterHighlightReview(chapters, highlights, reviews);
 		}
 		const bookReview = parseChapterReviews(reviewResp);
-		let popularHighlights;
 		if (get(settingsStore).syncPopularHighlightsToggle) {
 			const bestResp = await this.apiManager.getBestBookmarks(metaData.bookId);
 			if (bestResp?.items?.length) {
-				popularHighlights = parsePopularHighlights(bestResp);
+				// 按 chapterUid 分组热门划线
+				const popularByChapter = new Map<number, typeof bestResp.items[0][]>();
+				for (const item of bestResp.items) {
+					if (!popularByChapter.has(item.chapterUid)) popularByChapter.set(item.chapterUid, []);
+					popularByChapter.get(item.chapterUid).push(item);
+				}
+				const chapterInfoMap = new Map(bestResp.chapters.map((c) => [c.chapterUid, c]));
+
+				for (const chapter of chapterHighlightReview) {
+					const chapterPopular = popularByChapter.get(chapter.chapterUid) ?? [];
+					if (chapterPopular.length === 0) continue;
+
+					const existingHighlights = chapter.highlights ?? [];
+					const userRangeSet = new Set(existingHighlights.map((h) => h.range));
+
+					// 已有划线与热门重叠：标记为热门并加人数
+					for (const h of existingHighlights) {
+						const match = chapterPopular.find((p) => p.range === h.range);
+						if (match) {
+							h.isPopular = true;
+							h.popularCount = match.totalCount;
+						}
+					}
+
+					// 热门划线中用户未标注的：追加为新 Highlight
+					for (const p of chapterPopular) {
+						if (!userRangeSet.has(p.range)) {
+							const info = chapterInfoMap.get(p.chapterUid);
+							existingHighlights.push({
+								bookmarkId: p.bookmarkId,
+								created: 0,
+								createTime: '',
+								chapterUid: p.chapterUid,
+								chapterIdx: info?.chapterIdx ?? chapter.chapterIdx ?? 0,
+								chapterTitle: info?.title ?? chapter.chapterTitle,
+								markText: p.markText,
+								style: 0,
+								colorStyle: 0,
+								range: p.range,
+								isPopular: true,
+								popularCount: p.totalCount
+							});
+						}
+					}
+
+					// 按 range 起始位置重新排序
+					chapter.highlights = existingHighlights.sort((a, b) => {
+						return (parseInt(a.range.split('-')[0]) || 0) - (parseInt(b.range.split('-')[0]) || 0);
+					});
+				}
 			}
 		}
 		return {
 			metaData: metaData,
 			chapterHighlights: chapterHighlightReview,
-			bookReview: bookReview,
-			popularHighlights
+			bookReview: bookReview
 		};
 	}
 

--- a/src/syncNotebooks.ts
+++ b/src/syncNotebooks.ts
@@ -209,25 +209,10 @@ export default class SyncNotebooks {
 		}
 		const bookReview = parseChapterReviews(reviewResp);
 		let popularHighlights;
-		const popularEnabled = get(settingsStore).syncPopularHighlightsToggle;
-		console.log('[weread] syncPopularHighlightsToggle =', popularEnabled);
-		if (popularEnabled) {
+		if (get(settingsStore).syncPopularHighlightsToggle) {
 			const bestResp = await this.apiManager.getBestBookmarks(metaData.bookId);
-			console.log('[weread] bestbookmarks resp =', bestResp);
 			if (bestResp?.items?.length) {
 				popularHighlights = parsePopularHighlights(bestResp);
-				console.log('[weread] popularHighlights parsed =', popularHighlights.length, 'items');
-				// 按 chapterUid 分发到各章节
-				for (const chapter of chapterHighlightReview) {
-					const chapterPopular = popularHighlights.filter(
-						(p) => p.chapterUid === chapter.chapterUid
-					);
-					if (chapterPopular.length > 0) {
-						chapter.popularHighlights = chapterPopular;
-					}
-				}
-			} else {
-				console.warn('[weread] bestbookmarks: no items returned', bestResp);
 			}
 		}
 		return {

--- a/src/syncNotebooks.ts
+++ b/src/syncNotebooks.ts
@@ -16,7 +16,8 @@ import {
 	parseDailyNoteReferences,
 	parseReviews,
 	parseChapterResp,
-	parseArticleHighlightReview
+	parseArticleHighlightReview,
+	parsePopularHighlights
 } from './parser/parseResponse';
 import { settingsStore } from './settings';
 import { get } from 'svelte/store';
@@ -207,10 +208,18 @@ export default class SyncNotebooks {
 			chapterHighlightReview = parseChapterHighlightReview(chapters, highlights, reviews);
 		}
 		const bookReview = parseChapterReviews(reviewResp);
+		let popularHighlights;
+		if (get(settingsStore).syncPopularHighlightsToggle) {
+			const bestResp = await this.apiManager.getBestBookmarks(metaData.bookId);
+			if (bestResp?.items?.length) {
+				popularHighlights = parsePopularHighlights(bestResp);
+			}
+		}
 		return {
 			metaData: metaData,
 			chapterHighlights: chapterHighlightReview,
-			bookReview: bookReview
+			bookReview: bookReview,
+			popularHighlights
 		};
 	}
 

--- a/src/syncNotebooks.ts
+++ b/src/syncNotebooks.ts
@@ -24,11 +24,11 @@ import { Notice } from 'obsidian';
 import { createSyncFilterContext, evaluateMetadataSyncFilter } from './syncFilter';
 export default class SyncNotebooks {
 	private fileManager: FileManager;
-	private apiManager: ApiManager;
+	private apiManager: ApiRouter;
 
-	constructor(fileManager: FileManager, apiManeger: ApiManager) {
+	constructor(fileManager: FileManager, apiManager: ApiRouter) {
 		this.fileManager = fileManager;
-		this.apiManager = apiManeger;
+		this.apiManager = apiManager;
 	}
 
 	async syncNotebook(noteFile: AnnotationFile) {

--- a/src/syncNotebooks.ts
+++ b/src/syncNotebooks.ts
@@ -1,12 +1,15 @@
 import ApiRouter from './api-router';
 import FileManager from './fileManager';
+import PopularHighlightsCacheManager from './popularHighlightsCache';
 import {
 	Metadata,
 	Notebook,
 	AnnotationFile,
 	BookProgressResponse,
 	SyncedNote,
-	SyncLogEntry
+	SyncLogEntry,
+	PopularChapterHighlight,
+	PopularHighlight
 } from './models';
 import {
 	parseHighlights,
@@ -20,15 +23,17 @@ import {
 } from './parser/parseResponse';
 import { settingsStore } from './settings';
 import { get } from 'svelte/store';
-import { Notice } from 'obsidian';
+import { Notice, Vault } from 'obsidian';
 import { createSyncFilterContext, evaluateMetadataSyncFilter } from './syncFilter';
 export default class SyncNotebooks {
 	private fileManager: FileManager;
 	private apiManager: ApiRouter;
+	private cacheManager: PopularHighlightsCacheManager;
 
-	constructor(fileManager: FileManager, apiManager: ApiRouter) {
+	constructor(fileManager: FileManager, apiManager: ApiRouter, vault: Vault) {
 		this.fileManager = fileManager;
 		this.apiManager = apiManager;
+		this.cacheManager = new PopularHighlightsCacheManager(vault);
 	}
 
 	async syncNotebook(noteFile: AnnotationFile) {
@@ -207,19 +212,35 @@ export default class SyncNotebooks {
 			chapterHighlightReview = parseChapterHighlightReview(chapters, highlights, reviews);
 		}
 		const bookReview = parseChapterReviews(reviewResp);
+
+		let popularHighlights: PopularChapterHighlight[] = [];
+
 		if (get(settingsStore).syncPopularHighlightsToggle) {
-			const bestResp = await this.apiManager.getBestBookmarks(metaData.bookId);
-			if (bestResp?.items?.length) {
-				// 按 chapterUid 分组热门划线
-				const popularByChapter = new Map<number, typeof bestResp.items[0][]>();
-				for (const item of bestResp.items) {
-					if (!popularByChapter.has(item.chapterUid)) popularByChapter.set(item.chapterUid, []);
-					popularByChapter.get(item.chapterUid).push(item);
+			// 构建章节信息
+			const chaptersInfo = chapters.map((c) => ({
+				chapterUid: c.chapterUid ?? 0,
+				chapterIdx: c.chapterIdx ?? 0,
+				title: c.title
+			}));
+
+			// 获取热门划线（缓存优先 + 并发查询）
+			popularHighlights = await this.getPopularHighlights(metaData.bookId, chaptersInfo);
+
+			// 判断当前是否为分离式主题
+			const activeTheme = get(settingsStore).themes?.find(
+				(t) => t.id === get(settingsStore).activeThemeId
+			);
+			const isSeparatedWithPopularTheme = activeTheme?.id === 'builtin_separated_with_popular';
+
+			if (!isSeparatedWithPopularTheme) {
+				// 合并模式：热门划线合并到章节划线中
+				const popularByChapter = new Map<number, PopularHighlight[]>();
+				for (const chapter of popularHighlights) {
+					popularByChapter.set(chapter.chapterUid, chapter.highlights);
 				}
-				const chapterInfoMap = new Map(bestResp.chapters.map((c) => [c.chapterUid, c]));
 
 				for (const chapter of chapterHighlightReview) {
-					const chapterPopular = popularByChapter.get(chapter.chapterUid) ?? [];
+					const chapterPopular = popularByChapter.get(chapter.chapterUid ?? 0) ?? [];
 					if (chapterPopular.length === 0) continue;
 
 					const existingHighlights = chapter.highlights ?? [];
@@ -237,22 +258,27 @@ export default class SyncNotebooks {
 					// 热门划线中用户未标注的：追加为新 Highlight
 					for (const p of chapterPopular) {
 						if (!userRangeSet.has(p.range)) {
-							const info = chapterInfoMap.get(p.chapterUid);
 							existingHighlights.push({
 								bookmarkId: p.bookmarkId,
 								created: 0,
 								createTime: '',
-								chapterUid: p.chapterUid,
-								chapterIdx: info?.chapterIdx ?? chapter.chapterIdx ?? 0,
-								chapterTitle: info?.title ?? chapter.chapterTitle,
+								chapterUid: chapter.chapterUid ?? 0,
+								chapterIdx: chapter.chapterIdx ?? 0,
+								chapterTitle: chapter.chapterTitle,
 								markText: p.markText,
 								style: 0,
 								colorStyle: 0,
 								range: p.range,
 								isPopular: true,
-								popularCount: p.totalCount
+								popularCount: p.totalCount,
+								isUserHighlight: false
 							});
 						}
+					}
+
+					// 标记所有用户划线
+					for (const h of existingHighlights) {
+						h.isUserHighlight = true;
 					}
 
 					// 按 range 起始位置重新排序
@@ -260,13 +286,118 @@ export default class SyncNotebooks {
 						return (parseInt(a.range.split('-')[0]) || 0) - (parseInt(b.range.split('-')[0]) || 0);
 					});
 				}
+			} else {
+				// 分离模式：标记用户划线中的热门
+				for (const chapter of chapterHighlightReview) {
+					if (chapter.highlights) {
+						for (const h of chapter.highlights) {
+							h.isUserHighlight = true;
+							// 查找对应的热门划线
+							const popularChapter = popularHighlights.find(
+								(p) => p.chapterUid === chapter.chapterUid
+							);
+							if (popularChapter) {
+								const match = popularChapter.highlights.find((p) => p.range === h.range);
+								if (match) {
+									h.isPopular = true;
+									h.popularCount = match.totalCount;
+								}
+							}
+						}
+					}
+				}
 			}
 		}
 		return {
 			metaData: metaData,
 			chapterHighlights: chapterHighlightReview,
-			bookReview: bookReview
+			bookReview: bookReview,
+			popularHighlights: popularHighlights
 		};
+	}
+
+	/**
+	 * 获取热门划线（支持缓存 + 并发查询）
+	 */
+	private async getPopularHighlights(
+		bookId: string,
+		chapters: { chapterUid: number; chapterIdx: number; title: string }[]
+	): Promise<PopularChapterHighlight[]> {
+		// 1. 尝试从缓存获取
+		const cached = await this.cacheManager.get(bookId);
+		if (cached) {
+			return this.groupPopularByChapter(cached.items, cached.chapters);
+		}
+
+		// 2. 缓存未命中，使用并发批量获取
+		const chapterUids = chapters.map((c) => c.chapterUid);
+		const popularByChapter = await this.apiManager.getBestBookmarksBatch(bookId, chapterUids, 5);
+
+		// 3. 转换为数组格式
+		const items: {
+			bookmarkId: string;
+			chapterUid: number;
+			chapterTitle: string;
+			range: string;
+			markText: string;
+			totalCount: number;
+		}[] = [];
+		const chapterMap = new Map(chapters.map((c) => [c.chapterUid, c]));
+
+		for (const [chapterUid, highlights] of popularByChapter) {
+			const chapterInfo = chapterMap.get(chapterUid);
+			for (const h of highlights) {
+				items.push({
+					bookmarkId: h.bookmarkId,
+					chapterUid,
+					chapterTitle: chapterInfo?.title ?? '',
+					range: h.range,
+					markText: h.markText,
+					totalCount: h.totalCount
+				});
+			}
+		}
+
+		// 缓存章节类型（包含 bookId）
+		type CacheChapter = { bookId: string; chapterUid: number; chapterIdx: number; title: string };
+
+		// 4. 写入缓存
+		const cacheChapters: CacheChapter[] = chapters.map((c) => ({
+			bookId,
+			chapterUid: c.chapterUid,
+			chapterIdx: c.chapterIdx,
+			title: c.title
+		}));
+		await this.cacheManager.set(bookId, items as PopularHighlight[], cacheChapters);
+
+		// 5. 按章节分组返回
+		return this.groupPopularByChapter(items as PopularHighlight[], cacheChapters);
+	}
+
+	/**
+	 * 按章节分组热门划线
+	 */
+	private groupPopularByChapter(
+		items: PopularHighlight[],
+		chapters: { bookId?: string; chapterUid: number; chapterIdx: number; title: string }[]
+	): PopularChapterHighlight[] {
+		const chapterMap = new Map(chapters.map((c) => [c.chapterUid, c]));
+		const grouped = new Map<number, PopularChapterHighlight>();
+
+		for (const item of items) {
+			if (!grouped.has(item.chapterUid)) {
+				const chapterInfo = chapterMap.get(item.chapterUid);
+				grouped.set(item.chapterUid, {
+					chapterUid: item.chapterUid,
+					chapterIdx: chapterInfo?.chapterIdx ?? 0,
+					chapterTitle: chapterInfo?.title ?? item.chapterTitle,
+					highlights: []
+				});
+			}
+			grouped.get(item.chapterUid).highlights.push(item);
+		}
+
+		return Array.from(grouped.values());
 	}
 
 	private async filterNoteMetas(force = false, metaDataArr: Metadata[]): Promise<Metadata[]> {

--- a/src/syncReadingStats.ts
+++ b/src/syncReadingStats.ts
@@ -1,5 +1,5 @@
 import { Notice, Vault } from 'obsidian';
-import ApiManager from './api';
+import ApiRouter from './api-router';
 import { settingsStore } from './settings';
 import { get } from 'svelte/store';
 import type { ReadingStatsResponse } from './models';
@@ -282,7 +282,7 @@ function buildMarkdown(
 export default class SyncReadingStats {
 	constructor(
 		private vault: Vault,
-		private apiManager: ApiManager
+		private apiManager: ApiRouter
 	) {}
 
 	async sync(): Promise<void> {

--- a/src/themes/notebookTemplate.njk
+++ b/src/themes/notebookTemplate.njk
@@ -26,7 +26,12 @@ lastReadDate: {{ metaData.lastReadDate }}
 {% for highlight in chapter.highlights %}
 {% set rangeParts = highlight.range | split("-") %}
 {% set deeplink = "weread://bestbookmark?bookId=" + metaData.bookId + "&chapterUid=" + highlight.chapterUid + "&rangeStart=" + rangeParts[0] + "&rangeEnd=" + rangeParts[1] %}
+{% if highlight.isPopular %}
+> 🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) — 🙋 {{ highlight.popularCount }} 人划线 ^{{ highlight.bookmarkId }}
 {% if highlight.reviewContent %}
+- 💭 {{ highlight.reviewContent }}
+{% endif %}
+{% elif highlight.reviewContent %}
 > 📌 [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
 - 💭 {{ highlight.reviewContent }} - ⏱ {{ highlight.createTime }}
 {% else %}
@@ -64,15 +69,5 @@ lastReadDate: {{ metaData.lastReadDate }}
 ## 书评 No.{{ loop.index }}
 {{ bookReview.mdContent }} ^{{ bookReview.reviewId }}
 ⏱ {{ bookReview.createTime }}
-{% endfor %}
-{% endif %}
-
-{% if popularHighlights %}
-# 热门划线
-{% for chapter in popularHighlights %}
-## {{ chapter.chapterTitle }}
-{% for item in chapter.highlights %}
-> 🔥 {{ item.markText | trim }} — 🙋 {{ item.totalCount }} 人划线
-{% endfor %}
 {% endfor %}
 {% endif %}

--- a/src/themes/notebookTemplate.njk
+++ b/src/themes/notebookTemplate.njk
@@ -26,11 +26,15 @@ lastReadDate: {{ metaData.lastReadDate }}
 {% for highlight in chapter.highlights %}
 {% set rangeParts = highlight.range | split("-") %}
 {% set deeplink = "weread://bestbookmark?bookId=" + metaData.bookId + "&chapterUid=" + highlight.chapterUid + "&rangeStart=" + rangeParts[0] + "&rangeEnd=" + rangeParts[1] %}
-{% if highlight.isPopular %}
-> 🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) — 🙋 {{ highlight.popularCount }} 人划线 ^{{ highlight.bookmarkId }}
+{% if highlight.isPopular and highlight.created > 0 %}
+> 📌🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) — 🙋 {{ highlight.popularCount }} 人划线 ^{{ highlight.bookmarkId }}
 {% if highlight.reviewContent %}
-- 💭 {{ highlight.reviewContent }}
+- 💭 {{ highlight.reviewContent }} - ⏱ {{ highlight.createTime }}
+{% else %}
+> ⏱ {{ highlight.createTime }}
 {% endif %}
+{% elif highlight.isPopular %}
+> 🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) — 🙋 {{ highlight.popularCount }} 人划线 ^{{ highlight.bookmarkId }}
 {% elif highlight.reviewContent %}
 > 📌 [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
 - 💭 {{ highlight.reviewContent }} - ⏱ {{ highlight.createTime }}

--- a/src/themes/notebookTemplate.njk
+++ b/src/themes/notebookTemplate.njk
@@ -15,6 +15,7 @@ lastReadDate: {{ metaData.lastReadDate }}
 > - PC地址：{{ metaData.pcUrl }}
 
 # 高亮划线
+{% if syncPopularHighlightsToggle %}
 {% for chapter in chapterHighlights %}
 {% if chapter.level == 1 %}
 ## {{ chapter.chapterTitle }}
@@ -56,6 +57,30 @@ lastReadDate: {{ metaData.lastReadDate }}
 {% endif %}
 {% endfor %}
 {% endfor %}
+{% else %}
+{% for chapter in chapterHighlights %}
+{% if chapter.level == 1 %}
+## {{ chapter.chapterTitle }}
+{% elif chapter.level == 2 %}
+### {{ chapter.chapterTitle }}
+{% elif chapter.level == 3 %}
+#### {{ chapter.chapterTitle }}
+{% endif %}
+{% for highlight in chapter.highlights %}
+{% set rangeParts = highlight.range | split("-") %}
+{% set deeplink = "weread://bestbookmark?bookId=" + metaData.bookId + "&chapterUid=" + highlight.chapterUid + "&rangeStart=" + rangeParts[0] + "&rangeEnd=" + rangeParts[1] %}
+{# 普通用户划线（不显示热门）：📌 #}
+{% if highlight.reviewContent %}
+> 📌 [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
+- 💭 {{ highlight.reviewContent }} - ⏱ {{ highlight.createTime }}
+{% else %}
+> 📌 [{{ highlight.markText | trim }}](<{{ deeplink }}>)
+> ⏱ {{ highlight.createTime }} ^{{ highlight.bookmarkId }}
+
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endif %}
 
 # 读书笔记
 {% for chapter in bookReview.chapterReviews %}

--- a/src/themes/notebookTemplate.njk
+++ b/src/themes/notebookTemplate.njk
@@ -69,9 +69,10 @@ lastReadDate: {{ metaData.lastReadDate }}
 
 {% if popularHighlights %}
 # 热门划线
-{% for item in popularHighlights %}
+{% for chapter in popularHighlights %}
+## {{ chapter.chapterTitle }}
+{% for item in chapter.highlights %}
 > 🔥 {{ item.markText | trim }} — 🙋 {{ item.totalCount }} 人划线
-> 📖 {{ item.chapterTitle }}
-
+{% endfor %}
 {% endfor %}
 {% endif %}

--- a/src/themes/notebookTemplate.njk
+++ b/src/themes/notebookTemplate.njk
@@ -32,6 +32,7 @@ lastReadDate: {{ metaData.lastReadDate }}
 {% else %}
 > 📌 [{{ highlight.markText | trim }}](<{{ deeplink }}>)
 > ⏱ {{ highlight.createTime }} ^{{ highlight.bookmarkId }}
+
 {% endif %}
 {% endfor %}
 {% endfor %}

--- a/src/themes/notebookTemplate.njk
+++ b/src/themes/notebookTemplate.njk
@@ -34,11 +34,6 @@ lastReadDate: {{ metaData.lastReadDate }}
 > ⏱ {{ highlight.createTime }} ^{{ highlight.bookmarkId }}
 {% endif %}
 {% endfor %}
-{% if chapter.popularHighlights %}
-{% for item in chapter.popularHighlights %}
-> 🔥 {{ item.markText | trim }} — 🙋 {{ item.totalCount }} 人划线
-{% endfor %}
-{% endif %}
 {% endfor %}
 
 # 读书笔记
@@ -69,5 +64,14 @@ lastReadDate: {{ metaData.lastReadDate }}
 ## 书评 No.{{ loop.index }}
 {{ bookReview.mdContent }} ^{{ bookReview.reviewId }}
 ⏱ {{ bookReview.createTime }}
+{% endfor %}
+{% endif %}
+
+{% if popularHighlights %}
+# 热门划线
+{% for item in popularHighlights %}
+> 🔥 {{ item.markText | trim }} — 🙋 {{ item.totalCount }} 人划线
+> 📖 {{ item.chapterTitle }}
+
 {% endfor %}
 {% endif %}

--- a/src/themes/notebookTemplate.njk
+++ b/src/themes/notebookTemplate.njk
@@ -34,6 +34,11 @@ lastReadDate: {{ metaData.lastReadDate }}
 > ⏱ {{ highlight.createTime }} ^{{ highlight.bookmarkId }}
 {% endif %}
 {% endfor %}
+{% if chapter.popularHighlights %}
+{% for item in chapter.popularHighlights %}
+> 🔥 {{ item.markText | trim }} — 🙋 {{ item.totalCount }} 人划线
+{% endfor %}
+{% endif %}
 {% endfor %}
 
 # 读书笔记
@@ -64,14 +69,5 @@ lastReadDate: {{ metaData.lastReadDate }}
 ## 书评 No.{{ loop.index }}
 {{ bookReview.mdContent }} ^{{ bookReview.reviewId }}
 ⏱ {{ bookReview.createTime }}
-{% endfor %}
-{% endif %}
-
-{% if popularHighlights and popularHighlights.length > 0 %}
-# 热门划线
-{% for item in popularHighlights %}
-> 🔥 {{ item.markText | trim }} — 🙋 {{ item.totalCount }} 人划线
-> 📖 {{ item.chapterTitle }}
-
 {% endfor %}
 {% endif %}

--- a/src/themes/notebookTemplate.njk
+++ b/src/themes/notebookTemplate.njk
@@ -26,6 +26,25 @@ lastReadDate: {{ metaData.lastReadDate }}
 {% for highlight in chapter.highlights %}
 {% set rangeParts = highlight.range | split("-") %}
 {% set deeplink = "weread://bestbookmark?bookId=" + metaData.bookId + "&chapterUid=" + highlight.chapterUid + "&rangeStart=" + rangeParts[0] + "&rangeEnd=" + rangeParts[1] %}
+{% if highlight.isPopular and highlight.isUserHighlight %}
+{# 用户自己的划线 + 热门：📌🔥 + 共读人数 #}
+{% if highlight.reviewContent %}
+> 📌🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
+> 🔥 {{ highlight.popularCount }} 人共读
+- 💭 {{ highlight.reviewContent }} - ⏱ {{ highlight.createTime }}
+{% else %}
+> 📌🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>)
+> 🔥 {{ highlight.popularCount }} 人共读
+> ⏱ {{ highlight.createTime }} ^{{ highlight.bookmarkId }}
+
+{% endif %}
+{% elif highlight.isPopular %}
+{# 只有热门划线（非用户）：🔥 + 共读人数 #}
+> 🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>)
+> 📊 {{ highlight.popularCount }} 人共读 ^{{ highlight.bookmarkId }}
+
+{% else %}
+{# 普通用户划线（非热门）：📌 #}
 {% if highlight.reviewContent %}
 > 📌 [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
 - 💭 {{ highlight.reviewContent }} - ⏱ {{ highlight.createTime }}
@@ -33,6 +52,7 @@ lastReadDate: {{ metaData.lastReadDate }}
 > 📌 [{{ highlight.markText | trim }}](<{{ deeplink }}>)
 > ⏱ {{ highlight.createTime }} ^{{ highlight.bookmarkId }}
 
+{% endif %}
 {% endif %}
 {% endfor %}
 {% endfor %}

--- a/src/themes/notebookTemplate.njk
+++ b/src/themes/notebookTemplate.njk
@@ -26,16 +26,7 @@ lastReadDate: {{ metaData.lastReadDate }}
 {% for highlight in chapter.highlights %}
 {% set rangeParts = highlight.range | split("-") %}
 {% set deeplink = "weread://bestbookmark?bookId=" + metaData.bookId + "&chapterUid=" + highlight.chapterUid + "&rangeStart=" + rangeParts[0] + "&rangeEnd=" + rangeParts[1] %}
-{% if highlight.isPopular and highlight.created > 0 %}
-> 📌🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) — 🙋 {{ highlight.popularCount }} 人划线 ^{{ highlight.bookmarkId }}
 {% if highlight.reviewContent %}
-- 💭 {{ highlight.reviewContent }} - ⏱ {{ highlight.createTime }}
-{% else %}
-> ⏱ {{ highlight.createTime }}
-{% endif %}
-{% elif highlight.isPopular %}
-> 🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) — 🙋 {{ highlight.popularCount }} 人划线 ^{{ highlight.bookmarkId }}
-{% elif highlight.reviewContent %}
 > 📌 [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
 - 💭 {{ highlight.reviewContent }} - ⏱ {{ highlight.createTime }}
 {% else %}

--- a/src/themes/notebookTemplate.njk
+++ b/src/themes/notebookTemplate.njk
@@ -66,3 +66,12 @@ lastReadDate: {{ metaData.lastReadDate }}
 ⏱ {{ bookReview.createTime }}
 {% endfor %}
 {% endif %}
+
+{% if popularHighlights and popularHighlights.length > 0 %}
+# 热门划线
+{% for item in popularHighlights %}
+> 🔥 {{ item.markText | trim }} — 🙋 {{ item.totalCount }} 人划线
+> 📖 {{ item.chapterTitle }}
+
+{% endfor %}
+{% endif %}

--- a/src/themes/separatedTemplate.njk
+++ b/src/themes/separatedTemplate.njk
@@ -18,13 +18,7 @@ lastReadDate: {{ metaData.lastReadDate }}
 {% for highlight in chapter.highlights %}
 {% set rangeParts = highlight.range | split("-") %}
 {% set deeplink = "weread://bestbookmark?bookId=" + metaData.bookId + "&chapterUid=" + highlight.chapterUid + "&rangeStart=" + rangeParts[0] + "&rangeEnd=" + rangeParts[1] %}
-{% if highlight.isPopular and highlight.created > 0 %}
-> 📌🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) — 🙋 {{ highlight.popularCount }} 人划线 ^{{ highlight.bookmarkId }}
-{% elif highlight.isPopular %}
-> 🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) — 🙋 {{ highlight.popularCount }} 人划线 ^{{ highlight.bookmarkId }}
-{% else %}
 > 📌 [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
-{% endif %}
 {% endfor %}
 {% endfor %}
 

--- a/src/themes/separatedTemplate.njk
+++ b/src/themes/separatedTemplate.njk
@@ -18,7 +18,12 @@ lastReadDate: {{ metaData.lastReadDate }}
 {% for highlight in chapter.highlights %}
 {% set rangeParts = highlight.range | split("-") %}
 {% set deeplink = "weread://bestbookmark?bookId=" + metaData.bookId + "&chapterUid=" + highlight.chapterUid + "&rangeStart=" + rangeParts[0] + "&rangeEnd=" + rangeParts[1] %}
+{% if syncPopularHighlightsToggle and highlight.isPopular %}
+> 📌🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
+> 🔥 {{ highlight.popularCount }} 人共读
+{% else %}
 > 📌 [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
+{% endif %}
 {% endfor %}
 {% endfor %}
 

--- a/src/themes/separatedTemplate.njk
+++ b/src/themes/separatedTemplate.njk
@@ -20,6 +20,11 @@ lastReadDate: {{ metaData.lastReadDate }}
 {% set deeplink = "weread://bestbookmark?bookId=" + metaData.bookId + "&chapterUid=" + highlight.chapterUid + "&rangeStart=" + rangeParts[0] + "&rangeEnd=" + rangeParts[1] %}
 > 📌 [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
 {% endfor %}
+{% if chapter.popularHighlights %}
+{% for item in chapter.popularHighlights %}
+> 🔥 {{ item.markText | trim }} — 🙋 {{ item.totalCount }} 人划线
+{% endfor %}
+{% endif %}
 {% endfor %}
 
 # 笔记汇总
@@ -39,14 +44,5 @@ lastReadDate: {{ metaData.lastReadDate }}
 # 书评
 {{ bookReview.createTime }}
 {{ bookReview.mdContent }}
-{% endfor %}
-{% endif %}
-
-{% if popularHighlights and popularHighlights.length > 0 %}
-# 热门划线
-{% for item in popularHighlights %}
-> 🔥 {{ item.markText | trim }} — 🙋 {{ item.totalCount }} 人划线
-> 📖 {{ item.chapterTitle }}
-
 {% endfor %}
 {% endif %}

--- a/src/themes/separatedTemplate.njk
+++ b/src/themes/separatedTemplate.njk
@@ -20,11 +20,6 @@ lastReadDate: {{ metaData.lastReadDate }}
 {% set deeplink = "weread://bestbookmark?bookId=" + metaData.bookId + "&chapterUid=" + highlight.chapterUid + "&rangeStart=" + rangeParts[0] + "&rangeEnd=" + rangeParts[1] %}
 > 📌 [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
 {% endfor %}
-{% if chapter.popularHighlights %}
-{% for item in chapter.popularHighlights %}
-> 🔥 {{ item.markText | trim }} — 🙋 {{ item.totalCount }} 人划线
-{% endfor %}
-{% endif %}
 {% endfor %}
 
 # 笔记汇总
@@ -44,5 +39,14 @@ lastReadDate: {{ metaData.lastReadDate }}
 # 书评
 {{ bookReview.createTime }}
 {{ bookReview.mdContent }}
+{% endfor %}
+{% endif %}
+
+{% if popularHighlights %}
+# 热门划线
+{% for item in popularHighlights %}
+> 🔥 {{ item.markText | trim }} — 🙋 {{ item.totalCount }} 人划线
+> 📖 {{ item.chapterTitle }}
+
 {% endfor %}
 {% endif %}

--- a/src/themes/separatedTemplate.njk
+++ b/src/themes/separatedTemplate.njk
@@ -44,9 +44,10 @@ lastReadDate: {{ metaData.lastReadDate }}
 
 {% if popularHighlights %}
 # 热门划线
-{% for item in popularHighlights %}
+{% for chapter in popularHighlights %}
+## {{ chapter.chapterTitle }}
+{% for item in chapter.highlights %}
 > 🔥 {{ item.markText | trim }} — 🙋 {{ item.totalCount }} 人划线
-> 📖 {{ item.chapterTitle }}
-
+{% endfor %}
 {% endfor %}
 {% endif %}

--- a/src/themes/separatedTemplate.njk
+++ b/src/themes/separatedTemplate.njk
@@ -41,3 +41,12 @@ lastReadDate: {{ metaData.lastReadDate }}
 {{ bookReview.mdContent }}
 {% endfor %}
 {% endif %}
+
+{% if popularHighlights and popularHighlights.length > 0 %}
+# 热门划线
+{% for item in popularHighlights %}
+> 🔥 {{ item.markText | trim }} — 🙋 {{ item.totalCount }} 人划线
+> 📖 {{ item.chapterTitle }}
+
+{% endfor %}
+{% endif %}

--- a/src/themes/separatedTemplate.njk
+++ b/src/themes/separatedTemplate.njk
@@ -18,7 +18,9 @@ lastReadDate: {{ metaData.lastReadDate }}
 {% for highlight in chapter.highlights %}
 {% set rangeParts = highlight.range | split("-") %}
 {% set deeplink = "weread://bestbookmark?bookId=" + metaData.bookId + "&chapterUid=" + highlight.chapterUid + "&rangeStart=" + rangeParts[0] + "&rangeEnd=" + rangeParts[1] %}
-{% if highlight.isPopular %}
+{% if highlight.isPopular and highlight.created > 0 %}
+> 📌🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) — 🙋 {{ highlight.popularCount }} 人划线 ^{{ highlight.bookmarkId }}
+{% elif highlight.isPopular %}
 > 🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) — 🙋 {{ highlight.popularCount }} 人划线 ^{{ highlight.bookmarkId }}
 {% else %}
 > 📌 [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}

--- a/src/themes/separatedTemplate.njk
+++ b/src/themes/separatedTemplate.njk
@@ -18,7 +18,11 @@ lastReadDate: {{ metaData.lastReadDate }}
 {% for highlight in chapter.highlights %}
 {% set rangeParts = highlight.range | split("-") %}
 {% set deeplink = "weread://bestbookmark?bookId=" + metaData.bookId + "&chapterUid=" + highlight.chapterUid + "&rangeStart=" + rangeParts[0] + "&rangeEnd=" + rangeParts[1] %}
+{% if highlight.isPopular %}
+> 🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) — 🙋 {{ highlight.popularCount }} 人划线 ^{{ highlight.bookmarkId }}
+{% else %}
 > 📌 [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
+{% endif %}
 {% endfor %}
 {% endfor %}
 
@@ -39,15 +43,5 @@ lastReadDate: {{ metaData.lastReadDate }}
 # 书评
 {{ bookReview.createTime }}
 {{ bookReview.mdContent }}
-{% endfor %}
-{% endif %}
-
-{% if popularHighlights %}
-# 热门划线
-{% for chapter in popularHighlights %}
-## {{ chapter.chapterTitle }}
-{% for item in chapter.highlights %}
-> 🔥 {{ item.markText | trim }} — 🙋 {{ item.totalCount }} 人划线
-{% endfor %}
 {% endfor %}
 {% endif %}

--- a/src/themes/separatedWithPopularTemplate.njk
+++ b/src/themes/separatedWithPopularTemplate.njk
@@ -34,7 +34,7 @@ lastReadDate: {{ metaData.lastReadDate }}
 {% endif %}
 
 {% set hasPopularHighlights = false %}
-{% if popularHighlights and popularHighlights.length > 0 %}
+{% if syncPopularHighlightsToggle and popularHighlights and popularHighlights.length > 0 %}
 {% for chapter in popularHighlights %}
   {% if chapter.highlights and chapter.highlights.length > 0 %}
     {% set hasPopularHighlights = true %}
@@ -58,7 +58,7 @@ lastReadDate: {{ metaData.lastReadDate }}
 {% endfor %}
 {% endif %}
 {% endfor %}
-{% else %}
+{% elif syncPopularHighlightsToggle %}
 > 暂无热门划线
 {% endif %}
 

--- a/src/themes/separatedWithPopularTemplate.njk
+++ b/src/themes/separatedWithPopularTemplate.njk
@@ -1,0 +1,104 @@
+---
+isbn: {{ metaData.isbn }}
+lastReadDate: {{ metaData.lastReadDate }}
+---
+# {{ metaData.title }}
+> 作者：{{ metaData.author }}
+> {% if metaData.intro %}{{ metaData.intro | truncate(100) }}{% endif %}
+
+{% set hasUserHighlights = false %}
+{% for chapter in chapterHighlights %}
+  {% if chapter.highlights and chapter.highlights.length > 0 %}
+    {% set hasUserHighlights = true %}
+    {% break %}
+  {% endif %}
+{% endfor %}
+
+# 我的划线
+{% if hasUserHighlights %}
+{% for chapter in chapterHighlights %}
+{% if chapter.highlights and chapter.highlights.length > 0 %}
+## {{ chapter.chapterTitle }}
+{% for highlight in chapter.highlights %}
+{% set rangeParts = highlight.range | split("-") %}
+{% set deeplink = "weread://bestbookmark?bookId=" + metaData.bookId + "&chapterUid=" + highlight.chapterUid + "&rangeStart=" + rangeParts[0] + "&rangeEnd=" + rangeParts[1] %}
+> 📌 [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
+{% if highlight.isPopular %}
+> 🔥 {{ highlight.popularCount }} 人共读
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% else %}
+> 暂无划线
+{% endif %}
+
+{% set hasPopularHighlights = false %}
+{% if popularHighlights and popularHighlights.length > 0 %}
+{% for chapter in popularHighlights %}
+  {% if chapter.highlights and chapter.highlights.length > 0 %}
+    {% set hasPopularHighlights = true %}
+    {% break %}
+  {% endif %}
+{% endfor %}
+{% endif %}
+
+# 热门划线
+{% if hasPopularHighlights %}
+{% for chapter in popularHighlights %}
+{% if chapter.highlights and chapter.highlights.length > 0 %}
+## {{ chapter.chapterTitle }}
+{% for highlight in chapter.highlights %}
+{% set rangeParts = highlight.range | split("-") %}
+{% set deeplink = "weread://bestbookmark?bookId=" + metaData.bookId + "&chapterUid=" + highlight.chapterUid + "&rangeStart=" + rangeParts[0] + "&rangeEnd=" + rangeParts[1] %}
+> 🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
+{% if highlight.totalCount %}
+> 📊 {{ highlight.totalCount }} 人共读
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% else %}
+> 暂无热门划线
+{% endif %}
+
+# 我的笔记
+{% set hasNotes = false %}
+{% for chapter in chapterHighlights %}
+  {% if chapter.highlights %}
+    {% for highlight in chapter.highlights %}
+      {% if highlight.reviewContent %}
+        {% set hasNotes = true %}
+        {% break %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+  {% if hasNotes %}{% break %}{% endif %}
+{% endfor %}
+
+{% if hasNotes %}
+{% for chapter in chapterHighlights %}
+{% if chapter.highlights %}
+{% for highlight in chapter.highlights %}
+{% if highlight.reviewContent %}
+## {{ chapter.chapterTitle }} 的想法
+{{ highlight.reviewContent }}
+> 📌 {{ highlight.markText | trim }}
+
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% else %}
+> 暂无笔记
+{% endif %}
+
+{% if bookReview.bookReviews and bookReview.bookReviews.length > 0 %}
+# 书评
+{% for bookReview in bookReview.bookReviews %}
+## 书评 {{ loop.index }}
+{{ bookReview.createTime }}
+{{ bookReview.mdContent }}
+^{{ bookReview.reviewId }}
+{% endfor %}
+{% endif %}

--- a/src/themes/wereadOfficialTemplate.njk
+++ b/src/themes/wereadOfficialTemplate.njk
@@ -39,3 +39,11 @@ lastReadDate: {{ metaData.lastReadDate }}
 {% endif %}
 {% endfor %}
 {% endfor %}
+
+{% if popularHighlights and popularHighlights.length > 0 %}
+## ◆ 热门划线
+{% for item in popularHighlights %}
+> [{{ item.markText | trim }}] — {{ item.totalCount }} 人划线 · {{ item.chapterTitle }}
+
+{% endfor %}
+{% endif %}

--- a/src/themes/wereadOfficialTemplate.njk
+++ b/src/themes/wereadOfficialTemplate.njk
@@ -25,13 +25,17 @@ lastReadDate: {{ metaData.lastReadDate }}
 {% for highlight in chapter.highlights %}
 {% set rangeParts = highlight.range | split("-") %}
 {% set deeplink = "weread://bestbookmark?bookId=" + metaData.bookId + "&chapterUid=" + highlight.chapterUid + "&rangeStart=" + rangeParts[0] + "&rangeEnd=" + rangeParts[1] %}
-{% if highlight.isPopular %}
+{% if highlight.isPopular and highlight.created > 0 %}
 
-> 🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) — {{ highlight.popularCount }} 人划线 ^{{ highlight.bookmarkId }}
+> 📌🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) — {{ highlight.popularCount }} 人划线 ^{{ highlight.bookmarkId }}
 {% if highlight.reviewContent %}
 {{ highlight.createTime }} 发表想法
 {{ highlight.reviewContent }}
 {% endif %}
+
+{% elif highlight.isPopular %}
+
+> 🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) — {{ highlight.popularCount }} 人划线 ^{{ highlight.bookmarkId }}
 
 {% elif highlight.reviewContent %}
 

--- a/src/themes/wereadOfficialTemplate.njk
+++ b/src/themes/wereadOfficialTemplate.njk
@@ -38,12 +38,9 @@ lastReadDate: {{ metaData.lastReadDate }}
 
 {% endif %}
 {% endfor %}
-{% endfor %}
-
-{% if popularHighlights and popularHighlights.length > 0 %}
-## ◆ 热门划线
-{% for item in popularHighlights %}
-> [{{ item.markText | trim }}] — {{ item.totalCount }} 人划线 · {{ item.chapterTitle }}
-
+{% if chapter.popularHighlights %}
+{% for item in chapter.popularHighlights %}
+> [{{ item.markText | trim }}] — {{ item.totalCount }} 人划线
 {% endfor %}
 {% endif %}
+{% endfor %}

--- a/src/themes/wereadOfficialTemplate.njk
+++ b/src/themes/wereadOfficialTemplate.njk
@@ -25,7 +25,15 @@ lastReadDate: {{ metaData.lastReadDate }}
 {% for highlight in chapter.highlights %}
 {% set rangeParts = highlight.range | split("-") %}
 {% set deeplink = "weread://bestbookmark?bookId=" + metaData.bookId + "&chapterUid=" + highlight.chapterUid + "&rangeStart=" + rangeParts[0] + "&rangeEnd=" + rangeParts[1] %}
+{% if highlight.isPopular %}
+
+> 🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) — {{ highlight.popularCount }} 人划线 ^{{ highlight.bookmarkId }}
 {% if highlight.reviewContent %}
+{{ highlight.createTime }} 发表想法
+{{ highlight.reviewContent }}
+{% endif %}
+
+{% elif highlight.reviewContent %}
 
 {{ highlight.createTime }} 发表想法
 {{ highlight.reviewContent }}
@@ -39,14 +47,3 @@ lastReadDate: {{ metaData.lastReadDate }}
 {% endif %}
 {% endfor %}
 {% endfor %}
-
-{% if popularHighlights %}
-## ◆ 热门划线
-{% for chapter in popularHighlights %}
-### {{ chapter.chapterTitle }}
-{% for item in chapter.highlights %}
-> [{{ item.markText | trim }}] — {{ item.totalCount }} 人划线
-
-{% endfor %}
-{% endfor %}
-{% endif %}

--- a/src/themes/wereadOfficialTemplate.njk
+++ b/src/themes/wereadOfficialTemplate.njk
@@ -42,8 +42,11 @@ lastReadDate: {{ metaData.lastReadDate }}
 
 {% if popularHighlights %}
 ## ◆ 热门划线
-{% for item in popularHighlights %}
-> [{{ item.markText | trim }}] — {{ item.totalCount }} 人划线 · {{ item.chapterTitle }}
+{% for chapter in popularHighlights %}
+### {{ chapter.chapterTitle }}
+{% for item in chapter.highlights %}
+> [{{ item.markText | trim }}] — {{ item.totalCount }} 人划线
 
+{% endfor %}
 {% endfor %}
 {% endif %}

--- a/src/themes/wereadOfficialTemplate.njk
+++ b/src/themes/wereadOfficialTemplate.njk
@@ -25,19 +25,7 @@ lastReadDate: {{ metaData.lastReadDate }}
 {% for highlight in chapter.highlights %}
 {% set rangeParts = highlight.range | split("-") %}
 {% set deeplink = "weread://bestbookmark?bookId=" + metaData.bookId + "&chapterUid=" + highlight.chapterUid + "&rangeStart=" + rangeParts[0] + "&rangeEnd=" + rangeParts[1] %}
-{% if highlight.isPopular and highlight.created > 0 %}
-
-> 📌🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) — {{ highlight.popularCount }} 人划线 ^{{ highlight.bookmarkId }}
 {% if highlight.reviewContent %}
-{{ highlight.createTime }} 发表想法
-{{ highlight.reviewContent }}
-{% endif %}
-
-{% elif highlight.isPopular %}
-
-> 🔥 [{{ highlight.markText | trim }}](<{{ deeplink }}>) — {{ highlight.popularCount }} 人划线 ^{{ highlight.bookmarkId }}
-
-{% elif highlight.reviewContent %}
 
 {{ highlight.createTime }} 发表想法
 {{ highlight.reviewContent }}

--- a/src/themes/wereadOfficialTemplate.njk
+++ b/src/themes/wereadOfficialTemplate.njk
@@ -30,11 +30,21 @@ lastReadDate: {{ metaData.lastReadDate }}
 {{ highlight.createTime }} 发表想法
 {{ highlight.reviewContent }}
 
+{% if syncPopularHighlightsToggle and highlight.isPopular %}
 > [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
+> 🔥 {{ highlight.popularCount }} 人共读
+{% else %}
+> [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
+{% endif %}
 
 {% else %}
 
+{% if syncPopularHighlightsToggle and highlight.isPopular %}
 > [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
+> 🔥 {{ highlight.popularCount }} 人共读
+{% else %}
+> [{{ highlight.markText | trim }}](<{{ deeplink }}>) ^{{ highlight.bookmarkId }}
+{% endif %}
 
 {% endif %}
 {% endfor %}

--- a/src/themes/wereadOfficialTemplate.njk
+++ b/src/themes/wereadOfficialTemplate.njk
@@ -38,9 +38,12 @@ lastReadDate: {{ metaData.lastReadDate }}
 
 {% endif %}
 {% endfor %}
-{% if chapter.popularHighlights %}
-{% for item in chapter.popularHighlights %}
-> [{{ item.markText | trim }}] — {{ item.totalCount }} 人划线
+{% endfor %}
+
+{% if popularHighlights %}
+## ◆ 热门划线
+{% for item in popularHighlights %}
+> [{{ item.markText | trim }}] — {{ item.totalCount }} 人划线 · {{ item.chapterTitle }}
+
 {% endfor %}
 {% endif %}
-{% endfor %}

--- a/style.css
+++ b/style.css
@@ -73,7 +73,7 @@
 .weread-editor-instructions h3 {
 	font-size: 1em;
 	margin-top: 16px;
-	margin-bottom: 8px;
+	margin-bottom: 4px;
 	color: var(--text-normal);
 }
 
@@ -818,7 +818,7 @@
 	font-size: 15px;
 	font-weight: 500;
 	color: var(--text-normal);
-	margin-bottom: 8px;
+	margin-bottom: 4px;
 }
 
 .weread-mobile-login-desc {
@@ -1536,63 +1536,6 @@
 	margin-top: 16px;
 }
 
-.weread-book-detail-modal .modal-content {
-	padding: 20px;
-}
-
-.weread-book-detail-header {
-	display: flex;
-	gap: 24px;
-	margin-bottom: 18px;
-	align-items: flex-start;
-}
-
-.weread-book-detail-cover {
-	width: 144px;
-	height: 202px;
-	object-fit: cover;
-	border-radius: 12px;
-	background: var(--background-modifier-border);
-	flex: 0 0 144px;
-}
-
-.weread-book-detail-info {
-	flex: 1;
-	min-width: 0;
-}
-
-.weread-book-detail-info h2.is-clickable {
-	cursor: pointer;
-	color: var(--text-accent);
-}
-
-.weread-book-detail-author,
-.weread-book-detail-loading,
-.weread-book-detail-intro,
-.weread-book-detail-stat-label,
-.weread-book-detail-stat-value,
-.weread-book-detail-link {
-	font-size: 14px;
-	line-height: 1.6;
-}
-
-.weread-book-detail-author,
-.weread-book-detail-loading,
-.weread-book-detail-stat-label {
-	color: var(--text-muted);
-}
-
-.weread-book-detail-badges {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 6px;
-	margin: 8px 0 12px;
-}
-
-.weread-book-detail-entry-row {
-	margin: -4px 0 12px;
-}
-
 .weread-toolbar-icon-button {
 	width: 32px;
 	height: 32px;
@@ -1608,75 +1551,6 @@
 	background: var(--interactive-accent-hover);
 	border-color: var(--interactive-accent-hover);
 	color: var(--text-on-accent);
-}
-
-.weread-book-detail-badge {
-	padding: 2px 8px;
-	border-radius: 999px;
-	background: var(--background-modifier-hover);
-	font-size: 12px;
-	color: var(--text-muted);
-}
-
-.weread-book-detail-stats {
-	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-	gap: 10px 18px;
-	margin-bottom: 18px;
-}
-
-.weread-book-detail-stat-row {
-	display: flex;
-	flex-direction: column;
-}
-
-.weread-book-detail-section + .weread-book-detail-section {
-	margin-top: 16px;
-}
-
-.weread-book-detail-intro {
-	white-space: pre-wrap;
-}
-
-.weread-book-detail-link {
-	color: var(--text-accent);
-	text-decoration: none;
-}
-
-.weread-book-detail-link:hover {
-	text-decoration: underline;
-}
-
-@media (max-width: 900px) {
-	.weread-book-selector-panels {
-		grid-template-columns: 1fr;
-	}
-
-	.weread-bookshelf-toolbar {
-		align-items: stretch;
-	}
-
-	.weread-bookshelf-toolbar-actions {
-		margin-left: 0;
-		justify-content: flex-start;
-	}
-
-	.weread-book-detail-header {
-		display: grid;
-		grid-template-columns: 104px minmax(0, 1fr);
-		gap: 16px;
-	}
-
-	.weread-book-detail-cover {
-		width: 104px;
-		height: 146px;
-		flex-basis: 104px;
-	}
-
-	.weread-book-detail-stats {
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-		gap: 8px 12px;
-	}
 }
 
 /* 窄屏优化：隐藏筛选下拉菜单，显示筛选按钮 */
@@ -1974,7 +1848,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	margin-bottom: 8px;
+	margin-bottom: 4px;
 }
 
 .theme-title-group {
@@ -2932,7 +2806,7 @@
 	display: flex;
 	align-items: center;
 	gap: 10px;
-	padding: 10px 12px;
+	padding: 4px 8px;
 	background: var(--background-secondary);
 	border-radius: 8px;
 	border: 1px solid var(--background-modifier-border);
@@ -3386,3 +3260,588 @@
 	font-size: 0.95em;
 	color: var(--text-muted);
 }
+
+/* ── Book Detail View ────────────────────────────────────────────────────────── */
+
+.weread-book-detail-view {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	overflow: hidden;
+}
+
+/* Header */
+.weread-book-detail-header {
+	margin: 12px 16px;
+	padding: 16px 24px;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 8px;
+	background: var(--background-secondary);
+	flex-shrink: 0;
+}
+
+.weread-book-detail-header-top {
+	display: flex;
+	gap: 16px;
+	align-items: flex-start;
+}
+
+.weread-book-detail-cover {
+	height: 200px;
+	width: auto;
+	border-radius: 4px;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+	flex-shrink: 0;
+}
+
+.weread-book-detail-cover.is-clickable {
+	cursor: pointer;
+}
+
+.weread-book-detail-cover.is-clickable:hover {
+	opacity: 0.85;
+}
+
+.weread-book-detail-info {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+}
+
+.weread-book-detail-title {
+	margin: 0;
+	font-size: 1.2em;
+	font-weight: 600;
+	line-height: 1.4;
+}
+
+.weread-book-detail-title.is-clickable {
+	cursor: pointer;
+}
+
+.weread-book-detail-title.is-clickable:hover {
+	color: var(--interactive-accent);
+}
+
+.weread-book-detail-author {
+	margin: 0;
+	font-size: 0.9em;
+	color: var(--text-muted);
+}
+
+.weread-book-detail-rating {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	margin-top: 2px;
+}
+
+.weread-star {
+	color: var(--text-faint);
+}
+
+.weread-star.is-filled {
+	color: var(--color-orange);
+}
+
+.weread-book-detail-rating-value {
+	font-weight: 600;
+	font-size: 0.95em;
+	margin-left: 4px;
+}
+
+.weread-book-detail-rating-count {
+	font-size: 0.85em;
+	color: var(--text-muted);
+}
+
+.weread-book-detail-progress {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-top: 4px;
+}
+
+.weread-book-detail-progress-bar {
+	flex: 1;
+	max-width: 180px;
+	height: 6px;
+	background: var(--background-modifier-border);
+	border-radius: 3px;
+	overflow: hidden;
+}
+
+.weread-book-detail-progress-fill {
+	height: 100%;
+	background: var(--interactive-accent);
+	border-radius: 3px;
+	transition: width 0.3s ease;
+}
+
+.weread-book-detail-progress-text {
+	font-size: 0.85em;
+	color: var(--text-muted);
+	font-weight: 500;
+}
+
+.weread-book-detail-stats-row {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	margin-top: 4px;
+	flex-wrap: wrap;
+}
+
+.weread-book-detail-stat {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 0.85em;
+	color: var(--text-muted);
+}
+
+.weread-book-detail-stat.is-clickable {
+	cursor: pointer;
+	border-radius: 4px;
+	padding: 2px 6px;
+	margin: -2px -6px;
+}
+
+.weread-book-detail-stat.is-clickable:hover {
+	color: var(--interactive-accent);
+	background: var(--background-modifier-hover);
+}
+
+/* Intro */
+.weread-book-detail-intro-text {
+	font-size: 0.82em;
+	line-height: 1.5;
+	color: var(--text-muted);
+	word-break: break-word;
+	margin-top: 8px;
+}
+
+.weread-book-detail-intro-text.is-collapsed {
+	display: -webkit-box;
+	-webkit-line-clamp: 3;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+
+.weread-book-detail-intro-toggle {
+	align-self: flex-start;
+	font-size: 0.78em;
+	padding: 2px 8px;
+	color: var(--text-faint);
+	background: none;
+	border: none;
+	cursor: pointer;
+}
+
+.weread-book-detail-intro-toggle:hover {
+	color: var(--interactive-accent);
+}
+
+/* Tab Bar */
+.weread-book-detail-tabbar {
+	display: flex;
+	flex-shrink: 0;
+	border-bottom: 1px solid var(--background-modifier-border);
+	padding: 0 16px;
+	background: var(--background-primary);
+}
+
+.weread-book-detail-tab {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	padding: 6px 14px;
+	border: none;
+	background: none;
+	color: var(--text-muted);
+	font-size: 0.9em;
+	cursor: pointer;
+	border-radius: 20px;
+	transition: color 0.15s, background 0.15s;
+}
+
+.weread-book-detail-tab:hover {
+	color: var(--text-normal);
+	background: var(--background-secondary);
+}
+
+.weread-book-detail-tab.is-active {
+	color: var(--interactive-accent);
+	background: var(--background-modifier-hover);
+}
+
+/* 右侧圆形操作按钮 */
+.weread-book-detail-tab-action {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 30px;
+	height: 30px;
+	padding: 0;
+	border: none;
+	background: none;
+	color: var(--text-muted);
+	cursor: pointer;
+	border-radius: 50%;
+	transition: color 0.15s, background 0.15s;
+}
+
+.weread-book-detail-tab-action:hover {
+	color: var(--text-normal);
+	background: var(--background-secondary);
+}
+
+.weread-book-detail-tab-action.is-spinning svg {
+	animation: weread-spin 0.8s linear infinite;
+}
+
+.weread-book-detail-tabbar-spacer {
+	flex: 1;
+}
+
+@keyframes weread-spin {
+		from { transform: rotate(0deg); }
+		to { transform: rotate(360deg); }
+	}
+
+
+/* Content */
+.weread-book-detail-content {
+	flex: 1;
+	overflow-y: auto;
+	padding: 16px 24px;
+}
+
+/* Status States */
+.weread-book-detail-status {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	gap: 12px;
+}
+
+.weread-book-detail-loading {
+	font-size: 0.95em;
+	color: var(--text-muted);
+}
+
+.weread-book-detail-empty {
+	font-size: 0.95em;
+	color: var(--text-muted);
+	padding: 40px 0;
+	text-align: center;
+}
+
+.weread-book-detail-error {
+	font-size: 0.95em;
+	color: var(--text-error);
+}
+
+.weread-book-detail-retry-btn {
+	padding: 6px 16px;
+}
+
+/* Section (chapter group) */
+.weread-book-detail-section {
+	margin-bottom: 20px;
+}
+
+.weread-book-detail-section-title {
+	margin: 0 0 10px;
+	font-size: 1em;
+	font-weight: 600;
+	color: var(--text-normal);
+	padding-bottom: 6px;
+	border-bottom: 1px solid var(--background-modifier-border);
+}
+
+/* Highlight Card */
+.weread-book-detail-hl-card {
+	margin-bottom: 4px;
+	padding: 4px 8px;
+	background: var(--background-primary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 6px;
+	transition: border-color 0.15s;
+}
+
+.weread-book-detail-hl-card:hover {
+	border-color: var(--interactive-accent);
+	background: var(--background-secondary);
+}
+
+/* 左侧颜色引用边线 */
+.weread-book-detail-hl-quote {
+	border-left: 3px solid #e6c300;
+	padding-left: 8px;
+	margin-bottom: 2px;
+}
+
+.weread-book-detail-hl-card.hl-color-yellow .weread-book-detail-hl-quote { border-left-color: #f5c842; }
+.weread-book-detail-hl-card.hl-color-blue .weread-book-detail-hl-quote { border-left-color: #5b9bd5; }
+.weread-book-detail-hl-card.hl-color-green .weread-book-detail-hl-quote { border-left-color: #6cbf6c; }
+.weread-book-detail-hl-card.hl-color-red .weread-book-detail-hl-quote { border-left-color: #e07070; }
+.weread-book-detail-hl-card.hl-color-purple .weread-book-detail-hl-quote { border-left-color: #b47cc7; }
+
+.weread-book-detail-hl-text {
+	font-size: 0.9em;
+	line-height: 1.4;
+	color: var(--text-normal);
+	word-break: break-word;
+}
+
+.weread-book-detail-hl-meta {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	margin-top: 2px;
+}
+
+.weread-book-detail-hl-meta-item {
+	font-size: 0.78em;
+	color: var(--text-faint);
+}
+
+.weread-book-detail-hl-style-badge {
+	font-size: 0.75em;
+	padding: 1px 6px;
+	border-radius: 3px;
+	background: var(--background-modifier-hover);
+	color: var(--text-muted);
+}
+
+.weread-book-detail-hl-color-badge {
+	font-size: 0.75em;
+	padding: 1px 6px;
+	border-radius: 3px;
+	color: #fff;
+}
+
+.weread-book-detail-hl-color-badge.hl-color-yellow {
+	background: #c9a018;
+}
+
+.weread-book-detail-hl-color-badge.hl-color-blue {
+	background: #3d7eb5;
+}
+
+.weread-book-detail-hl-color-badge.hl-color-green {
+	background: #4a9a4a;
+}
+
+.weread-book-detail-hl-color-badge.hl-color-red {
+	background: #c05050;
+}
+
+.weread-book-detail-hl-color-badge.hl-color-purple {
+	background: #8c5e9e;
+}
+
+.weread-book-detail-hl-note {
+	display: flex;
+	align-items: center;
+	color: var(--interactive-accent);
+	cursor: help;
+	margin-left: auto;
+}
+
+/* Note Card */
+.weread-book-detail-note-card {
+	margin-bottom: 12px;
+	padding: 12px;
+	background: var(--background-primary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 6px;
+}
+
+.weread-book-detail-note-ref {
+	display: flex;
+	gap: 6px;
+	margin-bottom: 4px;
+	padding: 8px 10px;
+	background: var(--background-secondary);
+	border-left: 3px solid var(--interactive-accent);
+	border-radius: 4px;
+}
+
+.weread-book-detail-note-ref-icon {
+	color: var(--text-faint);
+	flex-shrink: 0;
+	margin-top: 2px;
+}
+
+.weread-book-detail-note-ref-text {
+	font-size: 0.85em;
+	color: var(--text-muted);
+	line-height: 1.5;
+	word-break: break-word;
+}
+
+.weread-book-detail-note-content {
+	font-size: 0.9em;
+	line-height: 1.6;
+	color: var(--text-normal);
+	word-break: break-word;
+}
+
+.weread-book-detail-note-meta {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	margin-top: 2px;
+	flex-wrap: wrap;
+}
+
+/* Popular Highlight Card */
+.weread-book-detail-popular-card {
+	margin-bottom: 4px;
+	padding: 4px 8px;
+	background: var(--background-primary);
+	border: 1px solid var(--background-modifier-border);
+	border-left: 3px solid var(--color-orange);
+	border-radius: 6px;
+}
+
+.weread-book-detail-popular-text {
+	font-size: 0.9em;
+	line-height: 1.6;
+	color: var(--text-normal);
+	word-break: break-word;
+}
+
+.weread-book-detail-popular-meta {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	margin-top: 2px;
+	flex-wrap: wrap;
+}
+
+.weread-book-detail-popular-count {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	font-size: 0.8em;
+	color: var(--color-orange);
+	font-weight: 500;
+}
+
+/* Review Card */
+.weread-book-detail-review-card {
+	margin-bottom: 12px;
+	padding: 12px;
+	background: var(--background-primary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 6px;
+}
+
+.weread-book-detail-review-author {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin-bottom: 4px;
+}
+
+.weread-book-detail-review-avatar {
+	width: 32px;
+	height: 32px;
+	border-radius: 50%;
+	object-fit: cover;
+	flex-shrink: 0;
+}
+
+.weread-book-detail-review-author-info {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.weread-book-detail-review-author-name {
+	font-size: 0.9em;
+	font-weight: 500;
+	color: var(--text-normal);
+}
+
+.weread-book-detail-review-time {
+	font-size: 0.75em;
+	color: var(--text-faint);
+}
+
+.weread-book-detail-review-title {
+	font-size: 0.95em;
+	font-weight: 600;
+	margin-bottom: 6px;
+	color: var(--text-normal);
+}
+
+.weread-book-detail-review-content {
+	font-size: 0.88em;
+	line-height: 1.6;
+	color: var(--text-muted);
+	word-break: break-word;
+}
+
+/* 操作按钮 */
+.weread-book-detail-hl-actions {
+	display: flex;
+	gap: 4px;
+	margin-left: auto;
+	margin-top: 0;
+}
+
+.weread-book-detail-action-btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	padding: 0;
+	border: none;
+	border-radius: 4px;
+	background: transparent;
+	color: var(--text-muted);
+	cursor: pointer;
+	flex-shrink: 0;
+}
+
+.weread-book-detail-action-btn:hover {
+	background: var(--background-modifier-hover);
+	color: var(--text-normal);
+}
+
+/* ── 悬浮按钮 ──────────────────────────────────────────────── */
+
+.weread-floating-btn {
+	position: absolute;
+	z-index: 10;
+	bottom: 48px;
+	right: 24px;
+	width: 36px;
+	height: 36px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: var(--interactive-accent);
+	color: var(--text-on-accent);
+	border-radius: 50%;
+	cursor: pointer;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+	opacity: 0.85;
+	transition: opacity 0.15s, transform 0.15s;
+}
+
+.weread-floating-btn:hover {
+	opacity: 1;
+	transform: scale(1.08);
+}
+
+/* ── 浮层面板 ──────────────────────────────────────────────── */

--- a/style.css
+++ b/style.css
@@ -3335,6 +3335,12 @@
 	gap: 3px;
 }
 
+.weread-book-detail-title-row {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
 .weread-book-detail-title {
 	margin: 0;
 	font-size: 1.2em;
@@ -3565,11 +3571,28 @@
 	cursor: pointer;
 	border-radius: 50%;
 	transition: color 0.15s, background 0.15s;
+	position: relative;
 }
 
 .weread-book-detail-tab-action:hover {
 	color: var(--text-normal);
 	background: var(--background-secondary);
+}
+
+.weread-book-detail-tab-action:hover::after {
+	content: attr(title);
+	position: absolute;
+	bottom: calc(100% + 4px);
+	left: 50%;
+	transform: translateX(-50%);
+	padding: 4px 8px;
+	border-radius: 4px;
+	background: var(--background-modifier-hover);
+	color: var(--text-normal);
+	font-size: 11px;
+	white-space: nowrap;
+	z-index: 100;
+	pointer-events: none;
 }
 
 .weread-book-detail-tab-action.is-spinning svg {
@@ -3912,11 +3935,28 @@
 	color: var(--text-muted);
 	cursor: pointer;
 	flex-shrink: 0;
+	position: relative;
 }
 
 .weread-book-detail-action-btn:hover {
 	background: var(--background-modifier-hover);
 	color: var(--text-normal);
+}
+
+.weread-book-detail-action-btn:hover::after {
+	content: attr(title);
+	position: absolute;
+	bottom: calc(100% + 4px);
+	left: 50%;
+	transform: translateX(-50%);
+	padding: 4px 8px;
+	border-radius: 4px;
+	background: var(--background-modifier-hover);
+	color: var(--text-normal);
+	font-size: 11px;
+	white-space: nowrap;
+	z-index: 100;
+	pointer-events: none;
 }
 
 /* ── 悬浮按钮 ──────────────────────────────────────────────── */

--- a/style.css
+++ b/style.css
@@ -3281,6 +3281,20 @@
 	position: relative;
 }
 
+@media (max-width: 768px) {
+	.weread-book-detail-header {
+		margin: 8px 12px 6px 12px;
+		padding: 12px 16px;
+	}
+}
+
+@media (max-width: 480px) {
+	.weread-book-detail-header {
+		margin: 6px 8px 4px 8px;
+		padding: 10px 12px;
+	}
+}
+
 .weread-book-detail-back-btn {
 	position: absolute;
 	top: 12px;
@@ -3311,12 +3325,32 @@
 	align-items: flex-start;
 }
 
+@media (max-width: 768px) {
+	.weread-book-detail-header-top {
+		flex-direction: column;
+		align-items: center;
+	}
+}
+
 .weread-book-detail-cover {
 	height: 200px;
 	width: auto;
 	border-radius: 4px;
 	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 	flex-shrink: 0;
+}
+
+@media (max-width: 768px) {
+	.weread-book-detail-cover {
+		height: 150px;
+		width: auto;
+	}
+}
+
+@media (max-width: 480px) {
+	.weread-book-detail-cover {
+		height: 120px;
+	}
 }
 
 .weread-book-detail-cover.is-clickable {
@@ -3333,6 +3367,13 @@
 	display: flex;
 	flex-direction: column;
 	gap: 3px;
+}
+
+@media (max-width: 768px) {
+	.weread-book-detail-info {
+		width: 100%;
+		text-align: center;
+	}
 }
 
 .weread-book-detail-title-row {
@@ -3441,6 +3482,13 @@
 	margin-top: 4px;
 }
 
+@media (max-width: 768px) {
+	.weread-book-detail-metadata {
+		gap: 2px 8px;
+		font-size: 0.75em;
+	}
+}
+
 .weread-book-detail-meta-item {
 	display: inline-flex;
 	align-items: center;
@@ -3475,6 +3523,13 @@
 	gap: 12px;
 	margin-top: 4px;
 	flex-wrap: wrap;
+}
+
+@media (max-width: 768px) {
+	.weread-book-detail-stats-row {
+		flex-wrap: wrap;
+		gap: 8px;
+	}
 }
 
 .weread-book-detail-stat {
@@ -3533,6 +3588,19 @@
 	flex-shrink: 0;
 	padding: 8px 16px 8px 16px;
 	background: var(--background-primary);
+	flex-wrap: wrap;
+	gap: 4px;
+}
+
+@media (max-width: 480px) {
+	.weread-book-detail-tabbar {
+		padding: 6px 8px;
+	}
+
+	.weread-book-detail-tab {
+		padding: 4px 10px;
+		font-size: 0.8em;
+	}
 }
 
 .weread-book-detail-tab {
@@ -3615,11 +3683,20 @@
 .weread-book-detail-content {
 	flex: 1;
 	overflow-y: auto;
-	padding: 16px 24px;
-	margin: 8px 16px 12px 16px;
+	padding: 16px 16px;
+	margin: 8px 12px 12px 12px;
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 8px;
 	background: var(--background-secondary);
+	max-width: 100%;
+	box-sizing: border-box;
+}
+
+@media (max-width: 480px) {
+	.weread-book-detail-content {
+		padding: 12px 12px;
+		margin: 6px 8px 8px 8px;
+	}
 }
 
 /* Status States */

--- a/style.css
+++ b/style.css
@@ -3271,6 +3271,7 @@
 	box-sizing: border-box;
 	width: 100%;
 	max-width: 100%;
+	padding: 0 !important;
 }
 
 /* Header */
@@ -3332,6 +3333,12 @@
 	align-items: flex-start;
 }
 
+@media (max-width: 768px) {
+	.weread-book-detail-header-top {
+		gap: 10px;
+	}
+}
+
 /* Keep horizontal layout on all screen sizes */
 
 .weread-book-detail-cover {
@@ -3344,14 +3351,14 @@
 
 @media (max-width: 768px) {
 	.weread-book-detail-cover {
-		height: 150px;
+		height: 180px;
 		width: auto;
 	}
 }
 
 @media (max-width: 480px) {
 	.weread-book-detail-cover {
-		height: 120px;
+		height: 150px;
 	}
 }
 
@@ -3547,13 +3554,13 @@
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;
-	gap: 4px 10px;
+	gap: 4px 12px;
 	margin-top: 4px;
 }
 
 @media (max-width: 768px) {
 	.weread-book-detail-metadata {
-		gap: 2px 8px;
+		gap: 3px 10px;
 		font-size: 0.75em;
 	}
 }
@@ -3561,15 +3568,22 @@
 .weread-book-detail-meta-item {
 	display: inline-flex;
 	align-items: center;
-	gap: 3px;
-	font-size: 0.8em;
+	gap: 4px;
+	font-size: 0.82em;
 	color: var(--text-muted);
 	white-space: nowrap;
 }
 
+.weread-book-detail-meta-item .svg-icon {
+	width: 13px;
+	height: 13px;
+	flex-shrink: 0;
+	position: relative;
+	top: 0;
+}
+
 .weread-book-detail-meta-item::before {
-	content: '·';
-	opacity: 0.4;
+	content: none;
 }
 
 .weread-book-detail-meta-item:first-child::before {
@@ -3590,7 +3604,9 @@
 	display: flex;
 	align-items: center;
 	gap: 12px;
-	margin-top: 4px;
+	margin-top: 8px;
+	padding-top: 8px;
+	border-top: 1px solid var(--background-modifier-border);
 	flex-wrap: wrap;
 }
 
@@ -3605,7 +3621,7 @@
 	display: flex;
 	align-items: center;
 	gap: 4px;
-	font-size: 0.85em;
+	font-size: 0.82em;
 	color: var(--text-muted);
 }
 
@@ -3654,18 +3670,17 @@
 /* Tab Bar */
 .weread-book-detail-tabbar {
 	display: flex;
-	padding: 8px 16px 8px 16px;
+	padding: 6px 16px;
 	background: var(--background-primary);
 	flex-wrap: wrap;
 	gap: 4px;
 	position: sticky;
 	top: 0;
 	z-index: 20;
-	border-bottom: 1px solid var(--background-modifier-border);
+	border: none !important;
 	margin: 0;
 	width: 100%;
 	box-sizing: border-box;
-	border-top: none;
 	overflow-x: hidden;
 }
 
@@ -3676,7 +3691,7 @@
 	right: 0;
 	top: 0;
 	transform: none;
-	border-bottom: 1px solid var(--background-modifier-border);
+	border: none !important;
 	margin: 0;
 	width: auto;
 }
@@ -3741,8 +3756,8 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: 30px;
-	height: 30px;
+	width: 36px;
+	height: 36px;
 	padding: 0;
 	border: none;
 	background: none;
@@ -3751,6 +3766,11 @@
 	border-radius: 50%;
 	transition: color 0.15s, background 0.15s;
 	position: relative;
+}
+
+.weread-book-detail-tab-action .svg-icon {
+	width: 18px;
+	height: 18px;
 }
 
 .weread-book-detail-tab-action:hover {
@@ -4126,9 +4146,13 @@
 	width: 22px;
 	height: 22px;
 	padding: 0;
-	border: none;
+	border: none !important;
+	outline: none !important;
+	box-shadow: none !important;
+	-webkit-appearance: none !important;
+	appearance: none !important;
 	border-radius: 4px;
-	background: transparent;
+	background: transparent !important;
 	color: var(--text-muted);
 	cursor: pointer;
 	flex-shrink: 0;
@@ -4195,8 +4219,8 @@
 	z-index: 10;
 	bottom: 120px;
 	right: 24px;
-	width: 48px;
-	height: 48px;
+	width: 36px;
+	height: 36px;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -4215,8 +4239,21 @@
 }
 
 .weread-floating-btn svg {
-	width: 24px;
-	height: 24px;
+	width: 18px;
+	height: 18px;
+}
+
+/* 移动端悬浮按钮放大，方便点击 */
+.is-mobile .weread-floating-btn {
+	width: 52px;
+	height: 52px;
+	bottom: 100px;
+	right: 20px;
+}
+
+.is-mobile .weread-floating-btn svg {
+	width: 26px;
+	height: 26px;
 }
 
 /* ── 浮层面板 ──────────────────────────────────────────────── */

--- a/style.css
+++ b/style.css
@@ -3264,33 +3264,44 @@
 /* ── Book Detail View ────────────────────────────────────────────────────────── */
 
 .weread-book-detail-view {
-	display: flex;
-	flex-direction: column;
+	display: block;
 	height: 100%;
-	overflow: hidden;
+	overflow-y: auto;
+	overflow-x: hidden;
+	box-sizing: border-box;
+	width: 100%;
+	max-width: 100%;
 }
 
 /* Header */
 .weread-book-detail-header {
-	margin: 12px 16px 8px 16px;
+	margin: 12px 16px 0px 16px;
 	padding: 16px 24px;
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 8px;
 	background: var(--background-secondary);
-	flex-shrink: 0;
 	position: relative;
+	box-sizing: border-box;
+	width: calc(100% - 32px);
+	overflow-x: hidden;
+	overflow-y: visible;
 }
 
 @media (max-width: 768px) {
 	.weread-book-detail-header {
-		margin: 8px 12px 6px 12px;
+		margin: 8px 12px 0px 12px;
 		padding: 12px 16px;
+		width: calc(100% - 24px);
+	}
+
+	.weread-book-detail-tabbar {
+		width: calc(100% - 24px);
 	}
 }
 
 @media (max-width: 480px) {
 	.weread-book-detail-header {
-		margin: 6px 8px 4px 8px;
+		margin: 6px 8px 0px 8px;
 		padding: 10px 12px;
 	}
 }
@@ -3325,12 +3336,7 @@
 	align-items: flex-start;
 }
 
-@media (max-width: 768px) {
-	.weread-book-detail-header-top {
-		flex-direction: column;
-		align-items: center;
-	}
-}
+/* Keep horizontal layout on all screen sizes */
 
 .weread-book-detail-cover {
 	height: 200px;
@@ -3371,8 +3377,75 @@
 
 @media (max-width: 768px) {
 	.weread-book-detail-info {
-		width: 100%;
-		text-align: center;
+		width: auto;
+		text-align: left;
+	}
+}
+
+/* Main info section - always visible */
+.weread-book-detail-info-main {
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+}
+
+/* Expandable info section - collapsible */
+.weread-book-detail-info-expand {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	margin-top: 4px;
+	padding-top: 4px;
+	border-top: 1px solid var(--background-modifier-border);
+	/* Default expanded state */
+}
+
+.weread-book-detail-info-expand.is-collapsed {
+	display: none;
+	/* Collapsed state - hide all content */
+}
+
+/* Toggle button for expand/collapse - desktop hidden, mobile icon-only */
+.weread-book-detail-toggle-btn {
+	display: none;
+	align-items: center;
+	gap: 4px;
+	padding: 0;
+	background: none;
+	border: none;
+	color: var(--text-muted);
+	cursor: pointer;
+	border-radius: 0;
+	transition: all 0.15s;
+	position: absolute;
+	top: 8px;
+	right: 8px;
+}
+
+.weread-book-detail-toggle-btn:hover {
+	color: var(--interactive-accent);
+	background: none;
+}
+
+/* Toggle button icon animation */
+.weread-book-detail-toggle-btn svg {
+	transition: transform 0.2s ease;
+	width: 20px;
+	height: 20px;
+}
+
+.weread-book-detail-toggle-btn.is-expanded svg {
+	transform: rotate(180deg);
+}
+
+/* Show toggle button only on mobile */
+@media (max-width: 768px) {
+	.weread-book-detail-toggle-btn {
+		display: flex;
+	}
+
+	.weread-book-detail-info {
+		position: relative;
 	}
 }
 
@@ -3585,11 +3658,28 @@
 /* Tab Bar */
 .weread-book-detail-tabbar {
 	display: flex;
-	flex-shrink: 0;
 	padding: 8px 16px 8px 16px;
 	background: var(--background-primary);
 	flex-wrap: wrap;
 	gap: 4px;
+	position: sticky;
+	top: 0;
+	z-index: 20;
+	border-bottom: 1px solid var(--background-modifier-border);
+	margin: 0;
+	width: calc(100% - 32px);
+	box-sizing: border-box;
+	border-top: none;
+	overflow-x: hidden;
+}
+
+/* Tab bar 固定在顶部时的样式 */
+.weread-book-detail-tabbar.is-fixed {
+	position: fixed;
+	left: 50%;
+	transform: translateX(-50%);
+	max-width: calc(100% - 32px);
+	border-bottom: 1px solid var(--background-modifier-border);
 }
 
 @media (max-width: 480px) {
@@ -3615,6 +3705,26 @@
 	cursor: pointer;
 	border-radius: 20px;
 	transition: color 0.15s, background 0.15s;
+}
+
+.weread-book-detail-tab-label {
+	/* 默认显示 */
+}
+
+@media (max-width: 768px) {
+	.weread-book-detail-tab-label {
+		display: none;
+	}
+
+	.weread-book-detail-tab {
+		padding: 4px 8px;
+		width: 36px;
+		height: 36px;
+		border-radius: 50%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
 }
 
 .weread-book-detail-tab:hover {
@@ -3681,21 +3791,30 @@
 
 /* Content */
 .weread-book-detail-content {
-	flex: 1;
-	overflow-y: auto;
 	padding: 16px 16px;
-	margin: 8px 12px 12px 12px;
+	margin: 0px 16px 12px 16px;
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 8px;
 	background: var(--background-secondary);
-	max-width: 100%;
 	box-sizing: border-box;
+	width: calc(100% - 32px);
+	overflow-x: hidden;
+	overflow-y: visible;
 }
 
 @media (max-width: 480px) {
+	.weread-book-detail-header {
+		width: calc(100% - 16px);
+	}
+
+	.weread-book-detail-tabbar {
+		width: calc(100% - 16px);
+	}
+
 	.weread-book-detail-content {
+		width: calc(100% - 16px);
 		padding: 12px 12px;
-		margin: 6px 8px 8px 8px;
+		margin: 0px 8px 8px 8px;
 	}
 }
 
@@ -4077,12 +4196,12 @@
 /* ── 悬浮按钮 ──────────────────────────────────────────────── */
 
 .weread-floating-btn {
-	position: absolute;
+	position: fixed;
 	z-index: 10;
-	bottom: 48px;
+	bottom: 120px;
 	right: 24px;
-	width: 36px;
-	height: 36px;
+	width: 48px;
+	height: 48px;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -4101,8 +4220,8 @@
 }
 
 .weread-floating-btn svg {
-	width: 18px;
-	height: 18px;
+	width: 24px;
+	height: 24px;
 }
 
 /* ── 浮层面板 ──────────────────────────────────────────────── */

--- a/style.css
+++ b/style.css
@@ -3528,8 +3528,7 @@
 .weread-book-detail-tabbar {
 	display: flex;
 	flex-shrink: 0;
-	border-bottom: 1px solid var(--background-modifier-border);
-	padding: 0 16px;
+	padding: 0 16px 10px;
 	background: var(--background-primary);
 }
 
@@ -3663,8 +3662,8 @@
 
 /* Highlight Card */
 .weread-book-detail-hl-card {
-	margin-bottom: 4px;
-	padding: 4px 8px;
+	margin-bottom: 10px;
+	padding: 8px 10px;
 	background: var(--background-primary);
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 6px;
@@ -3800,8 +3799,8 @@
 
 /* Popular Highlight Card */
 .weread-book-detail-popular-card {
-	margin-bottom: 4px;
-	padding: 4px 8px;
+	margin-bottom: 10px;
+	padding: 8px 10px;
 	background: var(--background-primary);
 	border: 1px solid var(--background-modifier-border);
 	border-left: 3px solid var(--color-orange);

--- a/style.css
+++ b/style.css
@@ -827,6 +827,46 @@
 	line-height: 1.5;
 }
 
+/* API Key 校验状态 */
+.weread-apikey-validation {
+	background-color: var(--background-secondary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 8px;
+	padding: 12px 16px;
+	margin: 8px 0 12px;
+}
+
+.weread-apikey-validation-row {
+	font-size: 13px;
+	color: var(--text-normal);
+	margin-bottom: 4px;
+}
+
+.weread-apikey-validation-row:last-child {
+	margin-bottom: 0;
+}
+
+.weread-apikey-validation-valid {
+	color: var(--color-green);
+	font-weight: 500;
+}
+
+.weread-apikey-validation-invalid {
+	color: var(--text-error);
+	font-weight: 500;
+}
+
+.weread-apikey-validation-status {
+	font-size: 13px;
+	color: var(--text-muted);
+}
+
+.weread-apikey-validation-desc {
+	font-size: 12px;
+	color: var(--text-muted);
+	margin-top: 6px;
+}
+
 .weread-manual-sync-preview {
 	display: grid;
 	grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));

--- a/style.css
+++ b/style.css
@@ -3278,6 +3278,31 @@
 	border-radius: 8px;
 	background: var(--background-secondary);
 	flex-shrink: 0;
+	position: relative;
+}
+
+.weread-book-detail-back-btn {
+	position: absolute;
+	top: 12px;
+	left: 12px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	padding: 0;
+	border: none;
+	border-radius: 6px;
+	background: none;
+	color: var(--text-muted);
+	cursor: pointer;
+	transition: color 0.15s, background 0.15s;
+	z-index: 1;
+}
+
+.weread-book-detail-back-btn:hover {
+	color: var(--text-normal);
+	background: var(--background-modifier-hover);
 }
 
 .weread-book-detail-header-top {
@@ -3326,6 +3351,9 @@
 }
 
 .weread-book-detail-author {
+	display: flex;
+	align-items: center;
+	gap: 4px;
 	margin: 0;
 	font-size: 0.9em;
 	color: var(--text-muted);
@@ -3336,6 +3364,10 @@
 	align-items: center;
 	gap: 2px;
 	margin-top: 2px;
+}
+
+.weread-book-detail-rating-icon {
+	color: var(--color-orange);
 }
 
 .weread-star {
@@ -3364,6 +3396,11 @@
 	margin-top: 4px;
 }
 
+.weread-book-detail-progress-icon {
+	color: var(--text-muted);
+	flex-shrink: 0;
+}
+
 .weread-book-detail-progress-bar {
 	flex: 1;
 	max-width: 180px;
@@ -3383,6 +3420,43 @@
 .weread-book-detail-progress-text {
 	font-size: 0.85em;
 	color: var(--text-muted);
+	font-weight: 500;
+}
+
+/* Metadata Row */
+.weread-book-detail-metadata {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 4px 10px;
+	margin-top: 4px;
+}
+
+.weread-book-detail-meta-item {
+	display: inline-flex;
+	align-items: center;
+	gap: 3px;
+	font-size: 0.8em;
+	color: var(--text-muted);
+	white-space: nowrap;
+}
+
+.weread-book-detail-meta-item::before {
+	content: '·';
+	opacity: 0.4;
+}
+
+.weread-book-detail-meta-item:first-child::before {
+	content: none;
+}
+
+.weread-book-detail-status-reading {
+	color: var(--color-green);
+	font-weight: 500;
+}
+
+.weread-book-detail-status-finished {
+	color: var(--color-blue);
 	font-weight: 500;
 }
 
@@ -3733,6 +3807,33 @@
 	font-size: 0.8em;
 	color: var(--color-orange);
 	font-weight: 500;
+}
+
+/* Load More Button */
+.weread-book-detail-loadmore {
+	text-align: center;
+	padding: 12px;
+	color: var(--text-muted);
+	font-size: 0.85em;
+}
+
+.weread-book-detail-loadmore-btn {
+	display: block;
+	width: 100%;
+	padding: 8px;
+	margin-top: 8px;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 6px;
+	background: var(--background-secondary);
+	color: var(--text-muted);
+	font-size: 0.85em;
+	cursor: pointer;
+	transition: background 0.15s, color 0.15s;
+}
+
+.weread-book-detail-loadmore-btn:hover {
+	background: var(--background-modifier-hover);
+	color: var(--text-normal);
 }
 
 /* Review Card */

--- a/style.css
+++ b/style.css
@@ -3272,7 +3272,7 @@
 
 /* Header */
 .weread-book-detail-header {
-	margin: 12px 16px;
+	margin: 12px 16px 8px 16px;
 	padding: 16px 24px;
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 8px;
@@ -3528,7 +3528,7 @@
 .weread-book-detail-tabbar {
 	display: flex;
 	flex-shrink: 0;
-	padding: 0 16px 10px;
+	padding: 8px 16px 8px 16px;
 	background: var(--background-primary);
 }
 
@@ -3613,6 +3613,10 @@
 	flex: 1;
 	overflow-y: auto;
 	padding: 16px 24px;
+	margin: 8px 16px 12px 16px;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 8px;
+	background: var(--background-secondary);
 }
 
 /* Status States */
@@ -3982,6 +3986,11 @@
 .weread-floating-btn:hover {
 	opacity: 1;
 	transform: scale(1.08);
+}
+
+.weread-floating-btn svg {
+	width: 18px;
+	height: 18px;
 }
 
 /* ── 浮层面板 ──────────────────────────────────────────────── */

--- a/style.css
+++ b/style.css
@@ -3293,10 +3293,6 @@
 		padding: 12px 16px;
 		width: calc(100% - 24px);
 	}
-
-	.weread-book-detail-tabbar {
-		width: calc(100% - 24px);
-	}
 }
 
 @media (max-width: 480px) {
@@ -3667,7 +3663,7 @@
 	z-index: 20;
 	border-bottom: 1px solid var(--background-modifier-border);
 	margin: 0;
-	width: calc(100% - 32px);
+	width: 100%;
 	box-sizing: border-box;
 	border-top: none;
 	overflow-x: hidden;
@@ -3676,10 +3672,13 @@
 /* Tab bar 固定在顶部时的样式 */
 .weread-book-detail-tabbar.is-fixed {
 	position: fixed;
-	left: 50%;
-	transform: translateX(-50%);
-	max-width: calc(100% - 32px);
+	left: 0;
+	right: 0;
+	top: 0;
+	transform: none;
 	border-bottom: 1px solid var(--background-modifier-border);
+	margin: 0;
+	width: auto;
 }
 
 @media (max-width: 480px) {
@@ -3804,10 +3803,6 @@
 
 @media (max-width: 480px) {
 	.weread-book-detail-header {
-		width: calc(100% - 16px);
-	}
-
-	.weread-book-detail-tabbar {
 		width: calc(100% - 16px);
 	}
 

--- a/style.css
+++ b/style.css
@@ -3374,10 +3374,13 @@
 
 .weread-book-detail-rating-icon {
 	color: var(--color-orange);
+	flex-shrink: 0;
+	margin-right: -8px;
 }
 
 .weread-star {
 	color: var(--text-faint);
+	font-size: 0.9em;
 }
 
 .weread-star.is-filled {
@@ -3387,7 +3390,7 @@
 .weread-book-detail-rating-value {
 	font-weight: 600;
 	font-size: 0.95em;
-	margin-left: 4px;
+	margin-left: -2px;
 }
 
 .weread-book-detail-rating-count {
@@ -3960,6 +3963,38 @@
 	white-space: nowrap;
 	z-index: 100;
 	pointer-events: none;
+}
+
+/* ── 加载更多按钮 ────────────────────────────────────────────── */
+
+.weread-book-detail-load-more {
+	display: flex;
+	justify-content: center;
+	padding: 16px 0;
+	margin-top: 8px;
+	border-top: 1px solid var(--background-modifier-border);
+}
+
+.weread-book-detail-load-more-btn {
+	padding: 8px 16px;
+	border-radius: 6px;
+	border: 1px solid var(--interactive-accent);
+	background: transparent;
+	color: var(--interactive-accent);
+	font-size: 0.9em;
+	font-weight: 500;
+	cursor: pointer;
+	transition: all 0.15s;
+}
+
+.weread-book-detail-load-more-btn:hover:not(:disabled) {
+	background: var(--interactive-accent);
+	color: var(--text-on-accent);
+}
+
+.weread-book-detail-load-more-btn:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
 }
 
 /* ── 悬浮按钮 ──────────────────────────────────────────────── */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
+    "baseUrl": "./src",
+    "paths": {
+      "*": ["*"]
+    },
     "inlineSourceMap": true,
     "inlineSources": true,
     "module": "ESNext",


### PR DESCRIPTION

## 概述

V2 是以 **API Key 为核心的重大架构升级**，引入微信读书 Agent API（Bearer Token 认证），保留 Cookie 向后兼容，并新增热门划线同步、书籍详情页、主题系统和阅读统计等功能。

## 主要变化

### 🔑 API Key 认证体系

- **扫码获取**：设置页 API Key 输入框旁增加「扫码获取」按钮，已登录用户一键获取 Key，未登录用户弹出二维码窗口完成登录后自动获取
- **自动获取**：插件启动时如果 Cookie 有效但无 API Key，自动调用 `/api/skills/apikeyGet` 获取
- **有效性校验**：打开设置页自动校验 Key，状态图标展示（✓ 有效 / ✗ 无效 / ◌ 未校验）
- **注销功能**：已配置 API Key 时显示「注销」按钮，一键清除 Key 和登录态
- **移动端适配**：提示去网页申请 Key（扫码需要 Electron）

### 🔀 API 双模式路由（ApiRouter）

```
有 API Key → 优先 V2 Agent API → 失败回退 V1 Cookie API
无 API Key → 仅 V1 Cookie API
```

- 新增 `ApiV2Manager`：通过 `POST /api/agent/gateway` 调用所有 V2 接口
- 新增 `ApiRouter`：统一入口，自动选择 V2/V1 路径，失败时透明回退
- V2 新增接口：热门划线、书架同步、公开书评、阅读统计
- 修复 V2 章节格式不匹配导致划线内容为空的问题（`/book/chapterinfo` 返回格式转换）

### 🔥 热门划线同步

- 每本书最多同步 **20 条热门划线**（按热度排序）
- 按章节**批量并发查询**（每批 5 个章节）
- **本地文件缓存**（`.weread-cache/`），默认 7 天有效期，可配置 TTL
- 缓存未过期时直接复用，无需联网
- **合并式模板**：热门划线与用户划线按章节融合，按 range 位置排序
  - 自己划了 + 热门 → `📌🔥 N 人共读`
  - 仅热门 → `🔥 N 人共读`
  - 仅自己 → `📌`（原有逻辑不变）
- **分离式模板**：热门划线在独立「热门划线」区块展示，按章节分组
- 开关控制：关闭「同步热门划线」则模板中不展示热门信息

### 📖 书籍详情页

以 `ItemView` 形式打开，**4 个标签页**：

1. **划线**：按章节分组，颜色边线区分（黄/蓝/绿/红/紫），支持 deeplink 跳转和复制
2. **笔记**：个人想法和注解，按时间倒序，显示引用原文
3. **热门划线**：社区热度最高的划线（需 API Key），按章节分组
4. **书评**：我的书评 + 社区精选书评（最多 20 条）

- **Header**：圆角卡片样式，含封面、标题、作者、阅读进度、时长、分类、出版社等元数据
- **操作按钮**：阅读（web/app deeplink）、刷新（同步本地笔记）、返回笔记（悬浮按钮）
- 新标签页打开，不覆盖书架页
- 移动端响应式适配（768px / 480px 断点）、吸顶 Tab 栏
- 本地笔记与详情页双向导航

### 🎨 主题系统

- 4 个内置主题：合并式、分离式、微信官方笔记主题、分离式（含热门划线）
- 支持**自定义主题**的创建、编辑、复制、删除、重命名
- 主题**导入/导出**（JSON 格式），支持 URL 远程导入
- V1 旧模板自动迁移为「旧模板」类型，保持向后兼容
- 模板编辑器（三栏布局：语法说明 + 编辑器 + 实时预览）
- 预览使用示例数据快速验证效果

### 📊 阅读统计

- 基于 V2 `/readdata/detail` 接口
- 同步生成 Markdown 统计文件：历年总览、当年/当月概况、偏好分析
- 文本柱状图展示月度/每日阅读时长
- 交互式统计视图（ItemView）：全部 / 周 / 月 / 年维度，含热力图

### 📚 书架增强

- 搜索框、类型筛选（图书/公众号）、同步状态筛选、阅读状态筛选
- 关闭「同步公众号内容」时自动隐藏类型筛选并过滤公众号
- 按年份分组、排序模式切换
- 同步日志（最近 10 次）
- 未登录时引导前往设置页配置 API Key

### ⚙️ 设置页重构

- API Key 始终可见（桌面 + 移动端），无 Key 时才显示传统登录
- 移除 Cookie 自动刷新相关设置项
- 新增设置：同步热门划线、热门划线缓存 TTL、阅读统计位置、起始年份

## 技术细节

- 新增 9+ 源码文件（api-router.ts、api-v2.ts、popularHighlightsCache.ts、wereadBookDetailView.ts 等）
- 新增 4 个 njk 主题模板文件存放于 `src/themes/`
- 全局替换 ApiManager → ApiRouter
- 移除 Cookie 自动刷新逻辑
- 热门划线使用 Vault 依赖注入替代全局 app
- 版本号升级至 2.0.0

## 使用文档

详细使用指南见 [docs/weread-v2-guide.md](https://github.com/zhaohongxuan/obsidian-weread-plugin/blob/feature/migrate_to_v2/docs/weread-v2-guide.md)
